### PR TITLE
refactor!: drop deprecated Fingerprint field and DOTSECENV_FINGERPRINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,7 +624,7 @@ Each entry includes a hash and cryptographic signature to prevent against tamper
 When running with SUID privileges, the following restrictions apply:
 
 - `-c` and `-v` flags are blocked
-- `DOTSECENV_CONFIG` and `DOTSECENV_FINGERPRINT` environment variables are ignored
+- `DOTSECENV_CONFIG` environment variable is ignored
 - Config defaults to `/etc/dotsecenv/config`
 - Write operations are blocked: `login`, `init config`, `init vault`, `secret store`, `secret share`, `secret revoke`
 
@@ -647,12 +647,11 @@ This prevents privilege escalation attacks when the binary is installed with ele
 
 ## Environment Variables
 
-| Variable                | Description                                             |
-| ----------------------- | ------------------------------------------------------- |
-| `DOTSECENV_CONFIG`      | Override config file path (ignored in SUID mode)        |
-| `DOTSECENV_FINGERPRINT` | Override fingerprint from config (ignored in SUID mode) |
-| `XDG_CONFIG_HOME`       | Override config directory (defaults to: `~/.config`)    |
-| `XDG_DATA_HOME`         | Override data directory (defaults to: `~/.local/share`) |
+| Variable           | Description                                             |
+| ------------------ | ------------------------------------------------------- |
+| `DOTSECENV_CONFIG` | Override config file path (ignored in SUID mode)        |
+| `XDG_CONFIG_HOME`  | Override config directory (defaults to: `~/.config`)    |
+| `XDG_DATA_HOME`    | Override data directory (defaults to: `~/.local/share`) |
 
 ## Known Limitations
 

--- a/cmd/dotsecenv/cmd_init_test.go
+++ b/cmd/dotsecenv/cmd_init_test.go
@@ -27,9 +27,11 @@ type configForTest struct {
 		Curves  []string `yaml:"curves,omitempty"`
 		MinBits int      `yaml:"min_bits"`
 	} `yaml:"approved_algorithms"`
-	Fingerprint string   `yaml:"fingerprint,omitempty"`
-	Vault       []string `yaml:"vault"`
-	Behavior    struct {
+	Login *struct {
+		Fingerprint string `yaml:"fingerprint"`
+	} `yaml:"login,omitempty"`
+	Vault    []string `yaml:"vault"`
+	Behavior struct {
 		RequireExplicitVaultUpgrade *bool `yaml:"require_explicit_vault_upgrade,omitempty"`
 		RestrictToConfiguredVaults  *bool `yaml:"restrict_to_configured_vaults,omitempty"`
 	} `yaml:"behavior,omitempty"`
@@ -129,7 +131,7 @@ func TestInitConfig_NoStrictFieldInOutput(t *testing.T) {
 	}
 }
 
-func TestInitConfig_DefaultFingerprintIsEmpty(t *testing.T) {
+func TestInitConfig_DefaultLoginIsNil(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")
 
@@ -139,10 +141,10 @@ func TestInitConfig_DefaultFingerprintIsEmpty(t *testing.T) {
 		t.Fatalf("init config failed: %v\nSTDERR: %s", err, stderr)
 	}
 
-	// Verify fingerprint defaults to empty
+	// Verify login section is absent until the user runs `dotsecenv login`.
 	cfg := loadConfigForTest(t, configPath)
-	if cfg.Fingerprint != "" {
-		t.Errorf("expected fingerprint to be empty by default, got fingerprint=%q", cfg.Fingerprint)
+	if cfg.Login != nil {
+		t.Errorf("expected login section to be absent by default, got %+v", *cfg.Login)
 	}
 }
 

--- a/cmd/dotsecenv/globals.go
+++ b/cmd/dotsecenv/globals.go
@@ -88,7 +88,7 @@ func resolveVaultPaths(configPath string, vaultPaths []string) ([]string, error)
 				cfgPath = xdgPaths.ConfigPath()
 			}
 
-			cfg, configErr := config.Load(cfgPath)
+			cfg, _, configErr := config.Load(cfgPath)
 			if configErr != nil {
 				return nil, fmt.Errorf("failed to load config for vault index %d: %v", idx, configErr)
 			}
@@ -151,7 +151,7 @@ func parseVaultSpec(configPath string, vaultPaths []string) (vaultPath string, f
 			cfgPath = xdgPaths.ConfigPath()
 		}
 
-		cfg, configErr := config.Load(cfgPath)
+		cfg, _, configErr := config.Load(cfgPath)
 		if configErr != nil {
 			return "", 0, fmt.Errorf("failed to load config: %v", configErr)
 		}
@@ -181,7 +181,7 @@ func printVaultList(configPath string, w io.Writer) {
 		cfgPath = xdgPaths.ConfigPath()
 	}
 
-	cfg, configErr := config.Load(cfgPath)
+	cfg, _, configErr := config.Load(cfgPath)
 	if configErr != nil {
 		return
 	}

--- a/cmd/dotsecenv/main_test.go
+++ b/cmd/dotsecenv/main_test.go
@@ -34,13 +34,14 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-// filteredEnv returns os.Environ() without DOTSECENV_CONFIG and DOTSECENV_FINGERPRINT
-// to avoid test pollution
+// filteredEnv returns os.Environ() without DOTSECENV_CONFIG to avoid test pollution.
+// (DOTSECENV_FINGERPRINT was removed in favor of the signed Login section; if
+// it is still set in the inherited env it has no effect, so no filtering needed.)
 func filteredEnv() []string {
 	baseEnv := os.Environ()
 	filtered := make([]string, 0, len(baseEnv))
 	for _, e := range baseEnv {
-		if !strings.HasPrefix(e, "DOTSECENV_CONFIG=") && !strings.HasPrefix(e, "DOTSECENV_FINGERPRINT=") {
+		if !strings.HasPrefix(e, "DOTSECENV_CONFIG=") {
 			filtered = append(filtered, e)
 		}
 	}
@@ -65,6 +66,40 @@ func runCmdWithEnv(env []string, args ...string) (string, string, error) {
 	cmd.Stderr = &stderr
 	err := cmd.Run()
 	return stdout.String(), stderr.String(), err
+}
+
+// setupTestUser creates a GPG identity ready to act as a dotsecenv user:
+// generates a key in gpgHome, writes a minimal config that points at vaultPath,
+// and runs `dotsecenv login` to populate a signed Login section. Tests can then
+// switch identity by passing different `-c configPath` values.
+//
+// `init vault` is per-vault, not per-user — call it once on the shared vaultPath
+// outside this helper.
+func setupTestUser(t *testing.T, gpgHome, vaultPath, name, email string) (fingerprint, configPath string) {
+	t.Helper()
+
+	fingerprint = generateKey(t, gpgHome, name, email)
+
+	configPath = filepath.Join(t.TempDir(), "config.yaml")
+	configContent := fmt.Sprintf(`
+approved_algorithms:
+  - algo: RSA
+    min_bits: 2048
+vault:
+  - "%s"
+gpg:
+  program: PATH
+`, vaultPath)
+	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
+		t.Fatalf("setupTestUser(%s): write config: %v", name, err)
+	}
+
+	env := []string{"GNUPGHOME=" + gpgHome}
+	if _, stderr, err := runCmdWithEnv(env, "-c", configPath, "login", fingerprint); err != nil {
+		t.Fatalf("setupTestUser(%s): dotsecenv login %s failed: %v\nstderr: %s", name, fingerprint, err, stderr)
+	}
+
+	return fingerprint, configPath
 }
 
 func TestGlobalOptions_ConfigPath(t *testing.T) {
@@ -258,6 +293,55 @@ gpg:
 	}
 	if !strings.Contains(stdout, configPath) {
 		t.Errorf("expected to find config path in output")
+	}
+}
+
+// TestDOTSECENVFingerprint_Ignored guards against regressions in DOTSECENV_FINGERPRINT removal.
+// The env var was removed in favor of the signed Login section. If anything in
+// the binary, docs, or CI accidentally re-introduces a read of this var, this
+// test catches it: a stale value in env must NOT change behavior, and no
+// warning should be emitted about it.
+func TestDOTSECENVFingerprint_Ignored(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+	vaultPath := filepath.Join(tmpDir, "vault")
+
+	err := os.WriteFile(configPath, []byte(fmt.Sprintf(`
+approved_algorithms:
+  - algo: RSA
+    min_bits: 2048
+vault:
+  - %s
+gpg:
+  program: PATH
+`, vaultPath)), 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := runCmd("init", "vault", "-v", vaultPath); err != nil {
+		t.Fatalf("init vault failed: %v", err)
+	}
+
+	// Baseline: validate with no env override.
+	stdoutBaseline, stderrBaseline, errBaseline := runCmd("-c", configPath, "validate")
+
+	// With a stray DOTSECENV_FINGERPRINT set: behavior must be identical.
+	stdoutWithEnv, stderrWithEnv, errWithEnv := runCmdWithEnv(
+		[]string{"DOTSECENV_FINGERPRINT=ABCDEF1234567890ABCDEF1234567890ABCDEF12"},
+		"-c", configPath, "validate",
+	)
+
+	if (errBaseline == nil) != (errWithEnv == nil) {
+		t.Errorf("DOTSECENV_FINGERPRINT changed exit status: baseline err=%v, with-env err=%v", errBaseline, errWithEnv)
+	}
+	if stdoutBaseline != stdoutWithEnv {
+		t.Errorf("DOTSECENV_FINGERPRINT changed stdout. baseline:\n%s\nwith-env:\n%s", stdoutBaseline, stdoutWithEnv)
+	}
+	if stderrBaseline != stderrWithEnv {
+		t.Errorf("DOTSECENV_FINGERPRINT changed stderr. baseline:\n%s\nwith-env:\n%s", stderrBaseline, stderrWithEnv)
+	}
+	if strings.Contains(strings.ToLower(stderrWithEnv), "dotsecenv_fingerprint") {
+		t.Errorf("stderr mentions DOTSECENV_FINGERPRINT — env var should be silently ignored:\n%s", stderrWithEnv)
 	}
 }
 

--- a/cmd/dotsecenv/revoke_test.go
+++ b/cmd/dotsecenv/revoke_test.go
@@ -181,44 +181,26 @@ func TestSecretRevoke_Self(t *testing.T) {
 		t.Fatalf("failed to generate key for User B: %v", err)
 	}
 
-	tmpDir := t.TempDir()
-	vaultPath := filepath.Join(tmpDir, "vault")
+	vaultPath := filepath.Join(t.TempDir(), "vault")
+	env := []string{"GNUPGHOME=" + gpgHome}
 
-	configPath := filepath.Join(tmpDir, "config.yaml")
+	// Each user gets their own config file with a real signed Login proof.
+	// They share vaultPath so multi-recipient sharing semantics still apply.
+	// setupTestUser internally calls generateKey, but we already generated keys
+	// above (under a timeout); pass them explicitly via a per-user config.
+	configPathA := writeUserConfig(t, vaultPath)
+	configPathB := writeUserConfig(t, vaultPath)
+	loginUser(t, env, configPathA, fpA)
+	loginUser(t, env, configPathB, fpB)
 
-	configContent := fmt.Sprintf(`
-approved_algorithms:
-  - algo: RSA
-    min_bits: 2048
-vault:
-  - "%s"
-gpg:
-  program: PATH
-`, vaultPath)
-
-	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	// Environment for User A
-	envA := []string{
-		"GNUPGHOME=" + gpgHome,
-		"DOTSECENV_FINGERPRINT=" + fpA,
-	}
-	// Environment for User B
-	envB := []string{
-		"GNUPGHOME=" + gpgHome,
-		"DOTSECENV_FINGERPRINT=" + fpB,
-	}
-
-	// Init vault
-	_, _, _ = runCmdWithEnv(envA, "init", "vault", "-v", vaultPath)
+	// Init vault once on the shared vault.
+	_, _, _ = runCmdWithEnv(env, "-c", configPathA, "init", "vault", "-v", vaultPath)
 
 	// Identities are auto-added by secret store (for User A) and secret share (for User B)
 
 	// 1. Store secret SEC1 (User A)
-	cmd := exec.Command(binaryPath, "-c", configPath, "secret", "store", "SEC1")
-	cmd.Env = append(filteredEnv(), envA...)
+	cmd := exec.Command(binaryPath, "-c", configPathA, "secret", "store", "SEC1")
+	cmd.Env = append(filteredEnv(), env...)
 	cmd.Stdin = strings.NewReader("secret_value_1")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -226,13 +208,13 @@ gpg:
 	}
 
 	// 2. Share with User B (User A)
-	_, _, err = runCmdWithEnv(envA, "-c", configPath, "secret", "share", "SEC1", fpB)
+	_, _, err = runCmdWithEnv(env, "-c", configPathA, "secret", "share", "SEC1", fpB)
 	if err != nil {
 		t.Fatalf("secret share failed: %v", err)
 	}
 
 	// Verify User B can access
-	stdout, _, err := runCmdWithEnv(envB, "-c", configPath, "secret", "get", "SEC1")
+	stdout, _, err := runCmdWithEnv(env, "-c", configPathB, "secret", "get", "SEC1")
 	if err != nil {
 		t.Fatalf("secret get (B) failed: %v", err)
 	}
@@ -242,7 +224,7 @@ gpg:
 
 	// 3. Revoke User A (Self Revocation)
 	// User A revokes themselves.
-	_, _, err = runCmdWithEnv(envA, "-c", configPath, "secret", "revoke", "SEC1", fpA)
+	_, _, err = runCmdWithEnv(env, "-c", configPathA, "secret", "revoke", "SEC1", fpA)
 	if err != nil {
 		t.Fatalf("secret revoke (self) failed: %v", err)
 	}
@@ -250,7 +232,7 @@ gpg:
 	// 4. Verify User A can still access older value after self-revocation
 	// After self-revocation, User A can still decrypt their original value
 	// (Fallback to older values is always allowed silently)
-	stdout, _, err = runCmdWithEnv(envA, "-c", configPath, "secret", "get", "SEC1")
+	stdout, _, err = runCmdWithEnv(env, "-c", configPathA, "secret", "get", "SEC1")
 	if err != nil {
 		t.Errorf("expected secret get (A) to succeed with older value after self-revocation, got error: %v", err)
 	}
@@ -260,11 +242,41 @@ gpg:
 	}
 
 	// 5. Verify User B CAN still access (with either config)
