### PR TITLE
feat: re-add identity add command

### DIFF
--- a/cmd/dotsecenv/cmd_identity_add.go
+++ b/cmd/dotsecenv/cmd_identity_add.go
@@ -23,8 +23,8 @@ Options:
   --all  Add identity to all configured vaults
   -v     Target vault (path or 1-based index)
 
-When neither --all nor -v is specified and only one vault is configured,
-that vault is selected automatically.`,
+When neither --all nor -v is specified, the vault is auto-selected if only
+one is configured, or you are prompted to choose interactively.`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		checkSUIDMode(cmd)

--- a/cmd/dotsecenv/cmd_identity_add.go
+++ b/cmd/dotsecenv/cmd_identity_add.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+
+	clilib "github.com/dotsecenv/dotsecenv/internal/cli"
+	"github.com/spf13/cobra"
+)
+
+var identityAddAll bool
+
+var identityAddCmd = &cobra.Command{
+	Use:   "add FINGERPRINT",
+	Short: "Add an identity to vault(s)",
+	Long: `Add a GPG identity to one or more vaults by fingerprint.
+
+The identity's public key is fetched from GPG, validated against the
+configured approved_algorithms, signed, and appended to the vault.
+
+If the identity already exists in a vault, it is skipped.
+
+Options:
+  --all  Add identity to all configured vaults
+  -v     Target vault (path or 1-based index)
+
+When neither --all nor -v is specified and only one vault is configured,
+that vault is selected automatically.`,
+	Args: cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		checkSUIDMode(cmd)
+
+		fingerprint := args[0]
+		cli, err := createCLI()
+		if err != nil {
+			os.Exit(int(clilib.PrintError(os.Stderr, err)))
+		}
+		defer func() { _ = cli.Close() }()
+
+		vaultPath, fromIndex, parseErr := parseVaultSpec(globalOpts.ConfigPath, globalOpts.VaultPaths)
+		if parseErr != nil {
+			os.Exit(int(clilib.PrintError(os.Stderr, clilib.NewError(parseErr.Error(), clilib.ExitGeneralError))))
+		}
+
+		exitErr := cli.IdentityAdd(fingerprint, identityAddAll, vaultPath, fromIndex)
+		exitWithError(exitErr)
+	},
+}
+
+func init() {
+	identityAddCmd.Flags().BoolVar(&identityAddAll, "all", false, "Add identity to all configured vaults")
+
+	identityCmd.AddCommand(identityAddCmd)
+}

--- a/internal/cli/identity.go
+++ b/internal/cli/identity.go
@@ -8,6 +8,138 @@ import (
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/vault"
 )
 
