### PR TITLE
refactor: drop SUID mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,6 @@ dotsecenv validate --fix  # Attempt to fix issues
 - **Append-Only Design**: Cryptographic history is preserved for audit trails
 - **GPG Agent Integration**: Leverages gpg-agent for secure key management
 - **XDG Compliance**: Respects XDG Base Directory Specification for configuration files
-- **SUID Mode Support**: Restricted operations when running with elevated privileges
 - **JSON Output**: Machine-readable output format for scripting
 
 ## Claude Code
@@ -462,15 +461,12 @@ The configuration file location is determined in the following order of preceden
 1. **`-c` flag** (highest priority): Explicitly specify a config file path
 2. **`DOTSECENV_CONFIG` environment variable**: Override the default location
 3. **XDG default**: `$XDG_CONFIG_HOME/dotsecenv/config` (typically `~/.config/dotsecenv/config`)
-4. **SUID mode**: `/etc/dotsecenv/config` (when running with elevated privileges)
 
 When both `-c` and `DOTSECENV_CONFIG` are specified, the `-c` flag takes precedence and a warning is printed to stderr (unless `-s` silent mode is enabled):
 
 ```
 warning: DOTSECENV_CONFIG environment variable ignored because -c flag was specified
 ```
-
-In SUID mode, the `DOTSECENV_CONFIG` environment variable is ignored for security reasons.
 
 ### Config File Format
 
@@ -615,20 +611,8 @@ Each entry includes a hash and cryptographic signature to prevent against tamper
 - GPG agent integration for secure key management
 - Full secret encryption/decryption lifecycle
 - Validation logic with optional auto-fix
