### PR TITLE
chore: update GOFIPS140 module to v1.26.0

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,7 +14,7 @@ builds:
   - id: default
     env:
       - CGO_ENABLED=0
-      - GOFIPS140=v1.0.0
+      - GOFIPS140=v1.26.0
     goos:
       - linux
       - darwin

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean:
 .PHONY: build
 build:
 	@echo "Building dotsecenv with FIPS 140-3 crypto..."
-	CGO_ENABLED=0 GOFIPS140=v1.0.0 go build -mod=vendor -ldflags "-s -w $(LDFLAGS)" -o bin/dotsecenv ./cmd/dotsecenv
+	CGO_ENABLED=0 GOFIPS140=v1.26.0 go build -mod=vendor -ldflags "-s -w $(LDFLAGS)" -o bin/dotsecenv ./cmd/dotsecenv
 	@echo "Binary built at: bin/dotsecenv"
 
 .PHONY: build-link

--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ Each entry includes a hash and cryptographic signature to prevent against tamper
 - **AES-256-GCM symmetric encryption**: NIST-approved authenticated encryption ([SP 800-38D](https://csrc.nist.gov/pubs/sp/800/38/d/final))
 - **[FIPS 186-5](https://csrc.nist.gov/pubs/fips/186-5/final) digital signatures**: RSA, ECDSA, and EdDSA signature schemes for vault entry authenticity and non-repudiation
 - **FIPS 186-5 compliant defaults**: Algorithm minimums meet the Digital Signature Standard requirements
-- **FIPS 140-3 Crypto**: Release binaries are built with Go's native FIPS 140-3 cryptographic module (`GOFIPS140=v1.0.0`) for NIST-validated cryptographic primitives on all platforms
+- **FIPS 140-3 Crypto**: Release binaries are built with Go's native FIPS 140-3 cryptographic module (`GOFIPS140=v1.26.0`) for NIST-validated cryptographic primitives on all platforms
 - Multi-recipient PGP encryption with hybrid cryptography
 - Hash-based integrity checking (SHA-256/SHA-512)
 - GPG agent integration for secure key management
@@ -746,7 +746,7 @@ make install-tools
 make build
 ```
 
-The default `make build` uses Go's native FIPS 140-3 cryptographic module (`GOFIPS140=v1.0.0`), which provides NIST-validated cryptographic primitives on all platforms without requiring CGO. See [go.dev/blog/fips140](https://go.dev/blog/fips140) for details.
+The default `make build` uses Go's native FIPS 140-3 cryptographic module (`GOFIPS140=v1.26.0`), which provides NIST-validated cryptographic primitives on all platforms without requiring CGO. See [go.dev/blog/fips140](https://go.dev/blog/fips140) for details.
 
 ### Testing
 


### PR DESCRIPTION
## Summary
- Updates GOFIPS140 cryptographic module from `v1.0.0` to `v1.26.0` (latest shipped with Go 1.26.x)
- Updated in Makefile, `.goreleaser.yaml`, and README references

## Test plan
- [x] `GOFIPS140=v1.26.0 go build` succeeds
- [x] Full test suite passes
- [x] Pre-push hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)