+// IdentityAdd adds a GPG identity to one or more vaults.
+// If addAll is true, the identity is added to every configured vault.
+// If vaultPath is non-empty, only the vault at that path is targeted.
+// If fromIndex > 0, the vault at that 1-based index is targeted.
+// When none of the above are set and exactly one vault is configured, it is auto-selected.
+func (c *CLI) IdentityAdd(fingerprint string, addAll bool, vaultPath string, fromIndex int) *Error {
+	config := c.vaultResolver.GetConfig()
+	entries := config.Entries
+
+	// Determine which vault indices to target
+	var indices []int
+	switch {
+	case addAll:
+		for i := range entries {
+			indices = append(indices, i)
+		}
+	case fromIndex > 0:
+		idx := fromIndex - 1 // convert 1-based to 0-based
+		if idx >= len(entries) {
+			return NewError(fmt.Sprintf("vault index %d exceeds number of configured vaults (%d)", fromIndex, len(entries)), ExitGeneralError)
+		}
+		indices = []int{idx}
+	case vaultPath != "":
+		found := false
+		for i, entry := range entries {
+			if entry.Path == vaultPath {
+				indices = []int{i}
+				found = true
+				break
+			}
+		}
+		if !found {
+			return NewError(fmt.Sprintf("vault path not found in configuration: %s", vaultPath), ExitConfigError)
+		}
+	default:
+		if len(entries) == 1 {
+			indices = []int{0}
+		} else {
+			return NewError("multiple vaults configured; use --all or -v to specify which vault(s)", ExitGeneralError)
+		}
+	}
+
+	if len(indices) == 0 {
+		return NewError("no vaults configured", ExitConfigError)
+	}
+
+	var added, skipped, failed int
+	var lastErr *Error
+	for _, idx := range indices {
+		vPath := entries[idx].Path
+
+		if c.vaultResolver.IdentityExistsInVault(fingerprint, idx) {
+			_, _ = fmt.Fprintf(c.output.Stderr(), "skipped: identity %s already in vault %d (%s)\n", fingerprint, idx+1, vPath)
+			skipped++
+			continue
+		}
+
+		if err := c.addIdentityToVault(fingerprint, idx); err != nil {
+			_, _ = fmt.Fprintf(c.output.Stderr(), "failed: vault %d (%s): %s\n", idx+1, vPath, err.Message)
+			lastErr = err
+			failed++
+			continue
+		}
+
+		_, _ = fmt.Fprintf(c.output.Stdout(), "added: identity %s to vault %d (%s)\n", fingerprint, idx+1, vPath)
+		added++
+	}
+
+	if len(indices) > 1 {
+		_, _ = fmt.Fprintf(c.output.Stdout(), "\nsummary: added=%d skipped=%d failed=%d\n", added, skipped, failed)
+	}
+
+	if failed > 0 {
+		// When a single vault was targeted, return its specific error
+		if len(indices) == 1 && lastErr != nil {
+			return lastErr
+		}
+		return NewError(fmt.Sprintf("%d vault(s) failed", failed), ExitVaultError)
+	}
+	return nil
+}
+
+// addIdentityToVault builds, signs, and adds an identity to the vault at the given index.
+func (c *CLI) addIdentityToVault(fingerprint string, index int) *Error {
+	publicKeyInfo, pubKeyErr := c.gpgClient.GetPublicKeyInfo(fingerprint)
+	if pubKeyErr != nil {
+		return NewError(fmt.Sprintf("failed to get public key: %v", pubKeyErr), ExitGPGError)
+	}
+
+	if !c.config.IsAlgorithmAllowed(publicKeyInfo.Algorithm, publicKeyInfo.AlgorithmBits) {
+		return NewError(fmt.Sprintf("algorithm not allowed: %s (%d bits)\n%s", publicKeyInfo.Algorithm, publicKeyInfo.AlgorithmBits, c.config.GetAllowedAlgorithmsString()), ExitAlgorithmNotAllowed)
+	}
+
+	if !publicKeyInfo.CanEncrypt {
+		return NewError(fmt.Sprintf("key %s is not capable of encryption (signing-only key).\nPlease ensure your key has an encryption subkey.", fingerprint), ExitGPGError)
+	}
+
+	now := time.Now().UTC()
+	algo, curve := c.gpgClient.ExtractAlgorithmAndCurve(publicKeyInfo.Algorithm)
+
+	newIdentity := vault.Identity{
+		AddedAt:       now,
+		Fingerprint:   fingerprint,
+		UID:           publicKeyInfo.UID,
+		Algorithm:     algo,
+		AlgorithmBits: publicKeyInfo.AlgorithmBits,
+		Curve:         curve,
+		CreatedAt:     c.gpgClient.GetKeyCreationTime(fingerprint),
+		ExpiresAt:     publicKeyInfo.ExpiresAt,
+		PublicKey:     publicKeyInfo.PublicKeyBase64,
+		SignedBy:      fingerprint,
+	}
+
+	newIdentity.Hash = identity.ComputeIdentityHash(&newIdentity)
+
+	signature, signErr := c.gpgClient.SignDataWithAgent(fingerprint, []byte(newIdentity.Hash))
+	if signErr != nil {
+		return NewError(fmt.Sprintf("failed to sign identity: %v", signErr), ExitGPGError)
+	}
+	newIdentity.Signature = signature
+
+	if err := c.vaultResolver.AddIdentity(newIdentity, index); err != nil {
+		return NewError(fmt.Sprintf("failed to add identity: %v", err), ExitVaultError)
+	}
+
+	if err := c.vaultResolver.SaveVault(index); err != nil {
+		return NewError(fmt.Sprintf("failed to save vault: %v", err), ExitVaultError)
+	}
+
+	return nil
+}
+
 // ensureIdentityInVault ensures the identity exists in the specified vault index
 // If the identity doesn't exist, it will be auto-added with a warning
 func (c *CLI) ensureIdentityInVault(fingerprint string, index int) *Error {

--- a/internal/cli/identity.go
+++ b/internal/cli/identity.go
@@ -24,34 +24,17 @@ func (c *CLI) IdentityAdd(fingerprint string, addAll bool, vaultPath string, fro
 		for i := range entries {
 			indices = append(indices, i)
 		}
-	case fromIndex > 0:
-		idx := fromIndex - 1 // convert 1-based to 0-based
-		if idx >= len(entries) {
-			return NewError(fmt.Sprintf("vault index %d exceeds number of configured vaults (%d)", fromIndex, len(entries)), ExitGeneralError)
-		}
-		indices = []int{idx}
-	case vaultPath != "":
-		found := false
-		for i, entry := range entries {
-			if entry.Path == vaultPath {
-				indices = []int{i}
-				found = true
-				break
-			}
-		}
-		if !found {
-			return NewError(fmt.Sprintf("vault path not found in configuration: %s", vaultPath), ExitConfigError)
+		if len(indices) == 0 {
+			return NewError("no vaults configured", ExitConfigError)
 		}
 	default:
-		if len(entries) == 1 {
-			indices = []int{0}
-		} else {
-			return NewError("multiple vaults configured; use --all or -v to specify which vault(s)", ExitGeneralError)
+		// Single vault: use the shared resolver (handles -v path, -v index,
+		// auto-select for single vault, and interactive prompt for multiple)
+		idx, err := c.resolveWritableVaultIndex(vaultPath, fromIndex, "Select vault to add identity to:")
+		if err != nil {
+			return err
 		}
-	}
-
-	if len(indices) == 0 {
-		return NewError("no vaults configured", ExitConfigError)
+		indices = []int{idx}
 	}
 
 	var added, skipped, failed int

--- a/internal/cli/identity.go
+++ b/internal/cli/identity.go
@@ -14,6 +14,12 @@ import (
 // If fromIndex > 0, the vault at that 1-based index is targeted.
 // When none of the above are set and exactly one vault is configured, it is auto-selected.
 func (c *CLI) IdentityAdd(fingerprint string, addAll bool, vaultPath string, fromIndex int) *Error {
+	// The current user signs the new identity entry (vouching for it)
+	signerFP, fpErr := c.checkFingerprintRequired("identity add")
+	if fpErr != nil {
+		return fpErr
+	}
+
 	config := c.vaultResolver.GetConfig()
 	entries := config.Entries
 
@@ -48,7 +54,7 @@ func (c *CLI) IdentityAdd(fingerprint string, addAll bool, vaultPath string, fro
 			continue
 		}
 
-		if err := c.addIdentityToVault(fingerprint, idx); err != nil {
+		if err := c.addIdentityToVault(fingerprint, signerFP, idx); err != nil {
 			_, _ = fmt.Fprintf(c.output.Stderr(), "failed: vault %d (%s): %s\n", idx+1, vPath, err.Message)
 			lastErr = err
 			failed++
@@ -74,7 +80,8 @@ func (c *CLI) IdentityAdd(fingerprint string, addAll bool, vaultPath string, fro
 }
 
 // addIdentityToVault builds, signs, and adds an identity to the vault at the given index.
-func (c *CLI) addIdentityToVault(fingerprint string, index int) *Error {
+// signerFingerprint is the current user's key used to sign (vouch for) the new identity.
+func (c *CLI) addIdentityToVault(fingerprint string, signerFingerprint string, index int) *Error {
 	publicKeyInfo, pubKeyErr := c.gpgClient.GetPublicKeyInfo(fingerprint)
 	if pubKeyErr != nil {
 		return NewError(fmt.Sprintf("failed to get public key: %v", pubKeyErr), ExitGPGError)
@@ -101,12 +108,12 @@ func (c *CLI) addIdentityToVault(fingerprint string, index int) *Error {
 		CreatedAt:     c.gpgClient.GetKeyCreationTime(fingerprint),
 		ExpiresAt:     publicKeyInfo.ExpiresAt,
 		PublicKey:     publicKeyInfo.PublicKeyBase64,
-		SignedBy:      fingerprint,
+		SignedBy:      signerFingerprint,
 	}
 
 	newIdentity.Hash = identity.ComputeIdentityHash(&newIdentity)
 
-	signature, signErr := c.gpgClient.SignDataWithAgent(fingerprint, []byte(newIdentity.Hash))
+	signature, signErr := c.gpgClient.SignDataWithAgent(signerFingerprint, []byte(newIdentity.Hash))
 	if signErr != nil {
 		return NewError(fmt.Sprintf("failed to sign identity: %v", signErr), ExitGPGError)
 	}
@@ -123,11 +130,17 @@ func (c *CLI) addIdentityToVault(fingerprint string, index int) *Error {
 	return nil
 }
 
-// ensureIdentityInVault ensures the identity exists in the specified vault index
-// If the identity doesn't exist, it will be auto-added with a warning
+// ensureIdentityInVault ensures the identity exists in the specified vault index.
+// If the identity doesn't exist, it will be auto-added with a warning.
+// The current user's key is used to sign (vouch for) the new identity.
 func (c *CLI) ensureIdentityInVault(fingerprint string, index int) *Error {
 	if c.vaultResolver.IdentityExistsInVault(fingerprint, index) {
 		return nil
+	}
+
+	signerFP, fpErr := c.checkFingerprintRequired("identity auto-add")
+	if fpErr != nil {
+		return fpErr
 	}
 
 	// Auto-add with warning
@@ -162,12 +175,12 @@ func (c *CLI) ensureIdentityInVault(fingerprint string, index int) *Error {
 		CreatedAt:     c.gpgClient.GetKeyCreationTime(fingerprint),
 		ExpiresAt:     publicKeyInfo.ExpiresAt,
 		PublicKey:     publicKeyInfo.PublicKeyBase64,
-		SignedBy:      fingerprint,
+		SignedBy:      signerFP,
 	}
 
 	newIdentity.Hash = identity.ComputeIdentityHash(&newIdentity)
 
-	signature, signErr := c.gpgClient.SignDataWithAgent(fingerprint, []byte(newIdentity.Hash))
+	signature, signErr := c.gpgClient.SignDataWithAgent(signerFP, []byte(newIdentity.Hash))
 	if signErr != nil {
 		return NewError(fmt.Sprintf("failed to sign identity: %v", signErr), ExitGPGError)
 	}

--- a/internal/cli/identity_add_test.go
+++ b/internal/cli/identity_add_test.go
@@ -41,6 +41,7 @@ func newIdentityAddCLI(t *testing.T, vaultPaths []string) (*CLI, *MockVaultResol
 			ApprovedAlgorithms: []config.ApprovedAlgorithm{
 				{Algo: "RSA", MinBits: 2048},
 			},
+			Fingerprint: "MYFINGERPRINT", // current user's login
 		},
 		vaultResolver: mock,
 		gpgClient:     gpgMock,

--- a/internal/cli/identity_add_test.go
+++ b/internal/cli/identity_add_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"bytes"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/config"
@@ -48,15 +50,31 @@ func newIdentityAddCLI(t *testing.T, vaultPaths []string) (*CLI, *MockVaultResol
 	return cli, mock, gpgMock, stdout, stderr
 }
 
+// createTempVaultFiles creates n temp files and returns their paths and a cleanup function.
+func createTempVaultFiles(t *testing.T, n int) []string {
+	t.Helper()
+	paths := make([]string, n)
+	for i := 0; i < n; i++ {
+		f, err := os.CreateTemp("", "testvault_*.jsonl")
+		if err != nil {
+			t.Fatalf("failed to create temp file: %v", err)
+		}
+		paths[i] = f.Name()
+		_ = f.Close()
+		t.Cleanup(func() { _ = os.Remove(f.Name()) })
+	}
+	return paths
+}
+
 func TestIdentityAdd_All(t *testing.T) {
-	cli, mock, _, stdout, _ := newIdentityAddCLI(t, []string{"/v1.jsonl", "/v2.jsonl"})
+	paths := createTempVaultFiles(t, 2)
+	cli, mock, _, stdout, _ := newIdentityAddCLI(t, paths)
 
 	err := cli.IdentityAdd("AABBCCDD", true, "", 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Both vaults should have the identity
 	if !mock.IdentityExistsInVault("AABBCCDD", 0) {
 		t.Error("identity not added to vault 0")
 	}
@@ -65,19 +83,20 @@ func TestIdentityAdd_All(t *testing.T) {
 	}
 
 	out := stdout.String()
-	if !contains(out, "added: identity AABBCCDD to vault 1") {
+	if !strings.Contains(out, "added: identity AABBCCDD to vault 1") {
 		t.Errorf("expected added message for vault 1, got: %s", out)
 	}
-	if !contains(out, "added: identity AABBCCDD to vault 2") {
+	if !strings.Contains(out, "added: identity AABBCCDD to vault 2") {
 		t.Errorf("expected added message for vault 2, got: %s", out)
 	}
-	if !contains(out, "summary: added=2 skipped=0 failed=0") {
+	if !strings.Contains(out, "summary: added=2 skipped=0 failed=0") {
 		t.Errorf("expected summary, got: %s", out)
 	}
 }
 
 func TestIdentityAdd_SingleVaultByIndex(t *testing.T) {
-	cli, mock, _, stdout, _ := newIdentityAddCLI(t, []string{"/v1.jsonl", "/v2.jsonl"})
+	paths := createTempVaultFiles(t, 2)
+	cli, mock, _, stdout, _ := newIdentityAddCLI(t, paths)
 
 	err := cli.IdentityAdd("AABBCCDD", false, "", 2) // 1-based index
 	if err != nil {
@@ -92,15 +111,16 @@ func TestIdentityAdd_SingleVaultByIndex(t *testing.T) {
 	}
 
 	out := stdout.String()
-	if !contains(out, "added: identity AABBCCDD to vault 2") {
+	if !strings.Contains(out, "added: identity AABBCCDD to vault 2") {
 		t.Errorf("expected added message for vault 2, got: %s", out)
 	}
 }
 
 func TestIdentityAdd_SingleVaultByPath(t *testing.T) {
-	cli, mock, _, stdout, _ := newIdentityAddCLI(t, []string{"/v1.jsonl", "/v2.jsonl"})
+	paths := createTempVaultFiles(t, 2)
+	cli, mock, _, stdout, _ := newIdentityAddCLI(t, paths)
 
-	err := cli.IdentityAdd("AABBCCDD", false, "/v2.jsonl", 0)
+	err := cli.IdentityAdd("AABBCCDD", false, paths[1], 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -113,13 +133,14 @@ func TestIdentityAdd_SingleVaultByPath(t *testing.T) {
 	}
 
 	out := stdout.String()
-	if !contains(out, "added: identity AABBCCDD to vault 2") {
+	if !strings.Contains(out, "added: identity AABBCCDD to vault 2") {
 		t.Errorf("expected added message for vault 2, got: %s", out)
 	}
 }
 
 func TestIdentityAdd_AutoSelectSingleVault(t *testing.T) {
-	cli, mock, _, _, _ := newIdentityAddCLI(t, []string{"/only.jsonl"})
+	paths := createTempVaultFiles(t, 1)
+	cli, mock, _, _, _ := newIdentityAddCLI(t, paths)
 
 	err := cli.IdentityAdd("AABBCCDD", false, "", 0)
 	if err != nil {
@@ -131,20 +152,24 @@ func TestIdentityAdd_AutoSelectSingleVault(t *testing.T) {
 	}
 }
 
-func TestIdentityAdd_ErrorMultipleVaultsNoFlag(t *testing.T) {
-	cli, _, _, _, _ := newIdentityAddCLI(t, []string{"/v1.jsonl", "/v2.jsonl"})
+func TestIdentityAdd_MultipleVaultsNoTTY(t *testing.T) {
+	paths := createTempVaultFiles(t, 2)
+	cli, _, _, _, _ := newIdentityAddCLI(t, paths)
 
+	// Without a TTY, resolveWritableVaultIndex should error asking for -v
 	err := cli.IdentityAdd("AABBCCDD", false, "", 0)
 	if err == nil {
-		t.Fatal("expected error when multiple vaults and no --all or -v")
+		t.Fatal("expected error when multiple vaults and no TTY")
 	}
-	if !contains(err.Message, "multiple vaults configured") {
+	if !strings.Contains(err.Message, "specify target vault using -v") &&
+		!strings.Contains(err.Message, "no terminal available") {
 		t.Errorf("unexpected error message: %s", err.Message)
 	}
 }
 
 func TestIdentityAdd_SkipsExisting(t *testing.T) {
-	cli, mock, _, stdout, stderr := newIdentityAddCLI(t, []string{"/v1.jsonl", "/v2.jsonl"})
+	paths := createTempVaultFiles(t, 2)
+	cli, mock, _, stdout, stderr := newIdentityAddCLI(t, paths)
 
 	// Pre-add identity to vault 0
 	mock.IdentitiesByVault[0] = map[string]vault.Identity{
@@ -157,45 +182,49 @@ func TestIdentityAdd_SkipsExisting(t *testing.T) {
 	}
 
 	stderrStr := stderr.String()
-	if !contains(stderrStr, "skipped: identity AABBCCDD already in vault 1") {
+	if !strings.Contains(stderrStr, "skipped: identity AABBCCDD already in vault 1") {
 		t.Errorf("expected skipped message, got stderr: %s", stderrStr)
 	}
 
 	out := stdout.String()
-	if !contains(out, "added: identity AABBCCDD to vault 2") {
+	if !strings.Contains(out, "added: identity AABBCCDD to vault 2") {
 		t.Errorf("expected added message for vault 2, got: %s", out)
 	}
-	if !contains(out, "summary: added=1 skipped=1 failed=0") {
+	if !strings.Contains(out, "summary: added=1 skipped=1 failed=0") {
 		t.Errorf("expected summary, got: %s", out)
 	}
 }
 
 func TestIdentityAdd_IndexOutOfRange(t *testing.T) {
-	cli, _, _, _, _ := newIdentityAddCLI(t, []string{"/v1.jsonl"})
+	paths := createTempVaultFiles(t, 1)
+	cli, _, _, _, _ := newIdentityAddCLI(t, paths)
 
 	err := cli.IdentityAdd("AABBCCDD", false, "", 5) // only 1 vault
 	if err == nil {
 		t.Fatal("expected error for out-of-range index")
 	}
-	if !contains(err.Message, "exceeds number of configured vaults") {
+	if !strings.Contains(err.Message, "exceeds number of configured vaults") {
 		t.Errorf("unexpected error message: %s", err.Message)
 	}
 }
 
 func TestIdentityAdd_UnknownVaultPath(t *testing.T) {
-	cli, _, _, _, _ := newIdentityAddCLI(t, []string{"/v1.jsonl"})
+	paths := createTempVaultFiles(t, 1)
+	cli, _, _, _, _ := newIdentityAddCLI(t, paths)
 
 	err := cli.IdentityAdd("AABBCCDD", false, "/nonexistent.jsonl", 0)
 	if err == nil {
 		t.Fatal("expected error for unknown vault path")
 	}
-	if !contains(err.Message, "vault path not found") {
+	// resolveWritableVaultIndex checks os.Stat first
+	if !strings.Contains(err.Message, "does not exist") {
 		t.Errorf("unexpected error message: %s", err.Message)
 	}
 }
 
 func TestIdentityAdd_AlgorithmNotAllowed(t *testing.T) {
-	cli, _, gpgMock, _, _ := newIdentityAddCLI(t, []string{"/v1.jsonl"})
+	paths := createTempVaultFiles(t, 1)
+	cli, _, gpgMock, _, _ := newIdentityAddCLI(t, paths)
 
 	// Override config to only allow ED25519
 	cli.config.ApprovedAlgorithms = []config.ApprovedAlgorithm{
@@ -217,17 +246,4 @@ func TestIdentityAdd_AlgorithmNotAllowed(t *testing.T) {
 	if err.ExitCode != ExitAlgorithmNotAllowed {
 		t.Errorf("expected ExitAlgorithmNotAllowed, got %d", err.ExitCode)
 	}
-}
-
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
-}
-
-func containsSubstring(s, substr string) bool {
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/cli/identity_add_test.go
+++ b/internal/cli/identity_add_test.go
@@ -1,0 +1,233 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/config"
+	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/gpg"
+	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/output"
+	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/vault"
+)
+
+func newIdentityAddCLI(t *testing.T, vaultPaths []string) (*CLI, *MockVaultResolver, *MockGPGClient, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	t.Setenv("DOTSECENV_FINGERPRINT", "")
+	t.Setenv("DOTSECENV_CONFIG", "")
+
+	mock := NewMockVaultResolver()
+	mock.VaultPaths = vaultPaths
+	for _, p := range vaultPaths {
+		mock.VaultEntries = append(mock.VaultEntries, vault.VaultEntry{Path: p})
+	}
+
+	gpgMock := NewMockGPGClient()
+	gpgMock.PublicKeyInfo["AABBCCDD"] = gpg.KeyInfo{
+		Fingerprint:     "AABBCCDD",
+		UID:             "Alice <alice@example.com>",
+		Algorithm:       "RSA",
+		AlgorithmBits:   4096,
+		CanEncrypt:      true,
+		PublicKeyBase64: "base64pubkey",
+	}
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	cli := &CLI{
+		config: config.Config{
+			ApprovedAlgorithms: []config.ApprovedAlgorithm{
+				{Algo: "RSA", MinBits: 2048},
+			},
+		},
+		vaultResolver: mock,
+		gpgClient:     gpgMock,
+		output:        output.NewHandler(stdout, stderr),
+	}
+
+	return cli, mock, gpgMock, stdout, stderr
+}
+
+func TestIdentityAdd_All(t *testing.T) {
+	cli, mock, _, stdout, _ := newIdentityAddCLI(t, []string{"/v1.jsonl", "/v2.jsonl"})
+
+	err := cli.IdentityAdd("AABBCCDD", true, "", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Both vaults should have the identity
+	if !mock.IdentityExistsInVault("AABBCCDD", 0) {
+		t.Error("identity not added to vault 0")
+	}
+	if !mock.IdentityExistsInVault("AABBCCDD", 1) {
+		t.Error("identity not added to vault 1")
+	}
+
+	out := stdout.String()
+	if !contains(out, "added: identity AABBCCDD to vault 1") {
+		t.Errorf("expected added message for vault 1, got: %s", out)
+	}
+	if !contains(out, "added: identity AABBCCDD to vault 2") {
+		t.Errorf("expected added message for vault 2, got: %s", out)
+	}
+	if !contains(out, "summary: added=2 skipped=0 failed=0") {
+		t.Errorf("expected summary, got: %s", out)
+	}
+}
+
+func TestIdentityAdd_SingleVaultByIndex(t *testing.T) {
+	cli, mock, _, stdout, _ := newIdentityAddCLI(t, []string{"/v1.jsonl", "/v2.jsonl"})
+
+	err := cli.IdentityAdd("AABBCCDD", false, "", 2) // 1-based index
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if mock.IdentityExistsInVault("AABBCCDD", 0) {
+		t.Error("identity should not be in vault 0")
+	}
+	if !mock.IdentityExistsInVault("AABBCCDD", 1) {
+		t.Error("identity not added to vault 1")
+	}
+
+	out := stdout.String()
+	if !contains(out, "added: identity AABBCCDD to vault 2") {
+		t.Errorf("expected added message for vault 2, got: %s", out)
+	}
+}
+
+func TestIdentityAdd_SingleVaultByPath(t *testing.T) {
+	cli, mock, _, stdout, _ := newIdentityAddCLI(t, []string{"/v1.jsonl", "/v2.jsonl"})
+
+	err := cli.IdentityAdd("AABBCCDD", false, "/v2.jsonl", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if mock.IdentityExistsInVault("AABBCCDD", 0) {
+		t.Error("identity should not be in vault 0")
+	}
+	if !mock.IdentityExistsInVault("AABBCCDD", 1) {
+		t.Error("identity not added to vault 1")
+	}
+
+	out := stdout.String()
+	if !contains(out, "added: identity AABBCCDD to vault 2") {
+		t.Errorf("expected added message for vault 2, got: %s", out)
+	}
+}
+
+func TestIdentityAdd_AutoSelectSingleVault(t *testing.T) {
+	cli, mock, _, _, _ := newIdentityAddCLI(t, []string{"/only.jsonl"})
+
+	err := cli.IdentityAdd("AABBCCDD", false, "", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !mock.IdentityExistsInVault("AABBCCDD", 0) {
+		t.Error("identity not added to the single vault")
+	}
+}
+
+func TestIdentityAdd_ErrorMultipleVaultsNoFlag(t *testing.T) {
+	cli, _, _, _, _ := newIdentityAddCLI(t, []string{"/v1.jsonl", "/v2.jsonl"})
+
+	err := cli.IdentityAdd("AABBCCDD", false, "", 0)
+	if err == nil {
+		t.Fatal("expected error when multiple vaults and no --all or -v")
+	}
+	if !contains(err.Message, "multiple vaults configured") {
+		t.Errorf("unexpected error message: %s", err.Message)
+	}
+}
+
+func TestIdentityAdd_SkipsExisting(t *testing.T) {
+	cli, mock, _, stdout, stderr := newIdentityAddCLI(t, []string{"/v1.jsonl", "/v2.jsonl"})
+
+	// Pre-add identity to vault 0
+	mock.IdentitiesByVault[0] = map[string]vault.Identity{
+		"AABBCCDD": {Fingerprint: "AABBCCDD"},
+	}
+
+	err := cli.IdentityAdd("AABBCCDD", true, "", 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	stderrStr := stderr.String()
+	if !contains(stderrStr, "skipped: identity AABBCCDD already in vault 1") {
+		t.Errorf("expected skipped message, got stderr: %s", stderrStr)
+	}
+
+	out := stdout.String()
+	if !contains(out, "added: identity AABBCCDD to vault 2") {
+		t.Errorf("expected added message for vault 2, got: %s", out)
+	}
+	if !contains(out, "summary: added=1 skipped=1 failed=0") {
+		t.Errorf("expected summary, got: %s", out)
+	}
+}
+
+func TestIdentityAdd_IndexOutOfRange(t *testing.T) {
+	cli, _, _, _, _ := newIdentityAddCLI(t, []string{"/v1.jsonl"})
+
+	err := cli.IdentityAdd("AABBCCDD", false, "", 5) // only 1 vault
+	if err == nil {
+		t.Fatal("expected error for out-of-range index")
+	}
+	if !contains(err.Message, "exceeds number of configured vaults") {
+		t.Errorf("unexpected error message: %s", err.Message)
+	}
+}
+
+func TestIdentityAdd_UnknownVaultPath(t *testing.T) {
+	cli, _, _, _, _ := newIdentityAddCLI(t, []string{"/v1.jsonl"})
+
+	err := cli.IdentityAdd("AABBCCDD", false, "/nonexistent.jsonl", 0)
+	if err == nil {
+		t.Fatal("expected error for unknown vault path")
+	}
+	if !contains(err.Message, "vault path not found") {
+		t.Errorf("unexpected error message: %s", err.Message)
+	}
+}
+
+func TestIdentityAdd_AlgorithmNotAllowed(t *testing.T) {
+	cli, _, gpgMock, _, _ := newIdentityAddCLI(t, []string{"/v1.jsonl"})
+
+	// Override config to only allow ED25519
+	cli.config.ApprovedAlgorithms = []config.ApprovedAlgorithm{
+		{Algo: "ED25519", MinBits: 0},
+	}
+	gpgMock.PublicKeyInfo["AABBCCDD"] = gpg.KeyInfo{
+		Fingerprint:     "AABBCCDD",
+		UID:             "Alice <alice@example.com>",
+		Algorithm:       "RSA",
+		AlgorithmBits:   4096,
+		CanEncrypt:      true,
+		PublicKeyBase64: "base64pubkey",
+	}
+
+	err := cli.IdentityAdd("AABBCCDD", false, "", 0)
+	if err == nil {
+		t.Fatal("expected algorithm not allowed error")
+	}
+	if err.ExitCode != ExitAlgorithmNotAllowed {
+		t.Errorf("expected ExitAlgorithmNotAllowed, got %d", err.ExitCode)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsSubstring(s, substr))
+}
+
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- Re-introduces `dotsecenv identity add FINGERPRINT` for explicitly adding GPG identities to vaults
- Supports `--all` (all vaults), `-v` (specific vault by index or path), and interactive vault selection when multiple vaults are configured
- Uses `resolveWritableVaultIndex` for consistent vault selection behavior with other commands (`secret put`, `secret share`, etc.)
- Idempotent: skips vaults where the identity already exists
- **Bugfix**: identity entries are now signed by the current user's key (the person vouching for the identity), not the target's key. Previously, adding someone else's identity required their private key, which broke the team onboarding use case. This fix applies to both `identity add` and the auto-add path in `ensureIdentityInVault` (used by `secret share`)
- 9 unit tests covering all code paths

Previously removed in #43 when vault subcommands were simplified. Bringing it back as a top-level `identity` subcommand for onboarding and key pre-authorization workflows.

## Test plan
- [x] `go build ./cmd/dotsecenv/` compiles
- [x] `go test ./...` all pass (9 new tests)
- [x] Manual: `dotsecenv identity add <fp> --all`
- [x] Manual: `dotsecenv identity add <fp> -v 1`
- [x] Manual: `dotsecenv identity add <fp>` with multiple vaults (interactive prompt)
- [x] Manual: `dotsecenv identity add <someone_elses_fp>` (no private key needed)
- [x] Manual: re-running same command shows "skipped"

🤖 Generated with [Claude Code](https://claude.com/claude-code)