-	stdout, _, err = runCmdWithEnv(envB, "-c", configPath, "secret", "get", "SEC1")
+	stdout, _, err = runCmdWithEnv(env, "-c", configPathB, "secret", "get", "SEC1")
 	if err != nil {
 		t.Errorf("secret get (B) failed after A revoked self: %v", err)
 	}
 	if strings.TrimSpace(stdout) != "secret_value_1" {
 		t.Errorf("unexpected secret value for B after A revoked self: %s", stdout)
+	}
+}
+
+// writeUserConfig writes a minimal per-user dotsecenv config pointing at vaultPath.
+// Used by tests that generate keys under a timeout (and so can't use setupTestUser).
+func writeUserConfig(t *testing.T, vaultPath string) string {
+	t.Helper()
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	content := fmt.Sprintf(`
+approved_algorithms:
+  - algo: RSA
+    min_bits: 2048
+vault:
+  - "%s"
+gpg:
+  program: PATH
+`, vaultPath)
+	if err := os.WriteFile(configPath, []byte(content), 0600); err != nil {
+		t.Fatalf("writeUserConfig: %v", err)
+	}
+	return configPath
+}
+
+// loginUser runs `dotsecenv login fp` against configPath to populate a signed
+// Login section. Used in conjunction with writeUserConfig when keys are
+// generated separately (e.g., under a timeout context).
+func loginUser(t *testing.T, env []string, configPath, fingerprint string) {
+	t.Helper()
+	if _, stderr, err := runCmdWithEnv(env, "-c", configPath, "login", fingerprint); err != nil {
+		t.Fatalf("loginUser(%s): %v\nstderr: %s", fingerprint, err, stderr)
 	}
 }

--- a/cmd/dotsecenv/security_test.go
+++ b/cmd/dotsecenv/security_test.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -93,47 +92,32 @@ func TestIssue_SelfRevokeAddsGPGKey(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(gpgHome) }()
 
-	// Create two users
-	fpA := generateKey(t, gpgHome, "User A", "usera@example.com")
-	fpB := generateKey(t, gpgHome, "User B", "userb@example.com")
+	vaultPath := filepath.Join(t.TempDir(), "vault")
+	env := []string{"GNUPGHOME=" + gpgHome}
 
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "config.yaml")
-	vaultPath := filepath.Join(tmpDir, "vault")
+	// Each user gets their own config with a real signed Login proof.
+	// They share the same vaultPath so secret-sharing semantics still apply.
+	fpA, configPathA := setupTestUser(t, gpgHome, vaultPath, "User A", "usera@example.com")
+	fpB, _ := setupTestUser(t, gpgHome, vaultPath, "User B", "userb@example.com")
 
-	configContent := fmt.Sprintf(`
-approved_algorithms:
-  - algo: RSA
-    min_bits: 2048
-vault:
-  - "%s"
-gpg:
-  program: PATH
-`, vaultPath)
-	if err := os.WriteFile(configPath, []byte(configContent), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	envA := []string{"GNUPGHOME=" + gpgHome, "DOTSECENV_FINGERPRINT=" + fpA}
-
-	// Init vault (identities are auto-added by secret store and secret share)
-	_, _, _ = runCmdWithEnv(envA, "init", "vault", "-v", vaultPath)
+	// Init vault once on the shared vault (identities are auto-added by secret store/share).
+	_, _, _ = runCmdWithEnv(env, "-c", configPathA, "init", "vault", "-v", vaultPath)
 
 	// 1. User A stores secret
-	cmd := exec.Command(binaryPath, "-c", configPath, "secret", "store", "SEC1")
-	cmd.Env = append(filteredEnv(), envA...)
+	cmd := exec.Command(binaryPath, "-c", configPathA, "secret", "store", "SEC1")
+	cmd.Env = append(filteredEnv(), env...)
 	cmd.Stdin = strings.NewReader("secret_value_1")
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("secret store failed: %v\n%s", err, out)
 	}
 
 	// 2. User A shares with User B
-	if _, _, err := runCmdWithEnv(envA, "-c", configPath, "secret", "share", "SEC1", fpB); err != nil {
+	if _, _, err := runCmdWithEnv(env, "-c", configPathA, "secret", "share", "SEC1", fpB); err != nil {
 		t.Fatalf("secret share failed: %v", err)
 	}
 
 	// 3. User A revokes User A (Self)
-	stdoutRevoke, stderrRevoke, err := runCmdWithEnv(envA, "-c", configPath, "secret", "revoke", "SEC1", fpA)
+	stdoutRevoke, stderrRevoke, err := runCmdWithEnv(env, "-c", configPathA, "secret", "revoke", "SEC1", fpA)
 	if err != nil {
 		t.Fatalf("secret revoke failed: %v\nSTDERR: %s", err, stderrRevoke)
 	}
@@ -142,7 +126,7 @@ gpg:
 
 	// 4. Verify User A gets the older value via fallback (silently)
 	// Since A was revoked from latest, but had access to previous, it should return previous.
-	_, _, err = runCmdWithEnv(envA, "-c", configPath, "secret", "get", "SEC1")
+	_, _, err = runCmdWithEnv(env, "-c", configPathA, "secret", "get", "SEC1")
 	if err != nil {
 		t.Errorf("CLI failed to get secret (fallback expected): %v", err)
 	}
@@ -191,46 +175,31 @@ func TestIssue_RevokeWithoutAccess(t *testing.T) {
 	}
 	defer func() { _ = os.RemoveAll(gpgHome) }()
 
-	fpA := generateKey(t, gpgHome, "User A", "usera@example.com")
-	fpB := generateKey(t, gpgHome, "User B", "userb@example.com")
-	fpC := generateKey(t, gpgHome, "User C", "userc@example.com")
+	vaultPath := filepath.Join(t.TempDir(), "vault")
+	env := []string{"GNUPGHOME=" + gpgHome}
 
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "config.yaml")
-	vaultPath := filepath.Join(tmpDir, "vault")
+	_, configPathA := setupTestUser(t, gpgHome, vaultPath, "User A", "usera@example.com")
+	fpB, configPathB := setupTestUser(t, gpgHome, vaultPath, "User B", "userb@example.com")
+	fpC, _ := setupTestUser(t, gpgHome, vaultPath, "User C", "userc@example.com")
 
-	configContent := fmt.Sprintf(`
-approved_algorithms:
-  - algo: RSA
-    min_bits: 2048
-vault:
-  - "%s"
-gpg:
-  program: PATH
-`, vaultPath)
-	_ = os.WriteFile(configPath, []byte(configContent), 0600)
-
-	envA := []string{"GNUPGHOME=" + gpgHome, "DOTSECENV_FINGERPRINT=" + fpA}
-	envB := []string{"GNUPGHOME=" + gpgHome, "DOTSECENV_FINGERPRINT=" + fpB}
-
-	// Init vault (identities are auto-added by secret store and secret share)
-	_, _, _ = runCmdWithEnv(envA, "init", "vault", "-v", vaultPath)
+	// Init vault once (identities are auto-added by secret store and secret share)
+	_, _, _ = runCmdWithEnv(env, "-c", configPathA, "init", "vault", "-v", vaultPath)
 
 	// 1. A creates secret (v1)
-	cmd := exec.Command(binaryPath, "-c", configPath, "secret", "store", "SEC1")
-	cmd.Env = append(filteredEnv(), envA...)
+	cmd := exec.Command(binaryPath, "-c", configPathA, "secret", "store", "SEC1")
+	cmd.Env = append(filteredEnv(), env...)
 	cmd.Stdin = strings.NewReader("v1")
 	_ = cmd.Run()
 
 	// 2. Share with B (v1 shared with A, B)
-	_, _, _ = runCmdWithEnv(envA, "-c", configPath, "secret", "share", "SEC1", fpB)
+	_, _, _ = runCmdWithEnv(env, "-c", configPathA, "secret", "share", "SEC1", fpB)
 
 	// 3. Share with C