-- SUID mode restrictions for elevated privilege protection
 - [SLSA Build Level 3](https://slsa.dev/spec/v1.2/build-requirements): Release binaries include verifiable provenance attestations generated via GitHub's [attest-build-provenance](https://github.com/actions/attest-build-provenance) action on hardened GitHub-hosted runners
 - **Hermetic E2E Testing**: Every pull request runs e2e tests in a network-isolated Linux namespace with eBPF verification via [harden-runner](https://github.com/step-security/harden-runner), proving zero external network connections. See [Security Model](https://dotsecenv.com/concepts/security-model/#hermetic-testing).
-
-### SUID Mode Restrictions
-
-When running with SUID privileges, the following restrictions apply:
-
-- `-c` and `-v` flags are blocked
-- `DOTSECENV_CONFIG` environment variable is ignored
-- Config defaults to `/etc/dotsecenv/config`
-- Write operations are blocked: `login`, `init config`, `init vault`, `secret store`, `secret share`, `secret revoke`
-
-This prevents privilege escalation attacks when the binary is installed with elevated permissions.
 
 ## Exit Codes
 
@@ -649,7 +633,7 @@ This prevents privilege escalation attacks when the binary is installed with ele
 
 | Variable           | Description                                             |
 | ------------------ | ------------------------------------------------------- |
-| `DOTSECENV_CONFIG` | Override config file path (ignored in SUID mode)        |
+| `DOTSECENV_CONFIG` | Override config file path                               |
 | `XDG_CONFIG_HOME`  | Override config directory (defaults to: `~/.config`)    |
 | `XDG_DATA_HOME`    | Override data directory (defaults to: `~/.local/share`) |
 
@@ -787,7 +771,6 @@ This creates both `v0.1.2` and `v0` tags pointing to the same commit, signs them
 - Secrets stored in plaintext on disk
 - Access to secrets by unauthorized users without GPG keys
 - Tampering with vault entries (signature verification)
-- Privilege escalation via SUID binaries
 - Stealth network exfiltration of secrets during CI/CD (hermetic testing)
 
 ### What dotsecenv DOES NOT Protect Against

--- a/cmd/dotsecenv/cmd_identity_add.go
+++ b/cmd/dotsecenv/cmd_identity_add.go
@@ -27,8 +27,6 @@ When neither --all nor -v is specified, the vault is auto-selected if only
 one is configured, or you are prompted to choose interactively.`,
 	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		checkSUIDMode(cmd)
-
 		fingerprint := args[0]
 		cli, err := createCLI()
 		if err != nil {

--- a/cmd/dotsecenv/globals.go
+++ b/cmd/dotsecenv/globals.go
@@ -11,7 +11,6 @@ import (
 	"github.com/dotsecenv/dotsecenv/internal/xdg"
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/config"
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/vault"
-	"github.com/spf13/cobra"
 )
 
 // GlobalOptions holds the global configuration flags
@@ -19,56 +18,6 @@ type GlobalOptions struct {
 	ConfigPath string
 	VaultPaths []string
 	Silent     bool
-}
-
-// isSUID returns true if the binary is running with SUID privileges
-func isSUID() bool {
-	return os.Getuid() != os.Geteuid()
-}
-
-// suidDisallowedCommands lists commands that are completely blocked in SUID mode
-var suidDisallowedCommands = map[string]bool{
-	"login":         true,
-	"init config":   true,
-	"init vault":    true,
-	"secret store":  true,
-	"secret share":  true,
-	"secret revoke": true,
-}
-
-// getCommandPath returns the full command path (e.g., "secret store", "vault describe")
-func getCommandPath(cmd *cobra.Command) string {
-	var parts []string
-	for c := cmd; c != nil && c.Name() != "dotsecenv"; c = c.Parent() {
-		parts = append([]string{c.Name()}, parts...)
-	}
-	return strings.Join(parts, " ")
-}
-
-// checkSUIDMode enforces SUID restrictions at command execution time.
-// In SUID mode: -c and -v flags are always blocked, and certain commands are disallowed.
-func checkSUIDMode(cmd *cobra.Command) {
-	if !isSUID() {
-		return
-	}
-
-	cmdPath := getCommandPath(cmd)
-
-	// Check for disallowed commands
-	if suidDisallowedCommands[cmdPath] {
-		fmt.Fprintf(os.Stderr, "error: '%s' command is not allowed in SUID mode\n", cmdPath)
-		os.Exit(int(clilib.ExitGeneralError))
-	}
-
-	// Check for disallowed flags (applies to all commands in SUID mode)
-	if globalOpts.ConfigPath != "" {
-		fmt.Fprintf(os.Stderr, "error: -c flag is not allowed in SUID mode\n")
-		os.Exit(int(clilib.ExitGeneralError))
-	}
-	if len(globalOpts.VaultPaths) > 0 {
-		fmt.Fprintf(os.Stderr, "error: -v flag is not allowed in SUID mode\n")
-		os.Exit(int(clilib.ExitGeneralError))
-	}
 }
 
 // globalOpts is the shared global options instance

--- a/cmd/dotsecenv/root.go
+++ b/cmd/dotsecenv/root.go
@@ -15,9 +15,6 @@ var rootCmd = &cobra.Command{
 	Short:         "Safe environment secrets",
 	SilenceUsage:  true,
 	SilenceErrors: true,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		checkSUIDMode(cmd)
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// If no subcommand, show help
 		_ = cmd.Help()

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -18,19 +18,15 @@ import (
 
 // ResolveConfigPath returns the effective config path considering:
 // 1. Explicit configPath argument (highest priority, e.g. -c flag)
-// 2. /etc/dotsecenv/config (if SUID mode)
-// 3. DOTSECENV_CONFIG env var (if not SUID mode)
-// 4. XDG default path
+// 2. DOTSECENV_CONFIG env var
+// 3. XDG default path
 // If configPath is specified and DOTSECENV_CONFIG is set, prints a warning to stderr (unless silent).
 func ResolveConfigPath(configPath string, silent bool, stderr io.Writer) string {
 	if configPath != "" {
-		if !silent && !isSUID() && os.Getenv("DOTSECENV_CONFIG") != "" {
+		if !silent && os.Getenv("DOTSECENV_CONFIG") != "" {
 			_, _ = fmt.Fprintf(stderr, "warning: DOTSECENV_CONFIG environment variable ignored because -c flag was specified\n")
 		}
 		return configPath
-	}
-	if isSUID() {
-		return "/etc/dotsecenv/config"
 	}
 	if envConfig := os.Getenv("DOTSECENV_CONFIG"); envConfig != "" {
 		return envConfig
@@ -64,10 +60,6 @@ func defaultHasTTY() bool {
 }
 
 // NewCLI creates a new CLI instance
-func isSUID() bool {
-	return os.Getuid() != os.Geteuid()
-}
-
 func NewCLI(vaultPaths []string, configPath string, silent bool, stdin io.Reader, stdout, stderr io.Writer) (*CLI, error) {
 	return newCLI(vaultPaths, configPath, silent, stdin, stdout, stderr, nil)
 }
@@ -99,12 +91,9 @@ func loadConfigAndPrepareGPG(configPath string, silent bool, stdin io.Reader, st
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			var suggestion string
-			switch {
-			case isSUID():
-				suggestion = fmt.Sprintf("config file not found: %s\nContact your system administrator to create this file.", configPath)
-			case os.Getuid() == 0:
+			if os.Getuid() == 0 {
 				suggestion = fmt.Sprintf("config file not found: %s\nRun 'sudo dotsecenv init config' to create one", configPath)
-			default:
+			} else {
 				suggestion = fmt.Sprintf("config file not found: %s\nRun 'dotsecenv init config' to create one", configPath)
 			}
 			return nil, NewError(suggestion, ExitConfigError)

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -209,11 +209,10 @@ func TestSecretPut_FromIndexOutOfRange(t *testing.T) {
 
 	// Test -v 4 (out of range)
 	err := cli.SecretPut("MY_SECRET", "", 4, "")
-	if err == nil {
+	switch {
+	case err == nil:
 		t.Fatalf("Expected SecretPut with -v 4 to fail, but it succeeded")
-	}
-
-	if !strings.Contains(err.Message, "-v index 4 exceeds number of configured vaults") {
+	case !strings.Contains(err.Message, "-v index 4 exceeds number of configured vaults"):
 		t.Errorf("Expected error message to contain '-v index 4 exceeds number of configured vaults', got: %s", err.Message)
 	}
 }
@@ -478,11 +477,10 @@ func TestSecretForget_AlreadyDeleted(t *testing.T) {
 
 	// Try to forget the already-deleted secret
 	forgetErr := cli.SecretForget("MY_SECRET", vaultPath, 0, false)
-	if forgetErr == nil {
+	switch {
+	case forgetErr == nil:
 		t.Fatal("SecretForget should fail for already-deleted secret")
-	}
-
-	if !strings.Contains(forgetErr.Message, "already deleted") {
+	case !strings.Contains(forgetErr.Message, "already deleted"):
 		t.Errorf("Expected 'already deleted' error, got: %s", forgetErr.Message)
 	}
 }
@@ -531,11 +529,10 @@ func TestSecretForget_NotFound(t *testing.T) {
 
 	// Try to forget a non-existent secret
 	forgetErr := cli.SecretForget("NONEXISTENT", vaultPath, 0, false)
-	if forgetErr == nil {
+	switch {
+	case forgetErr == nil:
 		t.Fatal("SecretForget should fail for non-existent secret")
-	}
-
-	if !strings.Contains(forgetErr.Message, "not found") {
+	case !strings.Contains(forgetErr.Message, "not found"):
 		t.Errorf("Expected 'not found' error, got: %s", forgetErr.Message)
 	}
 }
@@ -609,11 +606,10 @@ func TestSecretPut_BlockedByDeleted(t *testing.T) {
 
 	// Try to put to a deleted secret
 	putErr := cli.SecretPut("DELETED_SECRET", vaultPath, 0, "")
-	if putErr == nil {
+	switch {
+	case putErr == nil:
 		t.Fatal("SecretPut should fail for deleted secret")
-	}
-
-	if !strings.Contains(putErr.Message, "has been deleted") {
+	case !strings.Contains(putErr.Message, "has been deleted"):
 		t.Errorf("Expected 'has been deleted' error, got: %s", putErr.Message)
 	}
 
@@ -678,11 +674,10 @@ func TestSecretForget_NoAccess(t *testing.T) {
 
 	// Try to forget a secret we don't have access to
 	forgetErr := cli.SecretForget("OTHER_SECRET", vaultPath, 0, false)
-	if forgetErr == nil {
+	switch {
+	case forgetErr == nil:
 		t.Fatal("SecretForget should fail without access")
-	}
-
-	if !strings.Contains(forgetErr.Message, "access denied") {
+	case !strings.Contains(forgetErr.Message, "access denied"):
 		t.Errorf("Expected 'access denied' error, got: %s", forgetErr.Message)
 	}
 }
@@ -1480,13 +1475,12 @@ func TestSecretGet_FallbackNotFound(t *testing.T) {
 	}
 
 	err := cli.SecretGet("NONEXISTENT", false, false, false, "", 0)
-	if err == nil {
+	switch {
+	case err == nil:
 		t.Fatal("Expected error for non-existent secret")
-	}
-	if err.ExitCode != ExitVaultError {
+	case err.ExitCode != ExitVaultError:
 		t.Errorf("Expected ExitVaultError, got exit code: %d", err.ExitCode)
-	}
-	if !strings.Contains(err.Message, "not found") {
+	case !strings.Contains(err.Message, "not found"):
 		t.Errorf("Expected 'not found' in error message, got: %s", err.Message)
 	}
 }

--- a/internal/cli/identity_add_test.go
+++ b/internal/cli/identity_add_test.go
@@ -171,11 +171,11 @@ func TestIdentityAdd_MultipleVaultsNoTTY(t *testing.T) {
 
 	// Without a TTY, resolveWritableVaultIndex should error asking for -v
 	err := cli.IdentityAdd("AABBCCDD", false, "", 0)
-	if err == nil {
+	switch {
+	case err == nil:
 		t.Fatal("expected error when multiple vaults and no TTY")
-	}
-	if !strings.Contains(err.Message, "specify target vault using -v") &&
-		!strings.Contains(err.Message, "no terminal available") {
+	case !strings.Contains(err.Message, "specify target vault using -v") &&
+		!strings.Contains(err.Message, "no terminal available"):
 		t.Errorf("unexpected error message: %s", err.Message)
 	}
 }
@@ -213,10 +213,10 @@ func TestIdentityAdd_IndexOutOfRange(t *testing.T) {
 	cli, _, _, _, _ := newIdentityAddCLI(t, paths)
 
 	err := cli.IdentityAdd("AABBCCDD", false, "", 5) // only 1 vault
-	if err == nil {
+	switch {
+	case err == nil:
 		t.Fatal("expected error for out-of-range index")
-	}
-	if !strings.Contains(err.Message, "exceeds number of configured vaults") {
+	case !strings.Contains(err.Message, "exceeds number of configured vaults"):
 		t.Errorf("unexpected error message: %s", err.Message)
 	}
 }
@@ -226,11 +226,11 @@ func TestIdentityAdd_UnknownVaultPath(t *testing.T) {
 	cli, _, _, _, _ := newIdentityAddCLI(t, paths)
 
 	err := cli.IdentityAdd("AABBCCDD", false, "/nonexistent.jsonl", 0)
-	if err == nil {
+	switch {
+	case err == nil:
 		t.Fatal("expected error for unknown vault path")
-	}
-	// resolveWritableVaultIndex checks os.Stat first
-	if !strings.Contains(err.Message, "does not exist") {
+	case !strings.Contains(err.Message, "does not exist"):
+		// resolveWritableVaultIndex checks os.Stat first
 		t.Errorf("unexpected error message: %s", err.Message)
 	}
 }
@@ -253,10 +253,10 @@ func TestIdentityAdd_AlgorithmNotAllowed(t *testing.T) {
 	}
 
 	err := cli.IdentityAdd("AABBCCDD", false, "", 0)
-	if err == nil {
+	switch {
+	case err == nil:
 		t.Fatal("expected algorithm not allowed error")
-	}
-	if err.ExitCode != ExitAlgorithmNotAllowed {
+	case err.ExitCode != ExitAlgorithmNotAllowed:
 		t.Errorf("expected ExitAlgorithmNotAllowed, got %d", err.ExitCode)
 	}
 }

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -121,9 +121,7 @@ func InitConfig(configPath string, initialVaults []string, gpgProgram string, no
 	if len(initialVaults) > 0 {
 		vaultPaths = initialVaults
 	} else {
-		isSUID := os.Getuid() != os.Geteuid()
-		defaultVaults := xdgPaths.GetDefaultVaultPaths(isSUID)
-		vaultPaths = append(vaultPaths, defaultVaults...)
+		vaultPaths = append(vaultPaths, xdgPaths.GetDefaultVaultPaths()...)
 	}
 	cfg.Vault = vaultPaths
 
@@ -303,11 +301,7 @@ func InitVaultInteractiveStandalone(configPath string, out *output.Handler) *Err
 	if err != nil {
 		// Provide helpful suggestion based on execution context
 		var suggestion string
-		isSUID := os.Getuid() != os.Geteuid()
-		if isSUID {
-			// SUID mode: config at /etc/dotsecenv/config, init commands are blocked
-			suggestion = fmt.Sprintf("failed to load config: %v\nContact your system administrator to create this file.", err)
-		} else if os.Getuid() == 0 {
+		if os.Getuid() == 0 {
 			// Running as actual root (e.g., via sudo)
 			suggestion = fmt.Sprintf("failed to load config: %v\nRun 'sudo dotsecenv init config' first.", err)
 		} else {

--- a/internal/xdg/xdg.go
+++ b/internal/xdg/xdg.go
@@ -70,24 +70,13 @@ func (p Paths) EnsureDirs() error {
 	return nil
 }
 
-// GetDefaultVaultPaths generates default vault paths appropriate for the execution context
-// When isSUID is false (normal execution): returns [cwd, home, system] vaults
-// When isSUID is true (SUID execution): returns [system] vaults (home excluded for security)
-//
-// The home path uses XDG_DATA_HOME if set, otherwise defaults to ~/.local/share/dotsecenv/vault
-func (p Paths) GetDefaultVaultPaths(isSUID bool) []string {
-	var paths []string
-
-	// Include home vault unless running with SUID
-	// When SUID, we don't want to expose user's personal vault
-	if !isSUID {
-		paths = append(paths, ".dotsecenv/vault")
-		paths = append(paths, p.VaultPath())
+// GetDefaultVaultPaths generates the default vault paths for `dotsecenv init config`:
+// the cwd-relative `.dotsecenv/vault`, the user's home vault (XDG_DATA_HOME-aware),
+// and the conventional system vault `/var/lib/dotsecenv/vault`.
+func (p Paths) GetDefaultVaultPaths() []string {
+	return []string{
+		".dotsecenv/vault",
+		p.VaultPath(),
+		"/var/lib/dotsecenv/vault",
 	}
-
-	// Always include system vault
-	// in SUID mode, we only include the system vault
-	paths = append(paths, "/var/lib/dotsecenv/vault")
-
-	return paths
 }

--- a/internal/xdg/xdg_test.go
+++ b/internal/xdg/xdg_test.go
@@ -120,39 +120,19 @@ func TestGetDefaultVaultPaths(t *testing.T) {
 		DataHome: "/data",
 	}
 
-	t.Run("normal execution", func(t *testing.T) {
-		paths := p.GetDefaultVaultPaths(false)
-		expected := []string{
-			".dotsecenv/vault",
-			filepath.Join("/data", "dotsecenv", "vault"),
-			"/var/lib/dotsecenv/vault",
-		}
+	paths := p.GetDefaultVaultPaths()
+	expected := []string{
+		".dotsecenv/vault",
+		filepath.Join("/data", "dotsecenv", "vault"),
+		"/var/lib/dotsecenv/vault",
+	}
 
-		if len(paths) != len(expected) {
-			t.Errorf("expected %d paths, got %d", len(expected), len(paths))
+	if len(paths) != len(expected) {
+		t.Errorf("expected %d paths, got %d", len(expected), len(paths))
+	}
+	for i := range expected {
+		if paths[i] != expected[i] {
+			t.Errorf("path[%d]: expected %s, got %s", i, expected[i], paths[i])
 		}
-		for i := range expected {
-			if paths[i] != expected[i] {
-				t.Errorf("path[%d]: expected %s, got %s", i, expected[i], paths[i])
-			}
-		}
-	})
-
-	t.Run("suid execution", func(t *testing.T) {
-		paths := p.GetDefaultVaultPaths(true)
-		expected := []string{
-			"/var/lib/dotsecenv/vault",
-		}
-
-		if len(paths) != len(expected) {
-			t.Errorf("expected %d paths, got %d", len(expected), len(paths))
-		}
-		// Check that the user vault is NOT present
-		userVault := filepath.Join("/data", "dotsecenv", "vault")
-		for _, path := range paths {
-			if path == userVault {
-				t.Error("user vault found in SUID execution paths")
-			}
-		}
-	})
+	}
 }

--- a/pkg/dotsecenv/vault/integration_test.go
+++ b/pkg/dotsecenv/vault/integration_test.go
@@ -147,10 +147,10 @@ func TestManagerAddSecretValues(t *testing.T) {
 
 	// Verify
 	secret := m.GetSecretByKey("MY_SECRET")
-	if secret == nil {
+	switch {
+	case secret == nil:
 		t.Fatal("secret not found")
-	}
-	if len(secret.Values) != 2 {
+	case len(secret.Values) != 2:
 		t.Errorf("expected 2 values, got %d", len(secret.Values))
 	}
 }
@@ -179,19 +179,19 @@ func TestManagerGetAccessibleSecretValue(t *testing.T) {
 
 	// FP1 should get v1 (falls back to most recent they can access)
 	val := m.GetAccessibleSecretValue("FP1", "MY_SECRET")
-	if val == nil {
+	switch {
+	case val == nil:
 		t.Fatal("expected value for FP1")
-	}
-	if val.Value != "v1" {
+	case val.Value != "v1":
 		t.Errorf("expected v1, got %s", val.Value)
 	}
 
 	// FP2 can access latest (v2)
 	val = m.GetAccessibleSecretValue("FP2", "MY_SECRET")
-	if val == nil {
+	switch {
+	case val == nil:
 		t.Fatal("expected value for FP2")
-	}
-	if val.Value != "v2" {
+	case val.Value != "v2":
 		t.Errorf("expected v2, got %s", val.Value)
 	}
 


### PR DESCRIPTION
## Summary

- Remove the SUID hack entirely. The mechanism gave admins a hardcoded `/etc/dotsecenv/config` fallback plus a block-list of write commands when the binary ran with elevated privileges. Replacement: the upcoming policy directory at `/etc/dotsecenv/policy.d/` (separate plan), which uses ordinary filesystem permissions to enforce admin policy without conflating it with the binary's privilege model.
- Production deletions: `isSUID`, `suidDisallowedCommands`, `checkSUIDMode`, `getCommandPath` from `cmd/dotsecenv/globals.go`; `PersistentPreRun` from `cmd/dotsecenv/root.go`; `checkSUIDMode` call from `cmd/dotsecenv/cmd_identity_add.go`; duplicate `isSUID()` in `internal/cli/cli.go`; SUID branches in `ResolveConfigPath`, `loadConfigAndPrepareGPG`, and `InitVaultInteractiveStandalone`; `isSUID bool` parameter from `xdg.GetDefaultVaultPaths` (the only thing it gated was excluding the home vault).
- Behavioral change: `/etc/dotsecenv/config` is no longer a recognized fallback path, and the previously SUID-disallowed write commands now run normally regardless of the binary's privilege bits. Existing SUID installs that relied on the fallback should migrate to a regular config in `/etc` or `~/.config/dotsecenv/`.
- Side cleanup: golangci-lint flagged a batch of pre-existing SA5011 warnings in test files (`commands_test.go`, `identity_add_test.go`, `vault/integration_test.go`) where staticcheck couldn't see `t.Fatal` as terminal. Refactored those `if X == nil { t.Fatal } if X.Field` patterns to `switch { case X == nil: ... case ...: ... }` so the dereference is guarded. Same semantic, no behavior change.

## Test plan

- [ ] `make test` — all tests pass
- [ ] `make test-race` — race detector clean
- [ ] `make e2e` — `TestSecretRevoke_Self`, `TestIssue_*` pass; the regression test for `DOTSECENV_FINGERPRINT` env-var ignore still passes
- [ ] `make lint` — golangci-lint clean (lefthook pre-commit hook verified locally)
- [ ] Manual: run the binary as a normal user — `dotsecenv login`, `secret store`, etc. all work as before
- [ ] Manual: run a build with `chmod 4755 ./bin/dotsecenv` (SUID bit set), then run `./bin/dotsecenv login FP` — must succeed (was previously blocked); verify behavior is identical to non-SUID

## Out of scope

- The actual policy directory (`/etc/dotsecenv/policy.d/`) — separate plan, separate PR
- Migration tooling for existing SUID installs — documentation only for now

🤖 Generated with [Claude Code](https://claude.com/claude-code)