### PR TITLE
refactor: drop /var/lib/dotsecenv/vault from default vault paths

### DIFF
--- a/internal/xdg/xdg.go
+++ b/internal/xdg/xdg.go
@@ -71,12 +71,12 @@ func (p Paths) EnsureDirs() error {
 }
 
 // GetDefaultVaultPaths generates the default vault paths for `dotsecenv init config`:
-// the cwd-relative `.dotsecenv/vault`, the user's home vault (XDG_DATA_HOME-aware),
-// and the conventional system vault `/var/lib/dotsecenv/vault`.
+// the cwd-relative `.dotsecenv/vault` (typically committed alongside source) and
+// the user's home vault (XDG_DATA_HOME-aware). Multi-user / org-wide shared
+// vaults are an explicit admin choice and are not part of the defaults.
 func (p Paths) GetDefaultVaultPaths() []string {
 	return []string{
 		".dotsecenv/vault",
 		p.VaultPath(),
-		"/var/lib/dotsecenv/vault",
 	}
 }

--- a/internal/xdg/xdg_test.go
+++ b/internal/xdg/xdg_test.go
@@ -124,7 +124,6 @@ func TestGetDefaultVaultPaths(t *testing.T) {
 	expected := []string{
 		".dotsecenv/vault",
 		filepath.Join("/data", "dotsecenv", "vault"),
-		"/var/lib/dotsecenv/vault",
 	}
 
 	if len(paths) != len(expected) {


### PR DESCRIPTION
## Summary

- Drop `/var/lib/dotsecenv/vault` from `xdg.GetDefaultVaultPaths()`. The path was an SUID-era artifact: pre-SUID-drop, it was the binary's fallback when the home vault wasn't writable. With SUID gone (#110), defaulting init to a path the user can't write to is just noise — `init vault` against `/var/lib/*` fails without sudo, and fresh configs ship pointing at a vault that doesn't exist.
- New default vault list:
  - `.dotsecenv/vault` (cwd-relative; commit-to-repo pattern)
  - `<XDG_DATA_HOME>/dotsecenv/vault` (per-user home vault)
- Multi-user / org-wide shared vaults remain a supported configuration — admins simply add the path explicitly to user configs (or, when the policy directory plan lands, via `required_vault_paths`). The conventional location for a shared Linux vault is still `/var/lib/dotsecenv/vault` per FHS; it is no longer auto-injected.
- Test updated: `xdg_test.go`'s `TestGetDefaultVaultPaths` now asserts the 2-path output.

## Test plan

- [ ] `make test` — all tests pass
- [ ] `make test-race` — race detector clean
- [ ] `make e2e` — passes (no e2e test depends on the system path being a default)
- [ ] `make lint` — clean
- [ ] Manual: `dotsecenv init config -c /tmp/cfg.yaml --no-gpg-program` and inspect the generated `vault:` block — confirm only the cwd-relative and home paths appear

## Companion PR

- dotsecenv/website#120: drops `/var/lib/dotsecenv/vault` from the `vault doctor` sample output

🤖 Generated with [Claude Code](https://claude.com/claude-code)