-	_, _, _ = runCmdWithEnv(envA, "-c", configPath, "secret", "share", "SEC1", fpC)
+	_, _, _ = runCmdWithEnv(env, "-c", configPathA, "secret", "share", "SEC1", fpC)
 
 	// 4. A updates secret (v4) -> Only A has access
-	cmd = exec.Command(binaryPath, "-c", configPath, "secret", "store", "SEC1")
-	cmd.Env = append(filteredEnv(), envA...)
+	cmd = exec.Command(binaryPath, "-c", configPathA, "secret", "store", "SEC1")
+	cmd.Env = append(filteredEnv(), env...)
 	cmd.Stdin = strings.NewReader("v4")
 	_ = cmd.Run()
 
@@ -238,7 +207,7 @@ gpg:
 	// B has access to v2 and v3.
 	// B does NOT have access to v4 (latest).
 	// B tries to revoke C from SEC1.
-	_, stderr, err := runCmdWithEnv(envB, "-c", configPath, "secret", "revoke", "SEC1", fpC)
+	_, stderr, err := runCmdWithEnv(env, "-c", configPathB, "secret", "revoke", "SEC1", fpC)
 
 	if err == nil {
 		t.Errorf("SECURITY VULNERABILITY: User B revoked C from secret SEC1 despite not having access to latest value!")

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -76,6 +76,14 @@ func NewCLI(vaultPaths []string, configPath string, silent bool, stdin io.Reader
 // without opening any vaults. This is used by commands like `login` that
 // operate purely on config and do not need vault access.
 func NewCLIConfigOnly(configPath string, silent bool, stdin io.Reader, stdout, stderr io.Writer) (*CLI, error) {
+	return loadConfigAndPrepareGPG(configPath, silent, stdin, stdout, stderr)
+}
+
+// loadConfigAndPrepareGPG returns a CLI populated with everything except
+// vaultResolver and vaultPaths. Both NewCLI and NewCLIConfigOnly use this as
+// their prelude — the only difference between them is whether vaults are
+// opened afterward.
+func loadConfigAndPrepareGPG(configPath string, silent bool, stdin io.Reader, stdout, stderr io.Writer) (*CLI, error) {
 	xdgPaths, err := xdg.NewPaths()
 	if err != nil {
 		return nil, NewError(fmt.Sprintf("failed to get XDG paths: %v", err), ExitConfigError)
@@ -83,21 +91,20 @@ func NewCLIConfigOnly(configPath string, silent bool, stdin io.Reader, stdout, s
 
 	configPath = ResolveConfigPath(configPath, silent, stderr)
 
-	// Ensure directories exist
 	if err := xdgPaths.EnsureDirs(); err != nil {
 		return nil, NewError(fmt.Sprintf("failed to create directories: %v", err), ExitConfigError)
 	}
 
-	// Load config (fail if missing or invalid)
-	cfg, err := config.Load(configPath)
+	cfg, warnings, err := config.Load(configPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			var suggestion string
-			if isSUID() {
+			switch {
+			case isSUID():
 				suggestion = fmt.Sprintf("config file not found: %s\nContact your system administrator to create this file.", configPath)
-			} else if os.Getuid() == 0 {
+			case os.Getuid() == 0:
 				suggestion = fmt.Sprintf("config file not found: %s\nRun 'sudo dotsecenv init config' to create one", configPath)
-			} else {
+			default:
 				suggestion = fmt.Sprintf("config file not found: %s\nRun 'dotsecenv init config' to create one", configPath)
 			}
 			return nil, NewError(suggestion, ExitConfigError)
@@ -105,86 +112,45 @@ func NewCLIConfigOnly(configPath string, silent bool, stdin io.Reader, stdout, s
 		return nil, NewError(fmt.Sprintf("failed to load config: %v", err), ExitConfigError)
 	}
 
-	// Deprecation warning for fingerprint field
-	if cfg.HasDeprecatedFingerprint() && !silent {
-		_, _ = fmt.Fprintf(stderr, "warning: 'fingerprint:' field is deprecated and will be removed in a future version\n")
-		_, _ = fmt.Fprintf(stderr, "         Run 'dotsecenv login %s' to migrate to signed login\n", cfg.Fingerprint)
+	if !silent {
+		for _, w := range warnings {
+			_, _ = fmt.Fprintf(stderr, "warning: %s\n", w)
+		}
 	}
 
-	// Validate and set GPG program path from config
 	if err := gpg.ValidateAndSetGPGProgram(cfg.GPG.Program); err != nil {
 		return nil, NewError(fmt.Sprintf("failed: %v", err), ExitGPGError)
 	}
 
 	return &CLI{
-			configPath: configPath,
-			xdgPaths:   xdgPaths,
-			config:     cfg,
-			gpgClient:  &gpg.GPGClient{},
-			stdin:      stdin,
-			Silent:     silent,
-			output: output.NewHandler(stdout, stderr,
-				output.WithSilent(silent),
-			),
-			hasTTY: defaultHasTTY,
-		},
-		nil
+		configPath: configPath,
+		xdgPaths:   xdgPaths,
+		config:     cfg,
+		gpgClient:  &gpg.GPGClient{},
+		stdin:      stdin,
+		Silent:     silent,
+		output: output.NewHandler(stdout, stderr,
+			output.WithSilent(silent),
+		),
+		hasTTY: defaultHasTTY,
+	}, nil
 }
 
 // newCLI creates a CLI instance. If requireExplicitUpgradeOverride is non-nil, it overrides the config setting.
 func newCLI(vaultPaths []string, configPath string, silent bool, stdin io.Reader, stdout, stderr io.Writer, requireExplicitUpgradeOverride *bool) (*CLI, error) {
-	xdgPaths, err := xdg.NewPaths()
+	cli, err := loadConfigAndPrepareGPG(configPath, silent, stdin, stdout, stderr)
 	if err != nil {
-		return nil, NewError(fmt.Sprintf("failed to get XDG paths: %v", err), ExitConfigError)
+		return nil, err
 	}
-
-	configPath = ResolveConfigPath(configPath, silent, stderr)
-
-	// Ensure directories exist
-	if err := xdgPaths.EnsureDirs(); err != nil {
-		return nil, NewError(fmt.Sprintf("failed to create directories: %v", err), ExitConfigError)
-	}
-
-	// Load config (fail if missing or invalid)
-	cfg, err := config.Load(configPath)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			// Provide helpful suggestion based on execution context
-			var suggestion string
-			if isSUID() {
-				// SUID mode: config at /etc/dotsecenv/config, init commands are blocked
-				suggestion = fmt.Sprintf("config file not found: %s\nContact your system administrator to create this file.", configPath)
-			} else if os.Getuid() == 0 {
-				// Running as actual root (e.g., via sudo)
-				suggestion = fmt.Sprintf("config file not found: %s\nRun 'sudo dotsecenv init config' to create one", configPath)
-			} else {
-				// Normal user
-				suggestion = fmt.Sprintf("config file not found: %s\nRun 'dotsecenv init config' to create one", configPath)
-			}
-			return nil, NewError(suggestion, ExitConfigError)
-		}
-		return nil, NewError(fmt.Sprintf("failed to load config: %v", err), ExitConfigError)
-	}
-
-	// Deprecation warning for fingerprint field (use login section instead)
-	if cfg.HasDeprecatedFingerprint() && !silent {
-		_, _ = fmt.Fprintf(stderr, "warning: 'fingerprint:' field is deprecated and will be removed in a future version\n")
-		_, _ = fmt.Fprintf(stderr, "         Run 'dotsecenv login %s' to migrate to signed login\n", cfg.Fingerprint)
-	}
-
-	// Validate and set GPG program path from config
-	if err := gpg.ValidateAndSetGPGProgram(cfg.GPG.Program); err != nil {
-		return nil, NewError(fmt.Sprintf("failed: %v", err), ExitGPGError)
-	}
-
-	// Create vault resolver
-	var vaultResolver *vault.VaultResolver
+	cfg := cli.config
 
 	// Determine output writer for warnings
 	warnWriter := stderr
 	if silent {
 		warnWriter = io.Discard
 	}
+
+	var vaultResolver *vault.VaultResolver
 
 	// If -v flags were provided, use those paths directly
 	if len(vaultPaths) > 0 {
@@ -195,7 +161,7 @@ func newCLI(vaultPaths []string, configPath string, silent bool, stdin io.Reader
 			configPaths := make(map[string]bool)
 			for _, p := range cfg.Vault {
 				expanded := vault.ExpandPath(p)
-				if abs, err := filepath.Abs(expanded); err == nil {
+				if abs, absErr := filepath.Abs(expanded); absErr == nil {
 					configPaths[abs] = true
 				} else {
 					configPaths[expanded] = true
@@ -205,9 +171,9 @@ func newCLI(vaultPaths []string, configPath string, silent bool, stdin io.Reader
 			// Check if any specified path is NOT in config
 			for _, p := range vaultPaths {
 				expanded := vault.ExpandPath(p)
-				abs, err := filepath.Abs(expanded)
+				abs, absErr := filepath.Abs(expanded)
 				target := expanded
-				if err == nil {
+				if absErr == nil {
 					target = abs
 				}
 
@@ -265,21 +231,9 @@ func newCLI(vaultPaths []string, configPath string, silent bool, stdin io.Reader
 		}
 	}
 
-	return &CLI{
-			vaultPaths:    vaultPaths,
-			configPath:    configPath,
-			xdgPaths:      xdgPaths,
-			config:        cfg,
-			vaultResolver: vaultResolver,
-			gpgClient:     &gpg.GPGClient{},
-			stdin:         stdin,
-			Silent:        silent,
-			output: output.NewHandler(stdout, stderr,
-				output.WithSilent(silent),
-			),
-			hasTTY: defaultHasTTY,
-		},
-		nil
+	cli.vaultPaths = vaultPaths
+	cli.vaultResolver = vaultResolver
+	return cli, nil
 }
 
 // Warnf prints a warning message to stderr unless silent mode is enabled.
@@ -315,22 +269,18 @@ func (c *CLI) Close() error {
 	return nil
 }
 
-// getFingerprintFromEnv gets the current fingerprint to use.
-// In SUID mode, DOTSECENV_FINGERPRINT is ignored for security.
-// Prefers Login.Fingerprint over the deprecated Fingerprint field.
-func (c *CLI) getFingerprintFromEnv() string {
-	if !isSUID() {
-		envFP := os.Getenv("DOTSECENV_FINGERPRINT")
-		if envFP != "" {
-			return envFP
-		}
+// activeFingerprint returns the configured login fingerprint, or "" if no
+// signed Login proof is present in the config.
+func (c *CLI) activeFingerprint() string {
+	if c.config.Login == nil {
+		return ""
 	}
-	return c.config.GetFingerprint()
+	return c.config.Login.Fingerprint
 }
 
 // checkFingerprintRequired ensures a fingerprint is configured
 func (c *CLI) checkFingerprintRequired(operation string) (string, *Error) {
-	fp := c.getFingerprintFromEnv()
+	fp := c.activeFingerprint()
 	if fp == "" {
 		msg := fmt.Sprintf("select a user identity before running '%s'\n  run: `dotsecenv login FINGERPRINT`", operation)
 		return "", NewError(msg, ExitFingerprintRequired)

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -4,414 +4,22 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"os"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
-	"github.com/ProtonMail/gopenpgp/v3/crypto"
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/config"
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/gpg"
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/output"
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/vault"
 )
 
-// MockVaultResolver is a mock implementation of VaultResolver interface
-type MockVaultResolver struct {
-	mu                sync.Mutex
-	Identities        map[string]vault.Identity
-	IdentitiesByVault map[int]map[string]vault.Identity // index -> fingerprint -> identity
-	Secrets           map[int]map[string]vault.Secret   // index -> key -> secret
-	VaultPaths        []string                          // List of vault paths
-	AddSecretFunc     func(secret vault.Secret, index int) error
-	SavedVaults       []int // Track which vaults (indices) were saved
-	VaultEntries      []vault.VaultEntry
-	Managers          map[int]*vault.Manager // Optional managers for tests that need them
-}
-
-func NewMockVaultResolver() *MockVaultResolver {
-	return &MockVaultResolver{
-		Identities:        make(map[string]vault.Identity),
-		IdentitiesByVault: make(map[int]map[string]vault.Identity),
-		Secrets:           make(map[int]map[string]vault.Secret),
-		SavedVaults:       []int{},
-	}
-}
-
-func (m *MockVaultResolver) GetIdentityByFingerprint(fingerprint string) *vault.Identity {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	id, ok := m.Identities[fingerprint]
-	if !ok {
-		return nil
-	}
-	return &id
-}
-
-func (m *MockVaultResolver) AddSecret(secret vault.Secret, index int) error {
-	if m.AddSecretFunc != nil {
-		return m.AddSecretFunc(secret, index)
-	}
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	if _, ok := m.Secrets[index]; !ok {
-		m.Secrets[index] = make(map[string]vault.Secret)
-	}
-	m.Secrets[index][secret.Key] = secret
-	return nil
-}
-
-func (m *MockVaultResolver) AddIdentity(identity vault.Identity, index int) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.Identities[identity.Fingerprint] = identity
-
-	if index >= 0 {
-		if _, ok := m.IdentitiesByVault[index]; !ok {
-			m.IdentitiesByVault[index] = make(map[string]vault.Identity)
-		}
-		m.IdentitiesByVault[index][identity.Fingerprint] = identity
-	}
-	return nil
-}
-
-func (m *MockVaultResolver) SaveAll() error {
-	return nil
-}
-
-func (m *MockVaultResolver) CloseAll() error {
-	return nil
-}
-
-func (m *MockVaultResolver) GetSecretFromAnyVault(key string, stderr io.Writer) (*vault.SecretValue, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// Search in order
-	count := len(m.VaultPaths)
-	if len(m.VaultEntries) > count {
-		count = len(m.VaultEntries)
-	}
-
-	for i := 0; i < count; i++ {
-		if secrets, ok := m.Secrets[i]; ok {
-			if secret, ok := secrets[key]; ok {
-				if len(secret.Values) > 0 {
-					return &secret.Values[len(secret.Values)-1], nil
-				}
-			}
-		}
-	}
-	return nil, fmt.Errorf("secret not found")
-}
-
-func (m *MockVaultResolver) GetAccessibleSecretFromAnyVault(key, fingerprint string) (*vault.SecretValue, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	// Search in order
-	count := len(m.VaultPaths)
-	if len(m.VaultEntries) > count {
-		count = len(m.VaultEntries)
-	}
-
-	for i := 0; i < count; i++ {
-		if secrets, ok := m.Secrets[i]; ok {
-			if secret, ok := secrets[key]; ok {
-				if len(secret.Values) == 0 {
-					continue
-				}
-
-				// Check from most recent to oldest for accessible value
-				for j := len(secret.Values) - 1; j >= 0; j-- {
-					for _, fp := range secret.Values[j].AvailableTo {
-						if fp == fingerprint {
-							return &secret.Values[j], nil
-						}
-					}
-				}
-			}
-		}
-	}
-	return nil, fmt.Errorf("secret '%s' not found or not accessible", key)
-}
-
-func (m *MockVaultResolver) GetSecretByKeyFromVault(index int, key string) *vault.Secret {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if secrets, ok := m.Secrets[index]; ok {
-		if secret, ok := secrets[key]; ok {
-			return &secret
-		}
-	}
-	return nil
-}
-
-func (m *MockVaultResolver) FindSecretVaultIndex(key string) int {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	count := len(m.VaultPaths)
-	if len(m.VaultEntries) > count {
-		count = len(m.VaultEntries)
-	}
-
-	for i := 0; i < count; i++ {
-		if secrets, ok := m.Secrets[i]; ok {
-			if _, ok := secrets[key]; ok {
-				return i
-			}
-		}
-	}
-	return -1
-}
-
-func (m *MockVaultResolver) GetVaultManager(index int) *vault.Manager {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if m.Managers != nil {
-		return m.Managers[index]
-	}
-	return nil // Mock returns nil manager usually, but tests might need to mock this if they call methods on manager
-}
-
-func (m *MockVaultResolver) GetConfig() vault.VaultConfig {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return vault.VaultConfig{Entries: m.VaultEntries}
-}
-
-func (m *MockVaultResolver) GetVaultPaths() []string {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.VaultPaths
-}
-
-func (m *MockVaultResolver) GetAvailableVaultPathsWithIndices() []vault.VaultPathWithIndex {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	// In mock, all configured vaults are considered available
-	var result []vault.VaultPathWithIndex
-	for i, path := range m.VaultPaths {
-		result = append(result, vault.VaultPathWithIndex{Path: path, Index: i})
-	}
-	return result
-}
-
-func (m *MockVaultResolver) IsPathInConfig(path string) bool {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	for _, p := range m.VaultPaths {
-		if vault.ExpandPath(p) == vault.ExpandPath(path) {
-			return true
-		}
-	}
-	return false
-}
-
-func (m *MockVaultResolver) IdentityExistsInVault(fingerprint string, index int) bool {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if mapV, ok := m.IdentitiesByVault[index]; ok {
-		_, exists := mapV[fingerprint]
-		return exists
-	}
-	return false
-}
-
-func (m *MockVaultResolver) SaveVault(index int) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.SavedVaults = append(m.SavedVaults, index)
-	return nil
-}
-
-func (m *MockVaultResolver) GetLoadError(index int) error {
-	return nil
-}
-
-func (m *MockVaultResolver) GetSecret(index int, key string) (*vault.SecretValue, error) {
-	s := m.GetSecretByKeyFromVault(index, key)
-	if s == nil || len(s.Values) == 0 {
-		return nil, fmt.Errorf("not found")
-	}
-	return &s.Values[len(s.Values)-1], nil
-}
-
-func (m *MockVaultResolver) OpenVaultsFromPaths(paths []string, stderr io.Writer) error {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.VaultPaths = paths
-	// Rebuild entries
-	m.VaultEntries = nil
-	for _, p := range paths {
-		m.VaultEntries = append(m.VaultEntries, vault.VaultEntry{Path: p})
-	}
-	return nil
-}
-
-func (m *MockVaultResolver) OpenVaults(stderr io.Writer) error {
-	return nil
-}
-
-func (m *MockVaultResolver) VaultCount() int {
-	count := len(m.VaultPaths)
-	if len(m.VaultEntries) > count {
-		count = len(m.VaultEntries)
-	}
-	// Also count from Secrets map
-	for idx := range m.Secrets {
-		if idx+1 > count {
-			count = idx + 1
-		}
-	}
-	return count
-}
-
-func (m *MockVaultResolver) ListAllSecretKeys() []vault.SecretKeyInfo {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	var result []vault.SecretKeyInfo
-	seen := make(map[string]bool)
-
-	count := m.VaultCount()
-	for i := 0; i < count; i++ {
-		secrets, ok := m.Secrets[i]
-		if !ok {
-			continue
-		}
-
-		vaultPath := ""
-		if i < len(m.VaultEntries) {
-			vaultPath = m.VaultEntries[i].Path
-		} else if i < len(m.VaultPaths) {
-			vaultPath = m.VaultPaths[i]
-		}
-
-		for key, secret := range secrets {
-			if seen[key] {
-				continue
-			}
-			seen[key] = true
-
-			result = append(result, vault.SecretKeyInfo{
-				Key:      key,
-				Vault:    vaultPath,
-				VaultIdx: i + 1,
-				Deleted:  secret.IsDeleted(),
-			})
-		}
-	}
-
-	return result
-}
-
-func (m *MockVaultResolver) ListSecretKeysFromVault(index int) []vault.SecretKeyInfo {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	secrets, ok := m.Secrets[index]
-	if !ok {
-		return nil
-	}
-
-	vaultPath := ""
-	if index < len(m.VaultEntries) {
-		vaultPath = m.VaultEntries[index].Path
-	} else if index < len(m.VaultPaths) {
-		vaultPath = m.VaultPaths[index]
-	}
-
-	var result []vault.SecretKeyInfo
-	for key, secret := range secrets {
-		result = append(result, vault.SecretKeyInfo{
-			Key:      key,
-			Vault:    vaultPath,
-			VaultIdx: index + 1,
-			Deleted:  secret.IsDeleted(),
-		})
-	}
-
-	return result
-}
-
-// MockGPGClient is a mock implementation of GPGClient interface
-type MockGPGClient struct {
-	PublicKeyInfo map[string]gpg.KeyInfo
-}
-
-func NewMockGPGClient() *MockGPGClient {
-	return &MockGPGClient{
-		PublicKeyInfo: make(map[string]gpg.KeyInfo),
-	}
-}
-
-func (m *MockGPGClient) GetPublicKeyInfo(fingerprint string) (*gpg.KeyInfo, error) {
-	if info, ok := m.PublicKeyInfo[fingerprint]; ok {
-		return &info, nil
-	}
-	return nil, fmt.Errorf("public key info not found for %s", fingerprint)
-}
-
-func (m *MockGPGClient) EncryptToRecipients(plaintext []byte, recipients []string, signingKey *crypto.Key) (string, error) {
-	return fmt.Sprintf("encrypted_to_%s_%s", strings.Join(recipients, "_"), string(plaintext)), nil
-}
-
-func (m *MockGPGClient) SignDataWithAgent(fingerprint string, data []byte) (string, error) {
-	return fmt.Sprintf("signature_by_%s", fingerprint), nil
-}
-
-func (m *MockGPGClient) DecryptWithAgent(ciphertext []byte, fingerprint string) ([]byte, error) {
-	return nil, fmt.Errorf("not implemented")
-}
-
-func (m *MockGPGClient) ExtractAlgorithmAndCurve(fullAlgorithm string) (algorithm string, curve string) {
-	return fullAlgorithm, ""
-}
-
-func (m *MockGPGClient) GetKeyCreationTime(fingerprint string) time.Time {
-	return time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
-}
-
-func (m *MockGPGClient) SignIdentity(identity *vault.Identity, signerFingerprint string) (hash string, signature string, err error) {
-	return "mock_hash", "mock_signature", nil
-}
-
-func (m *MockGPGClient) SignSecret(secret *vault.Secret, signerFingerprint string, algorithmBits int) (hash string, signature string, err error) {
-	return "mock_hash", "mock_signature", nil
-}
-
-func (m *MockGPGClient) SignSecretValue(value *vault.SecretValue, secretKey string, signerFingerprint string, algorithmBits int) (hash string, signature string, err error) {
-	return "mock_hash", "mock_signature", nil
-}
-
-func (m *MockGPGClient) DecryptSecret(encryptedBase64 string, fingerprint string) ([]byte, error) {
-	return []byte("decrypted_secret"), nil
-}
-
-func (m *MockGPGClient) DecryptSecretValue(value *vault.SecretValue, fingerprint string) ([]byte, error) {
-	return []byte("decrypted_secret_value"), nil
-}
-
-func (m *MockGPGClient) IsAgentAvailable() bool {
-	return true
-}
-
-func (m *MockGPGClient) ListSecretKeys() ([]gpg.SecretKeyInfo, error) {
-	return []gpg.SecretKeyInfo{
-		{Fingerprint: "TESTFINGERPRINT", UID: "Test User <test@example.com>"},
-	}, nil
-}
+// MockVaultResolver and MockGPGClient live in testhelpers_test.go.
 
 // TestSecretPut_WithVaultPath tests the -v flag functionality
 func TestSecretPut_WithVaultPath(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "") // Clear env to use mock config fingerprint
-	t.Setenv("DOTSECENV_CONFIG", "")      // Clear env to avoid config pollution
+	t.Setenv("DOTSECENV_CONFIG", "") // Clear env to avoid config pollution
 
 	mockVaultResolver := NewMockVaultResolver()
 	testFP := "TESTFINGERPRINT"
@@ -437,7 +45,7 @@ func TestSecretPut_WithVaultPath(t *testing.T) {
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{
 			{Algo: "RSA", MinBits: 2048},
 		},
-		Fingerprint: testFP,
+		Login: newTestSignedLogin(t, testFP),
 	}
 
 	tmpFile, err := os.CreateTemp("", "testvault_*.yaml")
@@ -487,8 +95,7 @@ func TestSecretPut_WithVaultPath(t *testing.T) {
 
 // TestSecretPut_WithFromIndex tests the --from flag functionality
 func TestSecretPut_WithFromIndex(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "") // Clear env to use mock config fingerprint
-	t.Setenv("DOTSECENV_CONFIG", "")      // Clear env to avoid config pollution
+	t.Setenv("DOTSECENV_CONFIG", "") // Clear env to avoid config pollution
 
 	mockVaultResolver := NewMockVaultResolver()
 	testFP := "TESTFINGERPRINT"
@@ -514,7 +121,7 @@ func TestSecretPut_WithFromIndex(t *testing.T) {
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{
 			{Algo: "RSA", MinBits: 2048},
 		},
-		Fingerprint: testFP,
+		Login: newTestSignedLogin(t, testFP),
 	}
 
 	cli := &CLI{
@@ -584,7 +191,7 @@ func TestSecretPut_FromIndexOutOfRange(t *testing.T) {
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{
 			{Algo: "RSA", MinBits: 2048},
 		},
-		Fingerprint: testFP,
+		Login: newTestSignedLogin(t, testFP),
 	}
 
 	cli := &CLI{
@@ -626,8 +233,7 @@ func (m *MockGPGClientWithDecrypt) DecryptWithAgent(ciphertext []byte, fingerpri
 
 // TestSecretGet_WithFromIndex tests the -v N flag functionality for secret get
 func TestSecretGet_WithFromIndex(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "") // Clear env to use mock config fingerprint
-	t.Setenv("DOTSECENV_CONFIG", "")      // Clear env to avoid config pollution
+	t.Setenv("DOTSECENV_CONFIG", "") // Clear env to avoid config pollution
 
 	mockVaultResolver := NewMockVaultResolver()
 	testFP := "TESTFINGERPRINT"
@@ -686,7 +292,7 @@ func TestSecretGet_WithFromIndex(t *testing.T) {
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{
 			{Algo: "RSA", MinBits: 2048},
 		},
-		Fingerprint: testFP,
+		Login: newTestSignedLogin(t, testFP),
 	}
 
 	stdoutBuf := &bytes.Buffer{}
@@ -715,7 +321,6 @@ func TestSecretGet_WithFromIndex(t *testing.T) {
 
 // TestSecretForget_Basic tests basic secret forget functionality
 func TestSecretForget_Basic(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "")
 	t.Setenv("DOTSECENV_CONFIG", "")
 
 	mockVaultResolver := NewMockVaultResolver()
@@ -742,7 +347,7 @@ func TestSecretForget_Basic(t *testing.T) {
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{
 			{Algo: "RSA", MinBits: 2048},
 		},
-		Fingerprint: testFP,
+		Login: newTestSignedLogin(t, testFP),
 	}
 
 	tmpFile, err := os.CreateTemp("", "testvault_*.yaml")
@@ -819,7 +424,6 @@ func TestSecretForget_Basic(t *testing.T) {
 
 // TestSecretForget_AlreadyDeleted tests that forgetting an already-deleted secret fails
 func TestSecretForget_AlreadyDeleted(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "")
 	t.Setenv("DOTSECENV_CONFIG", "")
 
 	mockVaultResolver := NewMockVaultResolver()
@@ -838,7 +442,7 @@ func TestSecretForget_AlreadyDeleted(t *testing.T) {
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{
 			{Algo: "RSA", MinBits: 2048},
 		},
-		Fingerprint: testFP,
+		Login: newTestSignedLogin(t, testFP),
 	}
 
 	tmpFile, err := os.CreateTemp("", "testvault_*.yaml")
@@ -885,7 +489,6 @@ func TestSecretForget_AlreadyDeleted(t *testing.T) {
 
 // TestSecretForget_NotFound tests that forgetting a non-existent secret fails
 func TestSecretForget_NotFound(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "")
 	t.Setenv("DOTSECENV_CONFIG", "")
 
 	mockVaultResolver := NewMockVaultResolver()
@@ -904,7 +507,7 @@ func TestSecretForget_NotFound(t *testing.T) {
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{
 			{Algo: "RSA", MinBits: 2048},
 		},
-		Fingerprint: testFP,
+		Login: newTestSignedLogin(t, testFP),
 	}
 
 	tmpFile, err := os.CreateTemp("", "testvault_*.yaml")
@@ -939,7 +542,6 @@ func TestSecretForget_NotFound(t *testing.T) {
 
 // TestSecretPut_BlockedByDeleted tests that putting to a deleted secret fails
 func TestSecretPut_BlockedByDeleted(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "")
 	t.Setenv("DOTSECENV_CONFIG", "")
 
 	mockVaultResolver := NewMockVaultResolver()
@@ -966,7 +568,7 @@ func TestSecretPut_BlockedByDeleted(t *testing.T) {
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{
 			{Algo: "RSA", MinBits: 2048},
 		},
-		Fingerprint: testFP,
+		Login: newTestSignedLogin(t, testFP),
 	}
 
 	tmpFile, err := os.CreateTemp("", "testvault_*.yaml")
@@ -1022,7 +624,6 @@ func TestSecretPut_BlockedByDeleted(t *testing.T) {
 
 // TestSecretForget_NoAccess tests that forgetting without access fails
 func TestSecretForget_NoAccess(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "")
 	t.Setenv("DOTSECENV_CONFIG", "")
 
 	mockVaultResolver := NewMockVaultResolver()
@@ -1042,7 +643,7 @@ func TestSecretForget_NoAccess(t *testing.T) {
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{
 			{Algo: "RSA", MinBits: 2048},
 		},
-		Fingerprint: testFP,
+		Login: newTestSignedLogin(t, testFP),
 	}
 
 	tmpFile, err := os.CreateTemp("", "testvault_*.yaml")
@@ -1337,7 +938,6 @@ func TestSecretList_VaultPath(t *testing.T) {
 
 // TestSecretGet_WarnsWithoutTTY tests that secret get emits a warning when not in a TTY
 func TestSecretGet_WarnsWithoutTTY(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "")
 	t.Setenv("DOTSECENV_CONFIG", "")
 
 	testFP := "TESTFINGERPRINT"
@@ -1346,7 +946,7 @@ func TestSecretGet_WarnsWithoutTTY(t *testing.T) {
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{
 			{Algo: "RSA", MinBits: 2048},
 		},
-		Fingerprint: testFP,
+		Login: newTestSignedLogin(t, testFP),
 	}
 
 	// Setup mock vault resolver with a secret
@@ -1437,7 +1037,6 @@ func TestSmartJSONValue(t *testing.T) {
 }
 
 func TestSecretForget_IgnoreNotFound_NotFound(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "")
 	t.Setenv("DOTSECENV_CONFIG", "")
 
 	mockVaultResolver := NewMockVaultResolver()
@@ -1456,7 +1055,7 @@ func TestSecretForget_IgnoreNotFound_NotFound(t *testing.T) {
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{
 			{Algo: "RSA", MinBits: 2048},
 		},
-		Fingerprint: testFP,
+		Login: newTestSignedLogin(t, testFP),
 	}
 
 	tmpFile, err := os.CreateTemp("", "testvault_*.yaml")
@@ -1485,7 +1084,6 @@ func TestSecretForget_IgnoreNotFound_NotFound(t *testing.T) {
 }
 
 func TestSecretForget_IgnoreNotFound_NoValues(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "")
 	t.Setenv("DOTSECENV_CONFIG", "")
 
 	mockVaultResolver := NewMockVaultResolver()
@@ -1504,7 +1102,7 @@ func TestSecretForget_IgnoreNotFound_NoValues(t *testing.T) {
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{
 			{Algo: "RSA", MinBits: 2048},
 		},
-		Fingerprint: testFP,
+		Login: newTestSignedLogin(t, testFP),
 	}
 
 	tmpFile, err := os.CreateTemp("", "testvault_*.yaml")
@@ -1542,7 +1140,6 @@ func TestSecretForget_IgnoreNotFound_NoValues(t *testing.T) {
 }
 
 func TestSecretForget_IgnoreNotFound_AlreadyDeleted(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "")
 	t.Setenv("DOTSECENV_CONFIG", "")
 
 	mockVaultResolver := NewMockVaultResolver()
@@ -1561,7 +1158,7 @@ func TestSecretForget_IgnoreNotFound_AlreadyDeleted(t *testing.T) {
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{
 			{Algo: "RSA", MinBits: 2048},
 		},
-		Fingerprint: testFP,
+		Login: newTestSignedLogin(t, testFP),
 	}
 
 	tmpFile, err := os.CreateTemp("", "testvault_*.yaml")
@@ -1602,7 +1199,6 @@ func TestSecretForget_IgnoreNotFound_AlreadyDeleted(t *testing.T) {
 }
 
 func TestSecretGet_JSONOutput(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "")
 	t.Setenv("DOTSECENV_CONFIG", "")
 
 	testFP := "TESTFINGERPRINT"
@@ -1611,7 +1207,7 @@ func TestSecretGet_JSONOutput(t *testing.T) {
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{
 			{Algo: "RSA", MinBits: 2048},
 		},
-		Fingerprint: testFP,
+		Login: newTestSignedLogin(t, testFP),
 	}
 
 	mockVaultResolver := NewMockVaultResolver()
@@ -1667,7 +1263,6 @@ func TestSecretGet_JSONOutput(t *testing.T) {
 }
 
 func TestSecretGet_JSONOutput_SmartMarshal(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "")
 	t.Setenv("DOTSECENV_CONFIG", "")
 
 	testFP := "TESTFINGERPRINT"
@@ -1676,7 +1271,7 @@ func TestSecretGet_JSONOutput_SmartMarshal(t *testing.T) {
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{
 			{Algo: "RSA", MinBits: 2048},
 		},
-		Fingerprint: testFP,
+		Login: newTestSignedLogin(t, testFP),
 	}
 
 	mockVaultResolver := NewMockVaultResolver()
@@ -1737,7 +1332,6 @@ func TestSecretGet_JSONOutput_SmartMarshal(t *testing.T) {
 // TestSecretGet_FallbackToGPGAgent tests that secret get succeeds when the logged-in
 // fingerprint is NOT in AvailableTo but the GPG agent can still decrypt (different key in agent).
 func TestSecretGet_FallbackToGPGAgent(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "")
 	t.Setenv("DOTSECENV_CONFIG", "")
 
 	loggedInFP := "LOGGED_IN_FP"
@@ -1766,7 +1360,7 @@ func TestSecretGet_FallbackToGPGAgent(t *testing.T) {
 
 	mockConfig := config.Config{
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{{Algo: "RSA", MinBits: 2048}},
-		Fingerprint:        loggedInFP,
+		Login:              newTestSignedLogin(t, loggedInFP),
 	}
 
 	stdoutBuf := &bytes.Buffer{}
@@ -1794,7 +1388,6 @@ func TestSecretGet_FallbackToGPGAgent(t *testing.T) {
 // TestSecretGet_FallbackToGPGAgent_AllMode tests --all mode decrypts values
 // even when the logged-in fingerprint is not in AvailableTo.
 func TestSecretGet_FallbackToGPGAgent_AllMode(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "")
 	t.Setenv("DOTSECENV_CONFIG", "")
 
 	loggedInFP := "LOGGED_IN_FP"
@@ -1827,7 +1420,7 @@ func TestSecretGet_FallbackToGPGAgent_AllMode(t *testing.T) {
 
 	mockConfig := config.Config{
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{{Algo: "RSA", MinBits: 2048}},
-		Fingerprint:        loggedInFP,
+		Login:              newTestSignedLogin(t, loggedInFP),
 	}
 
 	stdoutBuf := &bytes.Buffer{}
@@ -1855,7 +1448,6 @@ func TestSecretGet_FallbackToGPGAgent_AllMode(t *testing.T) {
 // TestSecretGet_FallbackNotFound tests that when a secret truly doesn't exist,
 // the error is "not found" rather than "access denied".
 func TestSecretGet_FallbackNotFound(t *testing.T) {
-	t.Setenv("DOTSECENV_FINGERPRINT", "")
 	t.Setenv("DOTSECENV_CONFIG", "")
 
 	mockVaultResolver := NewMockVaultResolver()
@@ -1873,7 +1465,7 @@ func TestSecretGet_FallbackNotFound(t *testing.T) {
 
 	mockConfig := config.Config{
 		ApprovedAlgorithms: []config.ApprovedAlgorithm{{Algo: "RSA", MinBits: 2048}},
-		Fingerprint:        "SOMEFP",
+		Login:              newTestSignedLogin(t, "SOMEFP"),
 	}
 
 	stdoutBuf := &bytes.Buffer{}

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -35,9 +35,9 @@ COMMANDS:
   version                       Show version information
 
 ENVIRONMENT:
-  DOTSECENV_FINGERPRINT         Override fingerprint from config
-  XDG_CONFIG_HOME              Override config directory
-  XDG_DATA_HOME                Override data directory
+  DOTSECENV_CONFIG              Override config file path
+  XDG_CONFIG_HOME               Override config directory
+  XDG_DATA_HOME                 Override data directory
 `
 	_, _ = fmt.Fprint(w, help)
 }

--- a/internal/cli/identity_add_test.go
+++ b/internal/cli/identity_add_test.go
@@ -15,7 +15,6 @@ import (
 
 func newIdentityAddCLI(t *testing.T, vaultPaths []string) (*CLI, *MockVaultResolver, *MockGPGClient, *bytes.Buffer, *bytes.Buffer) {
 	t.Helper()
-	t.Setenv("DOTSECENV_FINGERPRINT", "")
 	t.Setenv("DOTSECENV_CONFIG", "")
 
 	mock := NewMockVaultResolver()
@@ -42,7 +41,7 @@ func newIdentityAddCLI(t *testing.T, vaultPaths []string) (*CLI, *MockVaultResol
 			ApprovedAlgorithms: []config.ApprovedAlgorithm{
 				{Algo: "RSA", MinBits: 2048},
 			},
-			Fingerprint: "MYFINGERPRINT", // current user's login
+			Login: newTestSignedLogin(t, "MYFINGERPRINT"), // current user's login
 		},
 		vaultResolver: mock,
 		gpgClient:     gpgMock,

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -160,16 +160,13 @@ func saveConfigWithComments(path string, cfg config.Config) error {
 		fmt.Fprintf(&sb, "    min_bits: %d\n", alg.MinBits)
 	}
 
-	// Login section (only if set) - preferred over deprecated fingerprint
+	// Login section (only if set)
 	if cfg.Login != nil && cfg.Login.Fingerprint != "" {
 		sb.WriteString("login:\n")
 		fmt.Fprintf(&sb, "  fingerprint: %s\n", cfg.Login.Fingerprint)
 		fmt.Fprintf(&sb, "  added_at: %s\n", cfg.Login.AddedAt.Format("2006-01-02T15:04:05Z07:00"))
 		fmt.Fprintf(&sb, "  hash: %s\n", cfg.Login.Hash)
 		fmt.Fprintf(&sb, "  signature: %s\n", cfg.Login.Signature)
-	} else if cfg.Fingerprint != "" {
-		// Deprecated fingerprint field (for backward compatibility)
-		fmt.Fprintf(&sb, "fingerprint: %s\n", cfg.Fingerprint)
 	}
 
 	// Vault paths
@@ -216,7 +213,7 @@ func ValidateVaultPathsAgainstConfig(configPath string, vaultPaths []string, out
 	effectiveConfigPath := ResolveConfigPath(configPath, true, out.Stderr()) // silent for resolution
 
 	// Load config (if it doesn't exist, no validation needed - allow creating vault anywhere)
-	cfg, err := config.Load(effectiveConfigPath)
+	cfg, _, err := config.Load(effectiveConfigPath)
 	if err != nil {
 		// Config doesn't exist or can't be read - allow vault creation
 		return nil
@@ -302,7 +299,7 @@ func InitVaultFile(vaultPath string, out *output.Handler) *Error {
 // InitVaultInteractiveStandalone allows user to select a vault from config to initialize
 // This runs without requiring the vaults to be openable (since they might not exist yet)
 func InitVaultInteractiveStandalone(configPath string, out *output.Handler) *Error {
-	cfg, err := config.Load(configPath)
+	cfg, warnings, err := config.Load(configPath)
 	if err != nil {
 		// Provide helpful suggestion based on execution context
 		var suggestion string
@@ -318,6 +315,12 @@ func InitVaultInteractiveStandalone(configPath string, out *output.Handler) *Err
 			suggestion = fmt.Sprintf("failed to load config: %v\nRun 'dotsecenv init config' first.", err)
 		}
 		return NewError(suggestion, ExitConfigError)
+	}
+
+	if !out.IsSilent() {
+		for _, w := range warnings {
+			_, _ = fmt.Fprintf(out.Stderr(), "warning: %s\n", w)
+		}
 	}
 
 	vaultCfg, err := vault.ParseVaultConfig(cfg.Vault)

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/config"
@@ -93,11 +92,6 @@ func (c *CLI) Login(fingerprint string) *Error {
 		fingerprint = selectedFP
 	}
 
-	envFP := os.Getenv("DOTSECENV_FINGERPRINT")
-	if envFP != "" && c.config.GetFingerprint() != "" && c.config.GetFingerprint() != fingerprint {
-		c.Warnf("DOTSECENV_FINGERPRINT is set; new fingerprint will be cached but not used in this session")
-	}
-
 	publicKeyInfo, pubKeyErr := c.gpgClient.GetPublicKeyInfo(fingerprint)
 	if pubKeyErr != nil {
 		return NewError(fmt.Sprintf("failed to get public key for fingerprint '%s': %v\nMake sure your GPG key is available in gpg-agent", fingerprint, pubKeyErr), ExitGPGError)
@@ -119,9 +113,8 @@ func (c *CLI) Login(fingerprint string) *Error {
 		return NewError(fmt.Sprintf("failed to create signed login: %v", err), ExitGPGError)
 	}
 
-	// Update config with new login (and clear deprecated fingerprint field)
+	// Update config with new login
 	c.config.Login = login
-	c.config.Fingerprint = "" // Clear deprecated field
 
 	if err := config.Save(c.configPath, c.config); err != nil {
 		return NewError(fmt.Sprintf("failed to save config: %v", err), ExitConfigError)

--- a/internal/cli/testhelpers_test.go
+++ b/internal/cli/testhelpers_test.go
@@ -1,0 +1,418 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ProtonMail/gopenpgp/v3/crypto"
+	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/config"
+	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/gpg"
+	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/vault"
+)
+
+// MockVaultResolver is a mock implementation of VaultResolver interface
+type MockVaultResolver struct {
+	mu                sync.Mutex
+	Identities        map[string]vault.Identity
+	IdentitiesByVault map[int]map[string]vault.Identity // index -> fingerprint -> identity
+	Secrets           map[int]map[string]vault.Secret   // index -> key -> secret
+	VaultPaths        []string                          // List of vault paths
+	AddSecretFunc     func(secret vault.Secret, index int) error
+	SavedVaults       []int // Track which vaults (indices) were saved
+	VaultEntries      []vault.VaultEntry
+	Managers          map[int]*vault.Manager // Optional managers for tests that need them
+}
+
+func NewMockVaultResolver() *MockVaultResolver {
+	return &MockVaultResolver{
+		Identities:        make(map[string]vault.Identity),
+		IdentitiesByVault: make(map[int]map[string]vault.Identity),
+		Secrets:           make(map[int]map[string]vault.Secret),
+		SavedVaults:       []int{},
+	}
+}
+
+func (m *MockVaultResolver) GetIdentityByFingerprint(fingerprint string) *vault.Identity {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	id, ok := m.Identities[fingerprint]
+	if !ok {
+		return nil
+	}
+	return &id
+}
+
+func (m *MockVaultResolver) AddSecret(secret vault.Secret, index int) error {
+	if m.AddSecretFunc != nil {
+		return m.AddSecretFunc(secret, index)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.Secrets[index]; !ok {
+		m.Secrets[index] = make(map[string]vault.Secret)
+	}
+	m.Secrets[index][secret.Key] = secret
+	return nil
+}
+
+func (m *MockVaultResolver) AddIdentity(identity vault.Identity, index int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Identities[identity.Fingerprint] = identity
+
+	if index >= 0 {
+		if _, ok := m.IdentitiesByVault[index]; !ok {
+			m.IdentitiesByVault[index] = make(map[string]vault.Identity)
+		}
+		m.IdentitiesByVault[index][identity.Fingerprint] = identity
+	}
+	return nil
+}
+
+func (m *MockVaultResolver) SaveAll() error {
+	return nil
+}
+
+func (m *MockVaultResolver) CloseAll() error {
+	return nil
+}
+
+func (m *MockVaultResolver) GetSecretFromAnyVault(key string, stderr io.Writer) (*vault.SecretValue, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Search in order
+	count := len(m.VaultPaths)
+	if len(m.VaultEntries) > count {
+		count = len(m.VaultEntries)
+	}
+
+	for i := 0; i < count; i++ {
+		if secrets, ok := m.Secrets[i]; ok {
+			if secret, ok := secrets[key]; ok {
+				if len(secret.Values) > 0 {
+					return &secret.Values[len(secret.Values)-1], nil
+				}
+			}
+		}
+	}
+	return nil, fmt.Errorf("secret not found")
+}
+
+func (m *MockVaultResolver) GetAccessibleSecretFromAnyVault(key, fingerprint string) (*vault.SecretValue, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// Search in order
+	count := len(m.VaultPaths)
+	if len(m.VaultEntries) > count {
+		count = len(m.VaultEntries)
+	}
+
+	for i := 0; i < count; i++ {
+		if secrets, ok := m.Secrets[i]; ok {
+			if secret, ok := secrets[key]; ok {
+				if len(secret.Values) == 0 {
+					continue
+				}
+
+				// Check from most recent to oldest for accessible value
+				for j := len(secret.Values) - 1; j >= 0; j-- {
+					for _, fp := range secret.Values[j].AvailableTo {
+						if fp == fingerprint {
+							return &secret.Values[j], nil
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil, fmt.Errorf("secret '%s' not found or not accessible", key)
+}
+
+func (m *MockVaultResolver) GetSecretByKeyFromVault(index int, key string) *vault.Secret {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if secrets, ok := m.Secrets[index]; ok {
+		if secret, ok := secrets[key]; ok {
+			return &secret
+		}
+	}
+	return nil
+}
+
+func (m *MockVaultResolver) FindSecretVaultIndex(key string) int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	count := len(m.VaultPaths)
+	if len(m.VaultEntries) > count {
+		count = len(m.VaultEntries)
+	}
+
+	for i := 0; i < count; i++ {
+		if secrets, ok := m.Secrets[i]; ok {
+			if _, ok := secrets[key]; ok {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func (m *MockVaultResolver) GetVaultManager(index int) *vault.Manager {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.Managers != nil {
+		return m.Managers[index]
+	}
+	return nil // Mock returns nil manager usually, but tests might need to mock this if they call methods on manager
+}
+
+func (m *MockVaultResolver) GetConfig() vault.VaultConfig {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return vault.VaultConfig{Entries: m.VaultEntries}
+}
+
+func (m *MockVaultResolver) GetVaultPaths() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.VaultPaths
+}
+
+func (m *MockVaultResolver) GetAvailableVaultPathsWithIndices() []vault.VaultPathWithIndex {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// In mock, all configured vaults are considered available
+	var result []vault.VaultPathWithIndex
+	for i, path := range m.VaultPaths {
+		result = append(result, vault.VaultPathWithIndex{Path: path, Index: i})
+	}
+	return result
+}
+
+func (m *MockVaultResolver) IsPathInConfig(path string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, p := range m.VaultPaths {
+		if vault.ExpandPath(p) == vault.ExpandPath(path) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MockVaultResolver) IdentityExistsInVault(fingerprint string, index int) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if mapV, ok := m.IdentitiesByVault[index]; ok {
+		_, exists := mapV[fingerprint]
+		return exists
+	}
+	return false
+}
+
+func (m *MockVaultResolver) SaveVault(index int) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.SavedVaults = append(m.SavedVaults, index)
+	return nil
+}
+
+func (m *MockVaultResolver) GetLoadError(index int) error {
+	return nil
+}
+
+func (m *MockVaultResolver) GetSecret(index int, key string) (*vault.SecretValue, error) {
+	s := m.GetSecretByKeyFromVault(index, key)
+	if s == nil || len(s.Values) == 0 {
+		return nil, fmt.Errorf("not found")
+	}
+	return &s.Values[len(s.Values)-1], nil
+}
+
+func (m *MockVaultResolver) OpenVaultsFromPaths(paths []string, stderr io.Writer) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.VaultPaths = paths
+	// Rebuild entries
+	m.VaultEntries = nil
+	for _, p := range paths {
+		m.VaultEntries = append(m.VaultEntries, vault.VaultEntry{Path: p})
+	}
+	return nil
+}
+
+func (m *MockVaultResolver) OpenVaults(stderr io.Writer) error {
+	return nil
+}
+
+func (m *MockVaultResolver) VaultCount() int {
+	count := len(m.VaultPaths)
+	if len(m.VaultEntries) > count {
+		count = len(m.VaultEntries)
+	}
+	// Also count from Secrets map
+	for idx := range m.Secrets {
+		if idx+1 > count {
+			count = idx + 1
+		}
+	}
+	return count
+}
+
+func (m *MockVaultResolver) ListAllSecretKeys() []vault.SecretKeyInfo {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	var result []vault.SecretKeyInfo
+	seen := make(map[string]bool)
+
+	count := m.VaultCount()
+	for i := 0; i < count; i++ {
+		secrets, ok := m.Secrets[i]
+		if !ok {
+			continue
+		}
+
+		vaultPath := ""
+		if i < len(m.VaultEntries) {
+			vaultPath = m.VaultEntries[i].Path
+		} else if i < len(m.VaultPaths) {
+			vaultPath = m.VaultPaths[i]
+		}
+
+		for key, secret := range secrets {
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+
+			result = append(result, vault.SecretKeyInfo{
+				Key:      key,
+				Vault:    vaultPath,
+				VaultIdx: i + 1,
+				Deleted:  secret.IsDeleted(),
+			})
+		}
+	}
+
+	return result
+}
+
+func (m *MockVaultResolver) ListSecretKeysFromVault(index int) []vault.SecretKeyInfo {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	secrets, ok := m.Secrets[index]
+	if !ok {
+		return nil
+	}
+
+	vaultPath := ""
+	if index < len(m.VaultEntries) {
+		vaultPath = m.VaultEntries[index].Path
+	} else if index < len(m.VaultPaths) {
+		vaultPath = m.VaultPaths[index]
+	}
+
+	var result []vault.SecretKeyInfo
+	for key, secret := range secrets {
+		result = append(result, vault.SecretKeyInfo{
+			Key:      key,
+			Vault:    vaultPath,
+			VaultIdx: index + 1,
+			Deleted:  secret.IsDeleted(),
+		})
+	}
+
+	return result
+}
+
+// MockGPGClient is a mock implementation of GPGClient interface
+type MockGPGClient struct {
+	PublicKeyInfo map[string]gpg.KeyInfo
+}
+
+func NewMockGPGClient() *MockGPGClient {
+	return &MockGPGClient{
+		PublicKeyInfo: make(map[string]gpg.KeyInfo),
+	}
+}
+
+func (m *MockGPGClient) GetPublicKeyInfo(fingerprint string) (*gpg.KeyInfo, error) {
+	if info, ok := m.PublicKeyInfo[fingerprint]; ok {
+		return &info, nil
+	}
+	return nil, fmt.Errorf("public key info not found for %s", fingerprint)
+}
+
+func (m *MockGPGClient) EncryptToRecipients(plaintext []byte, recipients []string, signingKey *crypto.Key) (string, error) {
+	return fmt.Sprintf("encrypted_to_%s_%s", strings.Join(recipients, "_"), string(plaintext)), nil
+}
+
+func (m *MockGPGClient) SignDataWithAgent(fingerprint string, data []byte) (string, error) {
+	return fmt.Sprintf("signature_by_%s", fingerprint), nil
+}
+
+func (m *MockGPGClient) DecryptWithAgent(ciphertext []byte, fingerprint string) ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (m *MockGPGClient) ExtractAlgorithmAndCurve(fullAlgorithm string) (algorithm string, curve string) {
+	return fullAlgorithm, ""
+}
+
+func (m *MockGPGClient) GetKeyCreationTime(fingerprint string) time.Time {
+	return time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
+}
+
+func (m *MockGPGClient) SignIdentity(identity *vault.Identity, signerFingerprint string) (hash string, signature string, err error) {
+	return "mock_hash", "mock_signature", nil
+}
+
+func (m *MockGPGClient) SignSecret(secret *vault.Secret, signerFingerprint string, algorithmBits int) (hash string, signature string, err error) {
+	return "mock_hash", "mock_signature", nil
+}
+
+func (m *MockGPGClient) SignSecretValue(value *vault.SecretValue, secretKey string, signerFingerprint string, algorithmBits int) (hash string, signature string, err error) {
+	return "mock_hash", "mock_signature", nil
+}
+
+func (m *MockGPGClient) DecryptSecret(encryptedBase64 string, fingerprint string) ([]byte, error) {
+	return []byte("decrypted_secret"), nil
+}
+
+func (m *MockGPGClient) DecryptSecretValue(value *vault.SecretValue, fingerprint string) ([]byte, error) {
+	return []byte("decrypted_secret_value"), nil
+}
+
+func (m *MockGPGClient) IsAgentAvailable() bool {
+	return true
+}
+
+func (m *MockGPGClient) ListSecretKeys() ([]gpg.SecretKeyInfo, error) {
+	return []gpg.SecretKeyInfo{
+		{Fingerprint: "TESTFINGERPRINT", UID: "Test User <test@example.com>"},
+	}, nil
+}
+
+// newTestSignedLogin builds a *config.Login by running CreateSignedLogin against
+// a fresh MockGPGClient. The mock's SignDataWithAgent returns a deterministic
+// "signature_by_<fp>" string, so the resulting Login is suitable for tests that
+// need a populated Login section without requiring a real GPG keyring.
+func newTestSignedLogin(t *testing.T, fingerprint string) *config.Login {
+	t.Helper()
+	login, err := CreateSignedLogin(NewMockGPGClient(), fingerprint)
+	if err != nil {
+		t.Fatalf("newTestSignedLogin(%q): %v", fingerprint, err)
+	}
+	return login
+}

--- a/pkg/dotsecenv/config/config.go
+++ b/pkg/dotsecenv/config/config.go
@@ -46,11 +46,10 @@ type Login struct {
 // Config represents the dotsecenv configuration
 type Config struct {
 	ApprovedAlgorithms []ApprovedAlgorithm `yaml:"approved_algorithms"`
-	Login              *Login              `yaml:"login,omitempty"`       // Authenticated login with cryptographic proof
-	Fingerprint        string              `yaml:"fingerprint,omitempty"` // DEPRECATED: use login section instead
-	Vault              []string            `yaml:"vault"`                 // List of vault paths
-	Behavior           BehaviorConfig      `yaml:"behavior,omitempty"`    // Granular behavior settings
-	GPG                GPGConfig           `yaml:"gpg,omitempty"`         // GPG configuration
+	Login              *Login              `yaml:"login,omitempty"`    // Authenticated login with cryptographic proof
+	Vault              []string            `yaml:"vault"`              // List of vault paths
+	Behavior           BehaviorConfig      `yaml:"behavior,omitempty"` // Granular behavior settings
+	GPG                GPGConfig           `yaml:"gpg,omitempty"`      // GPG configuration
 }
 
 // UnmarshalYAML provides custom YAML unmarshaling with better error messages for vault configuration
@@ -102,21 +101,6 @@ func (c *Config) ShouldRestrictToConfiguredVaults() bool {
 	return false
 }
 
-// GetFingerprint returns the active fingerprint, preferring login.fingerprint over the deprecated field.
-// This method provides backward compatibility during the migration from the old fingerprint field.
-func (c *Config) GetFingerprint() string {
-	if c.Login != nil && c.Login.Fingerprint != "" {
-		return c.Login.Fingerprint
-	}
-	return c.Fingerprint // fallback to deprecated field
-}
-
-// HasDeprecatedFingerprint returns true if the config uses the deprecated fingerprint field
-// without a login section. Used to emit deprecation warnings.
-func (c *Config) HasDeprecatedFingerprint() bool {
-	return c.Fingerprint != "" && (c.Login == nil || c.Login.Fingerprint == "")
-}
-
 // DefaultConfig returns a new Config with FIPS 186-5 compliant algorithm defaults.
 // Algorithm minimums are set per the Digital Signature Standard:
 //   - RSA: 2048 bits minimum (FIPS 186-5)
@@ -146,30 +130,55 @@ func DefaultConfig() Config {
 				MinBits: 2048,
 			},
 		},
-		Fingerprint: "",
-		Vault:       []string{},                 // No default vaults from library; caller must populate
-		GPG:         GPGConfig{Program: "PATH"}, // Default to PATH inference
+		Vault: []string{},                 // No default vaults from library; caller must populate
+		GPG:   GPGConfig{Program: "PATH"}, // Default to PATH inference
 	}
 }
 
-// Load reads the config from the specified path
-// If the file doesn't exist or is empty, it returns an error
-func Load(path string) (Config, error) {
+// Load reads the config from the specified path. Returns the parsed Config,
+// any human-readable warnings about deprecated/removed fields detected in the
+// file (callers should print these to stderr unless silent), and an error.
+// If the file doesn't exist or is empty, it returns an error.
+func Load(path string) (Config, []string, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return Config{}, fmt.Errorf("failed to read config: %w", err)
+		return Config{}, nil, fmt.Errorf("failed to read config: %w", err)
 	}
 
 	if len(data) == 0 {
-		return Config{}, fmt.Errorf("config file is empty")
+		return Config{}, nil, fmt.Errorf("config file is empty")
 	}
 
 	var cfg Config
 	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return Config{}, fmt.Errorf("failed to parse config: %w", err)
+		return Config{}, nil, fmt.Errorf("failed to parse config: %w", err)
 	}
 
-	return cfg, nil
+	return cfg, detectLegacyFields(data, path), nil
+}
+
+// detectLegacyFields scans the raw YAML for top-level keys that have been
+// removed or renamed in this version of dotsecenv and returns human-readable
+// warnings for each one detected. It never errors — unmarshal failures are
+// surfaced by Load's primary parse.
+//
+// The scan operates on the raw bytes (not the parsed Config) so that warnings
+// fire even after the corresponding struct field has been deleted: yaml.v3
+// silently drops unknown keys, which would otherwise hide the deprecation.
+func detectLegacyFields(data []byte, path string) []string {
+	var raw map[string]yaml.Node
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+
+	var warnings []string
+	if node, ok := raw["fingerprint"]; ok && node.Kind == yaml.ScalarNode && node.Value != "" {
+		warnings = append(warnings, fmt.Sprintf(
+			"deprecated 'fingerprint:' field detected in %s and ignored. Run 'dotsecenv login %s' to migrate to a signed login.",
+			path, node.Value,
+		))
+	}
+	return warnings
 }
 
 // Save writes the config to the specified path with proper formatting
@@ -246,14 +255,6 @@ func isCurveAllowed(curve string, allowedCurves []string) bool {
 		}
 	}
 	return false
-}
-
-// GetFingerprintFromEnv gets fingerprint from environment variable or config
-func GetFingerprintFromEnv(envFingerprint, cfgFingerprint string) string {
-	if envFingerprint != "" {
-		return envFingerprint
-	}
-	return cfgFingerprint
 }
 
 // GetAllowedAlgorithmsString returns a human-readable string of approved algorithms

--- a/pkg/dotsecenv/config/config_test.go
+++ b/pkg/dotsecenv/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"gopkg.in/yaml.v3"
 )
@@ -90,23 +91,107 @@ func TestConfigLoadSave(t *testing.T) {
 
 	cfgPath := filepath.Join(tempDir, "config.yaml")
 	cfg := DefaultConfig()
-	cfg.Fingerprint = "test-fingerprint"
+	// Hand-construct a Login literal: this test exercises YAML round-trip,
+	// not signature crypto, so importing gpg here would invert package layering.
+	// Truncate AddedAt to seconds — YAML round-trip drops monotonic/nanos.
+	cfg.Login = &Login{
+		Fingerprint: "test-fingerprint",
+		AddedAt:     time.Now().UTC().Truncate(time.Second),
+		Hash:        "abc",
+		Signature:   "sig",
+	}
 	cfg.Vault = []string{"/path/to/vault"}
 
 	if err := Save(cfgPath, cfg); err != nil {
 		t.Fatalf("Save failed: %v", err)
 	}
 
-	loadedCfg, err := Load(cfgPath)
+	loadedCfg, _, err := Load(cfgPath)
 	if err != nil {
 		t.Fatalf("Load failed: %v", err)
 	}
 
-	if loadedCfg.Fingerprint != cfg.Fingerprint {
-		t.Errorf("expected fingerprint %s, got %s", cfg.Fingerprint, loadedCfg.Fingerprint)
+	if loadedCfg.Login == nil {
+		t.Fatal("expected Login to be present after round-trip")
+	}
+	if loadedCfg.Login.Fingerprint != cfg.Login.Fingerprint {
+		t.Errorf("expected fingerprint %s, got %s", cfg.Login.Fingerprint, loadedCfg.Login.Fingerprint)
+	}
+	if !loadedCfg.Login.AddedAt.Equal(cfg.Login.AddedAt) {
+		t.Errorf("expected AddedAt %s, got %s", cfg.Login.AddedAt, loadedCfg.Login.AddedAt)
+	}
+	if loadedCfg.Login.Hash != cfg.Login.Hash {
+		t.Errorf("expected hash %s, got %s", cfg.Login.Hash, loadedCfg.Login.Hash)
+	}
+	if loadedCfg.Login.Signature != cfg.Login.Signature {
+		t.Errorf("expected signature %s, got %s", cfg.Login.Signature, loadedCfg.Login.Signature)
 	}
 	if len(loadedCfg.Vault) != len(cfg.Vault) || loadedCfg.Vault[0] != cfg.Vault[0] {
 		t.Errorf("vault paths mismatch")
+	}
+}
+
+func TestLoad_LegacyFingerprintWarning(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "config_legacy_test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	// Config containing the deprecated `fingerprint:` key. The struct field is
+	// gone, so unmarshal silently drops it — Load's second-pass detection is
+	// what surfaces the warning.
+	cfgPath := filepath.Join(tempDir, "legacy.yaml")
+	body := []byte(`
+approved_algorithms:
+  - algo: RSA
+    min_bits: 2048
+fingerprint: ABC123DEF456
+vault:
+  - /tmp/v
+`)
+	if err := os.WriteFile(cfgPath, body, 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	_, warnings, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if len(warnings) != 1 {
+		t.Fatalf("expected exactly 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0], "deprecated 'fingerprint:' field") {
+		t.Errorf("warning missing legacy-key tag: %s", warnings[0])
+	}
+	if !strings.Contains(warnings[0], "ABC123DEF456") {
+		t.Errorf("warning should include the fingerprint value to migrate: %s", warnings[0])
+	}
+	if !strings.Contains(warnings[0], "dotsecenv login") {
+		t.Errorf("warning should suggest the migration command: %s", warnings[0])
+	}
+}
+
+func TestLoad_NoWarningsForCleanConfig(t *testing.T) {
+	tempDir, err := os.MkdirTemp("", "config_clean_test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() { _ = os.RemoveAll(tempDir) }()
+
+	cfgPath := filepath.Join(tempDir, "clean.yaml")
+	cfg := DefaultConfig()
+	cfg.Vault = []string{"/tmp/v"}
+	if err := Save(cfgPath, cfg); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	_, warnings, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("expected no warnings for clean config, got: %v", warnings)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove `Config.Fingerprint` (deprecated YAML field) and `DOTSECENV_FINGERPRINT` (env-var override). Identity is now bound exclusively to the signed `login:` config section, populated by `dotsecenv login <FP>`. Both removed paths bypassed the cryptographic proof the `Login` struct exists to enforce.
- `config.Load` now scans the raw YAML for a top-level `fingerprint:` key and returns a stderr warning when detected — the YAML decoder silently drops the unknown field, so users see "deprecated 'fingerprint:' field detected … Run `dotsecenv login <FP>` to migrate" but the load still succeeds.
- Test suite refactored: `MockGPGClient`/`MockVaultResolver` extracted into `testhelpers_test.go`; ~15 unit tests now use `Login: newTestSignedLogin(t, fp)` (helper calls `CreateSignedLogin` against the existing mock). E2E tests gain a `setupTestUser` helper that generates a key, writes a per-user config, and runs `dotsecenv login` — tests flip identity by switching `-c` instead of toggling the env var. Adds a regression test asserting `DOTSECENV_FINGERPRINT` in env is silently ignored.
- Opportunistic: consolidate the duplicated config-load prelude between `NewCLI` and `NewCLIConfigOnly` into a private `loadConfigAndPrepareGPG` helper. Delete the now-unreachable `else if cfg.Fingerprint != ""` branch in `saveConfigWithComments`. Drop env-var doc line from `help.go` and the README env-var table.

## Test plan

- [ ] `make test` — all unit tests pass
- [ ] `make test-race` — race detector clean (the legacy-warning second YAML pass is read-only)
- [ ] `make e2e` — `TestSecretRevoke_Self`, `TestIssue_SelfRevokeAddsGPGKey`, `TestIssue_RevokeWithoutAccess`, plus the new `TestDOTSECENVFingerprint_Ignored` regression test
- [ ] `make lint` — golangci-lint clean (no newly-unused symbols)
- [ ] Manual: write a config containing `fingerprint: ABCDEF…`, run `dotsecenv -c <path> validate`, confirm stderr warning appears and the command still succeeds
- [ ] Manual: run `DOTSECENV_FINGERPRINT=garbage dotsecenv validate` — must behave identically to running without the env var (no warning, no override)

🤖 Generated with [Claude Code](https://claude.com/claude-code)