### PR TITLE
fix: init vault -v INDEX resolves numeric indices to config paths

### DIFF
--- a/cmd/dotsecenv/cmd_init.go
+++ b/cmd/dotsecenv/cmd_init.go
@@ -86,7 +86,7 @@ var initVaultCmd = &cobra.Command{
 	Long: `Initialize vault file(s).
 
 Two modes of operation:
-  1. With -v PATH: Initialize a specific vault file at the given path
+  1. With -v PATH or -v INDEX: Initialize a specific vault file (path or 1-based config index)
   2. Without -v: Interactive mode using vaults from configuration`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -94,13 +94,20 @@ Two modes of operation:
 		hasVaults := len(globalOpts.VaultPaths) > 0
 
 		if hasVaults {
-			// Validate vault paths against config (respects restrict_to_configured_vaults)
-			if err := clilib.ValidateVaultPathsAgainstConfig(globalOpts.ConfigPath, globalOpts.VaultPaths, out); err != nil {
+			// Resolve numeric vault indices to actual paths from config
+			resolvedPaths, resolveErr := resolveVaultPaths(globalOpts.ConfigPath, globalOpts.VaultPaths)
+			if resolveErr != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", resolveErr)
+				os.Exit(int(clilib.ExitGeneralError))
+			}
+
+			// Validate resolved vault paths against config (respects restrict_to_configured_vaults)
+			if err := clilib.ValidateVaultPathsAgainstConfig(globalOpts.ConfigPath, resolvedPaths, out); err != nil {
 				os.Exit(int(clilib.PrintError(os.Stderr, err)))
 			}
 
 			// Init specific vaults
-			for _, vPath := range globalOpts.VaultPaths {
+			for _, vPath := range resolvedPaths {
 				if err := clilib.InitVaultFile(vPath, out); err != nil {
 					os.Exit(int(clilib.PrintError(os.Stderr, err)))
 				}

--- a/cmd/dotsecenv/cmd_init_test.go
+++ b/cmd/dotsecenv/cmd_init_test.go
@@ -1,6 +1,7 @@
 package main_test
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -331,5 +332,128 @@ func TestInitConfig_HasDefaultAlgorithms(t *testing.T) {
 	}
 	if !hasEdDSA {
 		t.Errorf("expected EdDSA in approved_algorithms")
+	}
+}
+
+// writeTestConfig writes a minimal config file with the given vault paths
+func writeTestConfig(t *testing.T, configPath string, vaultPaths []string) {
+	t.Helper()
+	var vaultYAML string
+	for _, v := range vaultPaths {
+		vaultYAML += fmt.Sprintf("  - %s\n", v)
+	}
+	content := fmt.Sprintf(`approved_algorithms:
+  - algo: RSA
+    min_bits: 2048
+vault:
+%sgpg:
+  program: PATH
+`, vaultYAML)
+	if err := os.WriteFile(configPath, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+}
+
+func TestInitVault_WithIndex(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	vault1Path := filepath.Join(tmpDir, "vault1.dsv")
+	vault2Path := filepath.Join(tmpDir, "vault2.dsv")
+
+	writeTestConfig(t, configPath, []string{vault1Path, vault2Path})
+
+	// Init vault using index 1 (should resolve to vault1Path)
+	_, stderr, err := runCmd("init", "vault", "-c", configPath, "-v", "1")
+	if err != nil {
+		t.Fatalf("init vault -v 1 failed: %v\nSTDERR: %s", err, stderr)
+	}
+
+	// Verify vault was created at the config path, not a file named "1"
+	if _, statErr := os.Stat(vault1Path); os.IsNotExist(statErr) {
+		t.Errorf("expected vault file at %s, but it does not exist", vault1Path)
+	}
+	if _, statErr := os.Stat(filepath.Join(tmpDir, "1")); statErr == nil {
+		t.Errorf("found file named '1' — index was not resolved to config path")
+	}
+
+	// Verify stderr mentions the resolved path
+	if !strings.Contains(stderr, vault1Path) {
+		t.Errorf("expected stderr to reference %s, got: %s", vault1Path, stderr)
+	}
+}
+
+func TestInitVault_WithIndex_SecondVault(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	vault1Path := filepath.Join(tmpDir, "vault1.dsv")
+	vault2Path := filepath.Join(tmpDir, "vault2.dsv")
+
+	writeTestConfig(t, configPath, []string{vault1Path, vault2Path})
+
+	// Init vault using index 2 (should resolve to vault2Path)
+	_, stderr, err := runCmd("init", "vault", "-c", configPath, "-v", "2")
+	if err != nil {
+		t.Fatalf("init vault -v 2 failed: %v\nSTDERR: %s", err, stderr)
+	}
+
+	// Verify vault was created at vault2Path
+	if _, statErr := os.Stat(vault2Path); os.IsNotExist(statErr) {
+		t.Errorf("expected vault file at %s, but it does not exist", vault2Path)
+	}
+	// vault1 should NOT have been created
+	if _, statErr := os.Stat(vault1Path); statErr == nil {
+		t.Errorf("vault1 should not have been created when initializing index 2")
+	}
+}
+
+func TestInitVault_InvalidIndex(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	vault1Path := filepath.Join(tmpDir, "vault1.dsv")
+
+	writeTestConfig(t, configPath, []string{vault1Path})
+
+	// Index 99 exceeds configured vaults (only 1)
+	_, stderr, err := runCmd("init", "vault", "-c", configPath, "-v", "99")
+	if err == nil {
+		t.Fatal("expected error for out-of-range vault index, but command succeeded")
+	}
+
+	if !strings.Contains(stderr, "exceeds number of configured vaults") {
+		t.Errorf("expected 'exceeds number of configured vaults' error, got: %s", stderr)
+	}
+}
+
+func TestInitVault_ZeroIndex(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	vault1Path := filepath.Join(tmpDir, "vault1.dsv")
+
+	writeTestConfig(t, configPath, []string{vault1Path})
+
+	// Index 0 is invalid (1-based indexing)
+	_, stderr, err := runCmd("init", "vault", "-c", configPath, "-v", "0")
+	if err == nil {
+		t.Fatal("expected error for zero vault index, but command succeeded")
+	}
+
+	if !strings.Contains(stderr, "index") {
+		t.Errorf("expected index-related error, got: %s", stderr)
+	}
+}
+
+func TestInitVault_PathStillWorks(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultPath := filepath.Join(tmpDir, "explicit-vault.dsv")
+
+	// Init vault using explicit path (no config needed for path mode)
+	_, stderr, err := runCmd("init", "vault", "-v", vaultPath)
+	if err != nil {
+		t.Fatalf("init vault -v PATH failed: %v\nSTDERR: %s", err, stderr)
+	}
+
+	// Verify vault was created at the explicit path
+	if _, statErr := os.Stat(vaultPath); os.IsNotExist(statErr) {
+		t.Errorf("expected vault file at %s, but it does not exist", vaultPath)
 	}
 }

--- a/internal/cli/identity_add_test.go
+++ b/internal/cli/identity_add_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/gpg"
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/output"
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/vault"
+	"golang.org/x/term"
 )
 
 func newIdentityAddCLI(t *testing.T, vaultPaths []string) (*CLI, *MockVaultResolver, *MockGPGClient, *bytes.Buffer, *bytes.Buffer) {
@@ -154,6 +155,18 @@ func TestIdentityAdd_AutoSelectSingleVault(t *testing.T) {
 }
 
 func TestIdentityAdd_MultipleVaultsNoTTY(t *testing.T) {
+	// This test verifies behavior when no TTY is available.
+	// Skip when /dev/tty is a real terminal (e.g., running from a terminal
+	// session or git hook) since HandleInteractiveSelection opens /dev/tty
+	// directly and would hang waiting for input.
+	if tty, err := os.Open("/dev/tty"); err == nil {
+		isTerm := term.IsTerminal(int(tty.Fd()))
+		_ = tty.Close()
+		if isTerm {
+			t.Skip("skipping: /dev/tty is a real terminal; test requires no-TTY environment")
+		}
+	}
+
 	paths := createTempVaultFiles(t, 2)
 	cli, _, _, _, _ := newIdentityAddCLI(t, paths)
 


### PR DESCRIPTION
## Summary

- `dotsecenv init vault -v 1` now correctly resolves the numeric index to the vault path from config, instead of creating a file literally named "1"
- Adds `resolveVaultPaths()` call to `init vault` command, matching the pattern used by all other `-v` commands (`secret store`, `secret get`, etc.)
- Fixes pre-existing test hang: `TestIdentityAdd_MultipleVaultsNoTTY` now skips when `/dev/tty` is a real terminal (prevents hang during git pre-push hook execution)

## Test plan

- [x] 5 new integration tests: index resolution (vault 1, vault 2), invalid index, zero index, path still works
- [x] All existing tests pass (`go test ./...`)
- [x] Linting passes (`make lint`)
- [x] E2E tests pass (`make e2e`)
- [x] Pre-push hook completes without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)