### PR TITLE
feat: approved_vault_paths policy field, plus policy hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ behaves exactly as before (today's behavior is preserved). When the directory
 exists, fragments are loaded in lexical filename order and merged into an
 effective policy that constrains every user.
 
-### Phase 1 supports one allow-list field
+### Supported allow-list fields
 
 ```yaml
 # /etc/dotsecenv/policy.d/00-corp-baseline.yaml
@@ -548,24 +548,45 @@ approved_algorithms:
   - algo: EdDSA
     curves: [Ed25519, Ed448]
     min_bits: 255
+
+approved_vault_paths:
+  - /var/lib/dotsecenv/vault
+  - ~/.local/share/dotsecenv/vault
+  - ~/work/*/.dotsecenv/vault
 ```
 
-Cross-fragment merge: the union of all fragments' entries, with same-`algo`
-entries collapsed (curves union; `min_bits` takes the minimum — most-permissive
-reconciliation).
+**Cross-fragment merge** (allow-lists): union of all fragments' entries.
+For `approved_algorithms`, same-`algo` entries collapse — curves union and
+`min_bits` takes the minimum (most-permissive reconciliation). For
+`approved_vault_paths`, the merged result is the deduped union of patterns.
 
-User vs policy: the user's `approved_algorithms` is **intersected** with the
-policy's effective allow-list. Policy is a ceiling; users can be stricter
-locally; users cannot exceed policy. Algorithms or curves dropped by the
-intersection emit a stderr warning explaining what changed.
+**User vs policy** (intersection): the user's `approved_algorithms` is
+intersected with the policy's; the user's `cfg.Vault` is filtered to entries
+matching at least one `approved_vault_paths` pattern. Policy is a ceiling;
+users can be stricter locally; users cannot exceed policy. Dropped entries
+emit stderr warnings explaining what changed (suppressed by `-s`).
+
+**Vault path matching** uses `path/filepath.Match` (single-segment globs:
+`*`, `?`, `[abc]`); `~` expands to the user's home. There is no `**`
+recursive globbing — admins enumerate explicitly or use single-segment
+patterns. Explicit `-v` flags are subject to the same filter and are
+*rejected* (not silently dropped) when not allowed by policy.
+
+### Fail-closed on broken policy
+
+Any error loading policy aborts startup. A partially-readable or malformed
+policy directory is indistinguishable from tampering, so the only safe
+behavior is to refuse to run. The error is classified by category and
+returned with the matching exit code (see `policy validate` table below);
+`dotsecenv policy validate` and `dotsecenv policy list` continue to work
+even when policy is broken (so admins can diagnose).
 
 ### Forbidden keys in policy fragments
 
 Hard-rejected at load with an explicit error citing the offending fragment:
 
 - `login` — identity is per-user, not org-wide
-- `vault` — would erase user vaults; future phases add `approved_vault_paths`
-  for vault filtering
+- `vault` — would erase user vaults; use `approved_vault_paths` instead
 - `behavior`, `gpg` — reserved for future phases
 
 ### Permissions
@@ -587,6 +608,7 @@ dotsecenv policy list --json
 
 # Validate fragment structure (useful in CI for ops repos shipping policy)
 dotsecenv policy validate
+dotsecenv policy validate --json   # error embedded in JSON object
 ```
 
 `policy validate` exits with distinct codes per error category:
@@ -595,17 +617,17 @@ dotsecenv policy validate
 |------|---------|
 | 0    | No policy enforced or all fragments structurally valid |
 | 2    | Malformed YAML or forbidden key |
-| 8    | Insecure permissions on directory or any fragment |
+| 8    | Insecure permissions or unreadable fragment |
 | 1    | Empty allow-list field (omit the field instead) |
 
 ### Out of scope (current phase)
 
-- `approved_vault_paths` — coming in PR #2
-- `behavior.*` and `gpg.program` policy fields — coming in PR #3
+- `behavior.*` and `gpg.program` policy fields — coming in a follow-on PR
 - Project-level `.dotsecenv/policy.yaml`
 - Remote/centralized policy distribution
 - Encrypted/signed policy fragments
 - Windows policy support
+- `**` recursive glob support in `approved_vault_paths`
 
 ## Vault File Format
 

--- a/cmd/dotsecenv/cmd_policy.go
+++ b/cmd/dotsecenv/cmd_policy.go
@@ -33,6 +33,8 @@ Options:
 	},
 }
 
+var policyValidateJSON bool
+
 var policyValidateCmd = &cobra.Command{
 	Use:   "validate",
 	Short: "Validate policy fragment structure",
@@ -41,16 +43,21 @@ var policyValidateCmd = &cobra.Command{
 Exit codes:
   0  No policy enforced, or all fragments structurally valid
   2  Malformed YAML or forbidden key (use 'login:', 'vault:', 'behavior:', or 'gpg:')
-  8  Insecure permissions on directory or any fragment
-  1  Empty allow-list field (omit the field instead of setting an empty list)`,
+  8  Insecure permissions or unreadable fragment
+  1  Empty allow-list field (omit the field instead of setting an empty list)
+
+Options:
+  --json  Output as JSON (errors are embedded in the JSON object as well as
+          surfaced via the exit code)`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		exitWithError(clilib.PolicyValidate(globalOpts.Silent, os.Stdout, os.Stderr))
+		exitWithError(clilib.PolicyValidate(policyValidateJSON, globalOpts.Silent, os.Stdout, os.Stderr))
 	},
 }
 
 func init() {
 	policyListCmd.Flags().BoolVar(&policyListJSON, "json", false, "Output as JSON")
+	policyValidateCmd.Flags().BoolVar(&policyValidateJSON, "json", false, "Output as JSON")
 
 	policyCmd.AddCommand(policyListCmd)
 	policyCmd.AddCommand(policyValidateCmd)

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
 github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
 github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
-github.com/ProtonMail/gopenpgp/v3 v3.4.0 h1:WW0VK+mZjbu5SqhWNm58TYKFxyvduiUHTfyIKs60dgY=
-github.com/ProtonMail/gopenpgp/v3 v3.4.0/go.mod h1:bGdV9f6edhmd581wzXsQCTKdH8bXBbyhkgDKPjwPc6U=
 github.com/ProtonMail/gopenpgp/v3 v3.4.1 h1:K7uUhSHSJxORZ+RuHpilTT6S4MA2whCRlXNwLqd0+ys=
 github.com/ProtonMail/gopenpgp/v3 v3.4.1/go.mod h1:bGdV9f6edhmd581wzXsQCTKdH8bXBbyhkgDKPjwPc6U=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -106,9 +106,16 @@ func loadConfigAndPrepareGPG(configPath string, silent bool, stdin io.Reader, st
 		return nil, NewError(fmt.Sprintf("failed to load config: %v", err), ExitConfigError)
 	}
 
+	// Fail closed: any error loading policy aborts startup. A partially
+	// readable or malformed policy directory is indistinguishable from
+	// tampering; the only safe behavior is to refuse to run. Use the same
+	// classification as `dotsecenv policy validate` so users see consistent
+	// exit codes (e.g. ExitAccessDenied for unreadable / insecure perms,
+	// ExitConfigError for malformed / forbidden, ExitGeneralError for
+	// empty allow-list).
 	pol, polLoadWarnings, polLoadErr := policy.Load()
 	if polLoadErr != nil {
-		return nil, NewError(fmt.Sprintf("failed to load policy: %v", polLoadErr), ExitConfigError)
+		return nil, classifyPolicyError(polLoadErr)
 	}
 
 	var polApplyWarnings []string
@@ -163,6 +170,21 @@ func newCLI(vaultPaths []string, configPath string, silent bool, stdin io.Reader
 
 	// If -v flags were provided, use those paths directly
 	if len(vaultPaths) > 0 {
+		// Policy filter: explicit -v paths must match approved_vault_paths
+		// (when policy constrains them). Reject — don't silently drop —
+		// since the user explicitly asked for these paths.
+		if !cli.policy.Empty() {
+			for _, vp := range vaultPaths {
+				if !cli.policy.IsVaultPathAllowed(vp) {
+					polPatterns, _ := cli.policy.MergedApprovedVaultPaths()
+					return nil, NewError(fmt.Sprintf(
+						"vault path %s is not allowed by policy. Allowed patterns: %v",
+						vp, polPatterns,
+					), ExitAccessDenied)
+				}
+			}
+		}
+
 		// Check if overriding config vaults with NEW vaults
 		shouldWarnOrError := false
 		if len(cfg.Vault) > 0 {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,15 +2,40 @@ package cli
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/config"
+	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/policy"
 )
 
+// withTempPolicyDir overrides policy.DefaultDir for the duration of t and
+// restores it on cleanup. The returned dir is the one tests should write
+// fragments into.
+func withTempPolicyDir(t *testing.T) string {
+	t.Helper()
+	tmp := t.TempDir()
+	orig := policy.DefaultDir
+	policy.DefaultDir = tmp
+	t.Cleanup(func() { policy.DefaultDir = orig })
+	return tmp
+}
+
+// pointPolicyAtMissing makes policy.DefaultDir point at a path that does
+// not exist for the duration of t. Used to neutralise system-wide policy
+// in tests that don't care about it.
+func pointPolicyAtMissing(t *testing.T) {
+	t.Helper()
+	orig := policy.DefaultDir
+	policy.DefaultDir = filepath.Join(t.TempDir(), "no-such-policy-dir")
+	t.Cleanup(func() { policy.DefaultDir = orig })
+}
+
 func TestNewCLIConfigOnly_LoadsConfig(t *testing.T) {
+	pointPolicyAtMissing(t)
 	tmpDir := t.TempDir()
 	cfgPath := filepath.Join(tmpDir, "config.yaml")
 
@@ -41,6 +66,7 @@ func TestNewCLIConfigOnly_LoadsConfig(t *testing.T) {
 }
 
 func TestNewCLIConfigOnly_MissingConfig(t *testing.T) {
+	pointPolicyAtMissing(t)
 	tmpDir := t.TempDir()
 	cfgPath := filepath.Join(tmpDir, "nonexistent.yaml")
 
@@ -57,6 +83,7 @@ func TestNewCLIConfigOnly_MissingConfig(t *testing.T) {
 }
 
 func TestNewCLIConfigOnly_DoesNotOpenVaults(t *testing.T) {
+	pointPolicyAtMissing(t)
 	tmpDir := t.TempDir()
 	cfgPath := filepath.Join(tmpDir, "config.yaml")
 
@@ -80,3 +107,80 @@ func TestNewCLIConfigOnly_DoesNotOpenVaults(t *testing.T) {
 		t.Error("config-only CLI should not create or touch vault files")
 	}
 }
+
+// TestNewCLIConfigOnly_AbortsOnBrokenPolicy proves that any policy load
+// failure (malformed YAML, forbidden key, empty allow-list, insecure perms)
+// prevents dotsecenv from starting. Fail closed: a broken policy directory
+// is indistinguishable from tampering.
+//
+// The test uses a real temp dir as the policy directory but writes fragments
+// owned by the test user (not root). Since the production permission check
+// requires root ownership, the load would normally fail with
+// ErrInsecurePermissions before reaching the malformed-content check. We
+// can only fully exercise the malformed/forbidden paths via the unit-test
+// `loadFromDir(dir, secureStat)` in policy_test.go (which fakes the perm
+// check). Here we cover the "any failure aborts" contract by checking the
+// permission failure itself — equivalent semantically.
+func TestNewCLIConfigOnly_AbortsOnInsecurePolicy(t *testing.T) {
+	policyDir := withTempPolicyDir(t)
+	if err := os.WriteFile(filepath.Join(policyDir, "00-broken.yaml"), []byte("approved_algorithms: [{algo: RSA, min_bits: 2048}]"), 0o644); err != nil {
+		t.Fatalf("write fragment: %v", err)
+	}
+
+	// Set up a valid user config so the only thing that can fail is policy.
+	cfgDir := t.TempDir()
+	cfgPath := filepath.Join(cfgDir, "config.yaml")
+	cfg := config.DefaultConfig()
+	cfg.Vault = []string{filepath.Join(cfgDir, "vault.dsv")}
+	cfg.GPG.Program = "PATH"
+	if err := config.Save(cfgPath, cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	_, err := NewCLIConfigOnly(cfgPath, true, strings.NewReader(""), &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected NewCLIConfigOnly to fail on insecure policy, got nil")
+	}
+	if !strings.Contains(err.Error(), "insecure") {
+		t.Errorf("expected error to mention insecure permissions, got: %v", err)
+	}
+}
+
+// TestNewCLIConfigOnly_PolicyLoadErrorClassification ensures the error
+// classification (permission vs config vs general) reaches the caller —
+// not just a generic "failed to load policy" wrapper.
+func TestNewCLIConfigOnly_PolicyLoadErrorClassification(t *testing.T) {
+	policyDir := withTempPolicyDir(t)
+	// A test-user-owned fragment triggers ErrInsecurePermissions, which
+	// classifyPolicyError maps to ExitAccessDenied.
+	if err := os.WriteFile(filepath.Join(policyDir, "00.yaml"), []byte("approved_algorithms: [{algo: RSA, min_bits: 2048}]"), 0o644); err != nil {
+		t.Fatalf("write fragment: %v", err)
+	}
+
+	cfgDir := t.TempDir()
+	cfgPath := filepath.Join(cfgDir, "config.yaml")
+	cfg := config.DefaultConfig()
+	cfg.Vault = []string{filepath.Join(cfgDir, "vault.dsv")}
+	cfg.GPG.Program = "PATH"
+	if err := config.Save(cfgPath, cfg); err != nil {
+		t.Fatalf("save config: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	_, err := NewCLIConfigOnly(cfgPath, true, strings.NewReader(""), &stdout, &stderr)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	cliErr, ok := err.(*Error)
+	if !ok {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if cliErr.ExitCode != ExitAccessDenied {
+		t.Errorf("expected ExitAccessDenied (%d), got exit code %d", ExitAccessDenied, cliErr.ExitCode)
+	}
+}
+
+// errorsIsCheck satisfies the goimports lint by ensuring we use errors.Is
+// somewhere in this file even when tests don't reference it directly.
+var _ = errors.Is

--- a/internal/cli/policy.go
+++ b/internal/cli/policy.go
@@ -17,26 +17,6 @@ import (
 // attribution. Operates standalone (does not require a loaded user config),
 // so admins can introspect policy without being dotsecenv users themselves.
 func PolicyList(jsonMode, silent bool, stdout, stderr io.Writer) *Error {
-	out := output.NewHandler(stdout, stderr,
-		output.WithSilent(silent),
-		output.WithJSON(jsonMode),
-	)
-
-	pol, _, err := policy.Load()
-	if err != nil {
-		return classifyPolicyError(err)
-	}
-
-	if jsonMode {
-		return writePolicyListJSON(out, pol)
-	}
-	return writePolicyListText(out, pol)
-}
-
-// PolicyValidate parses all fragments and reports structural errors.
-// Returns nil on success (no policy enforced OR all fragments structurally
-// valid). Otherwise returns *Error with a distinct ExitCode per category.
-func PolicyValidate(silent bool, stdout, stderr io.Writer) *Error {
 	out := output.NewHandler(stdout, stderr, output.WithSilent(silent))
 
 	pol, _, err := policy.Load()
@@ -44,11 +24,49 @@ func PolicyValidate(silent bool, stdout, stderr io.Writer) *Error {
 		return classifyPolicyError(err)
 	}
 
+	if jsonMode {
+		return writePolicyListJSON(stdout, pol)
+	}
+	return writePolicyListText(out, pol)
+}
+
+// PolicyValidate parses all fragments and reports structural errors.
+// In text mode (default), prints a short status line. In JSON mode, emits a
+// structured object compatible with the convention from `vault doctor --json`
+// (raw json.NewEncoder output to stdout, no envelope; errors surface via the
+// returned *Error which the caller reports to stderr with the appropriate
+// non-zero exit code).
+//
+// Returns nil on success (no policy enforced OR all fragments structurally
+// valid). Otherwise returns *Error with a distinct ExitCode per category.
+func PolicyValidate(jsonMode, silent bool, stdout, stderr io.Writer) *Error {
+	out := output.NewHandler(stdout, stderr, output.WithSilent(silent))
+
+	pol, _, err := policy.Load()
+	if err != nil {
+		if jsonMode {
+			cliErr := classifyPolicyError(err)
+			_ = writePolicyValidateJSON(stdout, policy.DefaultDir, false, 0, cliErr)
+			return cliErr
+		}
+		return classifyPolicyError(err)
+	}
+
+	if jsonMode {
+		dir := pol.Dir
+		if dir == "" {
+			dir = policy.DefaultDir
+		}
+		if writeErr := writePolicyValidateJSON(stdout, dir, true, len(pol.Fragments), nil); writeErr != nil {
+			return NewError(fmt.Sprintf("failed to encode json: %v", writeErr), ExitGeneralError)
+		}
+		return nil
+	}
+
 	if pol.Empty() {
 		out.Successf("no policy in effect (%s does not exist)", policy.DefaultDir)
 		return nil
 	}
-
 	out.Successf("policy valid (%d fragment(s) in %s)", len(pol.Fragments), pol.Dir)
 	return nil
 }
@@ -57,7 +75,8 @@ func PolicyValidate(silent bool, stdout, stderr io.Writer) *Error {
 // exit code per category, matching the convention of other dotsecenv commands.
 func classifyPolicyError(err error) *Error {
 	switch {
-	case errors.Is(err, policy.ErrInsecurePermissions):
+	case errors.Is(err, policy.ErrInsecurePermissions),
+		errors.Is(err, policy.ErrUnreadableFragment):
 		return NewError(err.Error(), ExitAccessDenied)
 	case errors.Is(err, policy.ErrEmptyAllowList):
 		return NewError(err.Error(), ExitGeneralError)
@@ -78,13 +97,24 @@ func writePolicyListText(out *output.Handler, p policy.Policy) *Error {
 
 	out.WriteLine(fmt.Sprintf("Policy directory: %s (%d fragment(s))", p.Dir, len(p.Fragments)))
 
-	algos, origins := p.MergedApprovedAlgorithms()
+	algos, algoOrigins := p.MergedApprovedAlgorithms()
 	if len(algos) > 0 {
 		out.WriteLine("  approved_algorithms:")
 		for i, a := range algos {
 			out.WriteLine(fmt.Sprintf("    - %s  %s",
 				formatAlgo(a),
-				formatOrigins(origins[i]),
+				formatOrigins(algoOrigins[i]),
+			))
+		}
+	}
+
+	vaultPatterns, vaultOrigins := p.MergedApprovedVaultPaths()
+	if len(vaultPatterns) > 0 {
+		out.WriteLine("  approved_vault_paths:")
+		for _, pat := range vaultPatterns {
+			out.WriteLine(fmt.Sprintf("    - %s  %s",
+				pat,
+				formatOrigins(vaultOrigins[pat]),
 			))
 		}
 	}
@@ -92,16 +122,23 @@ func writePolicyListText(out *output.Handler, p policy.Policy) *Error {
 	return nil
 }
 
-// writePolicyListJSON emits the effective policy as a JSON envelope.
-func writePolicyListJSON(out *output.Handler, p policy.Policy) *Error {
+// writePolicyListJSON emits the effective policy as raw JSON to stdout,
+// matching the convention from `vault describe --json` and `vault doctor --json`
+// (json.NewEncoder direct emission, no envelope wrapper).
+func writePolicyListJSON(stdout io.Writer, p policy.Policy) *Error {
 	type algoEntry struct {
 		Entry   config.ApprovedAlgorithm `json:"entry"`
 		Origins []string                 `json:"origins"`
 	}
+	type vaultEntry struct {
+		Pattern string   `json:"pattern"`
+		Origins []string `json:"origins"`
+	}
 	type listOutput struct {
-		Dir                string      `json:"dir,omitempty"`
-		Fragments          []string    `json:"fragments,omitempty"`
-		ApprovedAlgorithms []algoEntry `json:"approved_algorithms,omitempty"`
+		Dir                string       `json:"dir,omitempty"`
+		Fragments          []string     `json:"fragments,omitempty"`
+		ApprovedAlgorithms []algoEntry  `json:"approved_algorithms,omitempty"`
+		ApprovedVaultPaths []vaultEntry `json:"approved_vault_paths,omitempty"`
 	}
 
 	data := listOutput{}
@@ -112,19 +149,63 @@ func writePolicyListJSON(out *output.Handler, p policy.Policy) *Error {
 		for _, f := range p.Fragments {
 			data.Fragments = append(data.Fragments, filepath.Base(f.Path))
 		}
-		algos, origins := p.MergedApprovedAlgorithms()
+		algos, algoOrigins := p.MergedApprovedAlgorithms()
 		for i, a := range algos {
 			data.ApprovedAlgorithms = append(data.ApprovedAlgorithms, algoEntry{
 				Entry:   a,
-				Origins: basenames(origins[i]),
+				Origins: basenames(algoOrigins[i]),
+			})
+		}
+		vaultPatterns, vaultOrigins := p.MergedApprovedVaultPaths()
+		for _, pat := range vaultPatterns {
+			data.ApprovedVaultPaths = append(data.ApprovedVaultPaths, vaultEntry{
+				Pattern: pat,
+				Origins: basenames(vaultOrigins[pat]),
 			})
 		}
 	}
 
-	if err := out.WriteJSON(data, nil); err != nil {
-		return NewError(fmt.Sprintf("failed to write json: %v", err), ExitGeneralError)
+	encoder := json.NewEncoder(stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(data); err != nil {
+		return NewError(fmt.Sprintf("failed to encode json: %v", err), ExitGeneralError)
 	}
 	return nil
+}
+
+// validateOutput is the JSON shape for `dotsecenv policy validate --json`.
+// Mirrors the vault-doctor pattern: a flat object on stdout, no envelope.
+// On failure, error.{code,message} is populated and `valid` is false.
+type validateOutput struct {
+	Dir           string         `json:"dir"`
+	Valid         bool           `json:"valid"`
+	FragmentCount int            `json:"fragment_count"`
+	Error         *validateError `json:"error,omitempty"`
+}
+
+type validateError struct {
+	ExitCode int    `json:"exit_code"`
+	Message  string `json:"message"`
+}
+
+// writePolicyValidateJSON emits the validate result as raw JSON to stdout.
+// When cliErr is non-nil, the error block is populated; valid is forced false.
+func writePolicyValidateJSON(stdout io.Writer, dir string, valid bool, fragmentCount int, cliErr *Error) error {
+	out := validateOutput{
+		Dir:           dir,
+		Valid:         valid,
+		FragmentCount: fragmentCount,
+	}
+	if cliErr != nil {
+		out.Valid = false
+		out.Error = &validateError{
+			ExitCode: int(cliErr.ExitCode),
+			Message:  cliErr.Message,
+		}
+	}
+	encoder := json.NewEncoder(stdout)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(out)
 }
 
 func formatAlgo(a config.ApprovedAlgorithm) string {
@@ -147,6 +228,3 @@ func basenames(paths []string) []string {
 	}
 	return out
 }
-
-// Compile-time check: encoding/json must remain imported (used by WriteJSON envelope).
-var _ = json.Marshal

--- a/pkg/dotsecenv/policy/apply.go
+++ b/pkg/dotsecenv/policy/apply.go
@@ -11,7 +11,6 @@ import (
 // and returns the constrained Config plus warnings describing what changed.
 // Returns cfg unchanged when p is empty (no policy enforced).
 //
-// Phase 1 only intersects approved_algorithms. PR #2 will add vault filtering.
 // PR #3 will add scalar overrides (behavior.*, gpg.program).
 func Apply(cfg config.Config, p Policy) (config.Config, []string) {
 	if p.Empty() {
@@ -24,6 +23,13 @@ func Apply(cfg config.Config, p Policy) (config.Config, []string) {
 	if len(polAlgos) > 0 {
 		intersected, w := intersectApprovedAlgorithms(cfg.ApprovedAlgorithms, polAlgos)
 		cfg.ApprovedAlgorithms = intersected
+		warnings = append(warnings, w...)
+	}
+
+	polVaultPatterns, _ := p.MergedApprovedVaultPaths()
+	if len(polVaultPatterns) > 0 {
+		filtered, w := filterApprovedVaults(cfg.Vault, p)
+		cfg.Vault = filtered
 		warnings = append(warnings, w...)
 	}
 
@@ -107,4 +113,26 @@ func maxInt(a, b int) int {
 		return a
 	}
 	return b
+}
+
+// filterApprovedVaults retains only the user vault paths that match at least
+// one of the policy's approved_vault_paths patterns. Dropped paths produce
+// warnings explaining the policy attribution.
+func filterApprovedVaults(userVaults []string, p Policy) ([]string, []string) {
+	var (
+		out      []string
+		warnings []string
+	)
+	for _, v := range userVaults {
+		if p.IsVaultPathAllowed(v) {
+			out = append(out, v)
+			continue
+		}
+		patterns, _ := p.MergedApprovedVaultPaths()
+		warnings = append(warnings, fmt.Sprintf(
+			"policy filters vault path %s (not matched by approved_vault_paths: %v)",
+			v, patterns,
+		))
+	}
+	return out, warnings
 }

--- a/pkg/dotsecenv/policy/merge.go
+++ b/pkg/dotsecenv/policy/merge.go
@@ -1,9 +1,11 @@
 package policy
 
 import (
+	"path/filepath"
 	"sort"
 
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/config"
+	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/vault"
 )
 
 // MergedApprovedAlgorithms returns the cross-fragment union of approved_algorithms
@@ -64,4 +66,60 @@ func (p Policy) MergedApprovedAlgorithms() (entries []config.ApprovedAlgorithm, 
 		origins = append(origins, b.origins)
 	}
 	return entries, origins
+}
+
+// MergedApprovedVaultPaths returns the deduped cross-fragment union of
+// approved_vault_paths patterns plus an origin map (pattern -> fragment paths
+// that contributed it). Patterns are returned in first-seen order across
+// fragments (lexical fragment order, then within-fragment order).
+func (p Policy) MergedApprovedVaultPaths() (patterns []string, origins map[string][]string) {
+	origins = map[string][]string{}
+	seen := map[string]struct{}{}
+	for _, f := range p.Fragments {
+		for _, pat := range f.ApprovedVaultPaths {
+			if _, ok := seen[pat]; !ok {
+				patterns = append(patterns, pat)
+				seen[pat] = struct{}{}
+			}
+			// Append origin if this fragment hasn't already been recorded for this pattern.
+			origs := origins[pat]
+			if len(origs) == 0 || origs[len(origs)-1] != f.Path {
+				origins[pat] = append(origs, f.Path)
+			}
+		}
+	}
+	return patterns, origins
+}
+
+// IsVaultPathAllowed reports whether vaultPath matches any of the policy's
+// approved_vault_paths patterns. When the policy has no approved_vault_paths
+// set (e.g. an empty or absent policy), this returns true — the policy
+// doesn't constrain vault paths in that case.
+//
+// Matching uses filepath.Match (single-segment wildcards: *, ?, [abc]) with
+// `~` expansion via vault.ExpandPath on both pattern and path before matching.
+// Both are also passed through filepath.Abs (best-effort) to normalize.
+func (p Policy) IsVaultPathAllowed(vaultPath string) bool {
+	patterns, _ := p.MergedApprovedVaultPaths()
+	if len(patterns) == 0 {
+		return true
+	}
+	target := normalizePath(vaultPath)
+	for _, pat := range patterns {
+		if matched, _ := filepath.Match(normalizePath(pat), target); matched {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizePath expands ~ and resolves to absolute (best-effort).
+// Used to give pattern and target a common representation before
+// filepath.Match. Returns the original input on resolution failure.
+func normalizePath(p string) string {
+	expanded := vault.ExpandPath(p)
+	if abs, err := filepath.Abs(expanded); err == nil {
+		return abs
+	}
+	return expanded
 }

--- a/pkg/dotsecenv/policy/policy.go
+++ b/pkg/dotsecenv/policy/policy.go
@@ -31,7 +31,10 @@ import (
 var DefaultDir = "/etc/dotsecenv/policy.d"
 
 // Sentinel errors returned by Load. Callers (e.g. dotsecenv policy validate)
-// use errors.Is to map these to distinct exit codes.
+// use errors.Is to map these to distinct exit codes. Any of these errors
+// from Load() is fatal: dotsecenv refuses to start until the offending
+// fragment is fixed or removed. Failing closed is the only safe behavior
+// when admin policy can't be parsed.
 var (
 	// ErrInsecurePermissions indicates a fragment file or the directory has
 	// group/other write bits set, or is owned by a non-root user.
@@ -49,6 +52,12 @@ var (
 	// ErrMalformedFragment indicates a fragment file could not be parsed as
 	// YAML.
 	ErrMalformedFragment = errors.New("malformed policy fragment")
+
+	// ErrUnreadableFragment indicates a fragment file could not be read
+	// (e.g. permission denied at open time, even though the directory
+	// listing exposed the file). Fail closed: a partially-readable policy
+	// directory is indistinguishable from tampering, so refuse to start.
+	ErrUnreadableFragment = errors.New("unreadable policy fragment")
 )
 
 // Policy is the loaded set of policy fragments. Fragments are stored raw so
@@ -65,7 +74,7 @@ func (p Policy) Empty() bool { return len(p.Fragments) == 0 }
 type Fragment struct {
 	Path               string                     `yaml:"-"` // populated by loader
 	ApprovedAlgorithms []config.ApprovedAlgorithm `yaml:"approved_algorithms,omitempty"`
-	// PR #2 will add: ApprovedVaultPaths []string
+	ApprovedVaultPaths []string                   `yaml:"approved_vault_paths,omitempty"`
 	// PR #3 will add: Behavior config.BehaviorConfig and GPG config.GPGConfig
 }
 
@@ -122,7 +131,7 @@ func loadFromDir(dir string, statFn func(string) (os.FileInfo, error)) (Policy, 
 
 		data, readErr := os.ReadFile(p)
 		if readErr != nil {
-			return Policy{}, nil, fmt.Errorf("read policy fragment %s: %w", p, readErr)
+			return Policy{}, nil, fmt.Errorf("%w: %s: %v", ErrUnreadableFragment, p, readErr)
 		}
 
 		if err := rejectForbiddenKeys(p, data); err != nil {
@@ -161,11 +170,15 @@ func rejectForbiddenKeys(path string, data []byte) error {
 	return nil
 }
 
-// rejectEmptyAllowLists guards against `approved_algorithms: []` (the
-// empty-list authoring bug). Omit the field or set actual entries.
+// rejectEmptyAllowLists guards against `approved_algorithms: []` and
+// `approved_vault_paths: []` (the empty-list authoring bug). Omit the
+// field or set actual entries.
 func rejectEmptyAllowLists(path string, f Fragment) error {
 	if f.ApprovedAlgorithms != nil && len(f.ApprovedAlgorithms) == 0 {
 		return fmt.Errorf("%w: %s sets approved_algorithms: [] (omit the field instead of setting an empty list)", ErrEmptyAllowList, path)
+	}
+	if f.ApprovedVaultPaths != nil && len(f.ApprovedVaultPaths) == 0 {
+		return fmt.Errorf("%w: %s sets approved_vault_paths: [] (omit the field instead of setting an empty list)", ErrEmptyAllowList, path)
 	}
 	return nil
 }

--- a/pkg/dotsecenv/policy/policy_test.go
+++ b/pkg/dotsecenv/policy/policy_test.go
@@ -265,6 +265,35 @@ func TestLoadFromDir_MalformedYAML(t *testing.T) {
 	}
 }
 
+// TestLoadFromDir_UnreadableFragment guards the "fail closed when a fragment
+// is in the directory listing but cannot be read" case. statFn fakes secure
+// permissions (so checkSecure passes), but the file's actual mode 0000
+// causes os.ReadFile to fail. Skipped when running as root (root bypasses
+// POSIX read bits).
+func TestLoadFromDir_UnreadableFragment(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root — POSIX read bits are bypassed; cannot exercise unreadable fragment path")
+	}
+
+	dir := t.TempDir()
+	p := writeFragment(t, dir, "00.yaml", "approved_algorithms: [{algo: RSA, min_bits: 2048}]")
+	if err := os.Chmod(p, 0o000); err != nil {
+		t.Fatalf("chmod 0000: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(p, 0o644) })
+
+	_, _, err := loadFromDir(dir, secureStat(0))
+	if err == nil {
+		t.Fatal("expected error for unreadable fragment, got nil")
+	}
+	if !errors.Is(err, ErrUnreadableFragment) {
+		t.Errorf("expected ErrUnreadableFragment, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "00.yaml") {
+		t.Errorf("error should cite fragment path, got: %v", err)
+	}
+}
+
 // --- MergedApprovedAlgorithms tests ---
 
 func TestMerged_EmptyPolicy(t *testing.T) {
@@ -489,5 +518,200 @@ func TestApply_PolicyHasNoCurves_UserCurvesRetained(t *testing.T) {
 	got := out.ApprovedAlgorithms[0]
 	if len(got.Curves) != 1 || got.Curves[0] != "P-384" {
 		t.Errorf("expected user curves retained, got: %v", got.Curves)
+	}
+}
+
+// --- approved_vault_paths tests ---
+
+func TestLoadFromDir_ApprovedVaultPaths_Parses(t *testing.T) {
+	dir := t.TempDir()
+	writeFragment(t, dir, "00.yaml", `
+approved_vault_paths:
+  - /var/lib/dotsecenv/vault
+  - ~/.local/share/dotsecenv/vault
+  - ~/work/*/.dotsecenv/vault
+`)
+	pol, _, err := loadFromDir(dir, secureStat(0))
+	if err != nil {
+		t.Fatalf("loadFromDir: %v", err)
+	}
+	if len(pol.Fragments) != 1 {
+		t.Fatalf("expected 1 fragment, got %d", len(pol.Fragments))
+	}
+	want := []string{
+		"/var/lib/dotsecenv/vault",
+		"~/.local/share/dotsecenv/vault",
+		"~/work/*/.dotsecenv/vault",
+	}
+	got := pol.Fragments[0].ApprovedVaultPaths
+	if len(got) != len(want) {
+		t.Fatalf("expected %d patterns, got %d: %v", len(want), len(got), got)
+	}
+	for i, p := range want {
+		if got[i] != p {
+			t.Errorf("pattern[%d]: expected %s, got %s", i, p, got[i])
+		}
+	}
+}
+
+func TestLoadFromDir_ApprovedVaultPaths_EmptyRejected(t *testing.T) {
+	dir := t.TempDir()
+	writeFragment(t, dir, "00.yaml", "approved_vault_paths: []")
+
+	_, _, err := loadFromDir(dir, secureStat(0))
+	if err == nil {
+		t.Fatal("expected error for empty approved_vault_paths, got nil")
+	}
+	if !errors.Is(err, ErrEmptyAllowList) {
+		t.Errorf("expected ErrEmptyAllowList, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "approved_vault_paths") {
+		t.Errorf("error should cite the field name, got: %v", err)
+	}
+}
+
+func TestMergedApprovedVaultPaths_DedupedUnion(t *testing.T) {
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", ApprovedVaultPaths: []string{
+			"/var/lib/dotsecenv/vault",
+			"~/.local/share/dotsecenv/vault",
+		}},
+		{Path: "99.yaml", ApprovedVaultPaths: []string{
+			"~/.local/share/dotsecenv/vault", // duplicate
+			"~/work/*/.dotsecenv/vault",
+		}},
+	}}
+	patterns, origins := p.MergedApprovedVaultPaths()
+	want := []string{
+		"/var/lib/dotsecenv/vault",
+		"~/.local/share/dotsecenv/vault",
+		"~/work/*/.dotsecenv/vault",
+	}
+	if len(patterns) != len(want) {
+		t.Fatalf("expected %d patterns, got %d: %v", len(want), len(patterns), patterns)
+	}
+	for i, p := range want {
+		if patterns[i] != p {
+			t.Errorf("pattern[%d]: expected %s, got %s", i, p, patterns[i])
+		}
+	}
+	// Duplicate pattern should list both fragments.
+	dup := "~/.local/share/dotsecenv/vault"
+	if len(origins[dup]) != 2 {
+		t.Errorf("expected 2 origins for duplicated pattern, got: %v", origins[dup])
+	}
+}
+
+func TestIsVaultPathAllowed_NoPatterns_AllAllowed(t *testing.T) {
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml"}, // no approved_vault_paths
+	}}
+	if !p.IsVaultPathAllowed("/anything/goes") {
+		t.Error("expected unconstrained policy to allow any path")
+	}
+}
+
+func TestIsVaultPathAllowed_LiteralMatch(t *testing.T) {
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", ApprovedVaultPaths: []string{
+			"/var/lib/dotsecenv/vault",
+		}},
+	}}
+	if !p.IsVaultPathAllowed("/var/lib/dotsecenv/vault") {
+		t.Error("expected literal path to match itself")
+	}
+	if p.IsVaultPathAllowed("/tmp/foo") {
+		t.Error("expected unrelated path to be rejected")
+	}
+}
+
+func TestIsVaultPathAllowed_SingleSegmentGlob(t *testing.T) {
+	// Use an absolute test root so we don't depend on the test runner's HOME
+	// or the OS-specific resolution that vault.ExpandPath performs (which
+	// consults user.Current(), not $HOME).
+	root := t.TempDir()
+
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", ApprovedVaultPaths: []string{
+			filepath.Join(root, "work/*/.dotsecenv/vault"),
+		}},
+	}}
+	cases := []struct {
+		path    string
+		allowed bool
+	}{
+		{filepath.Join(root, "work/projA/.dotsecenv/vault"), true},
+		{filepath.Join(root, "work/projB/.dotsecenv/vault"), true},
+		// Deep path: filepath.Match `*` does NOT cross / boundaries.
+		{filepath.Join(root, "work/team-a/projB/.dotsecenv/vault"), false},
+		// Different prefix.
+		{filepath.Join(root, "personal/.dotsecenv/vault"), false},
+	}
+	for _, tc := range cases {
+		if got := p.IsVaultPathAllowed(tc.path); got != tc.allowed {
+			t.Errorf("IsVaultPathAllowed(%q) = %v, want %v", tc.path, got, tc.allowed)
+		}
+	}
+}
+
+func TestApply_FilterApprovedVaults(t *testing.T) {
+	root := t.TempDir()
+	allowedVault := filepath.Join(root, "share/dotsecenv/vault")
+
+	cfg := config.Config{
+		Vault: []string{
+			allowedVault,
+			"/tmp/foo",
+		},
+	}
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", ApprovedVaultPaths: []string{allowedVault}},
+	}}
+	out, warnings := Apply(cfg, p)
+	if len(out.Vault) != 1 {
+		t.Fatalf("expected 1 vault retained, got %d: %v", len(out.Vault), out.Vault)
+	}
+	if out.Vault[0] != allowedVault {
+		t.Errorf("expected %s retained, got %s", allowedVault, out.Vault[0])
+	}
+	if len(warnings) != 1 || !strings.Contains(warnings[0], "/tmp/foo") {
+		t.Errorf("expected warning citing /tmp/foo, got: %v", warnings)
+	}
+}
+
+// TestIsVaultPathAllowed_TildeExpansion exercises the ~ -> $HOME expansion
+// path against the real current user's home directory (since vault.ExpandPath
+// uses user.Current(), not $HOME). Skipped when user.Current() fails (e.g.
+// in containers without a passwd entry).
+func TestIsVaultPathAllowed_TildeExpansion(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("cannot resolve home: %v", err)
+	}
+
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", ApprovedVaultPaths: []string{
+			"~/.local/share/dotsecenv/vault",
+		}},
+	}}
+	target := filepath.Join(home, ".local/share/dotsecenv/vault")
+	if !p.IsVaultPathAllowed(target) {
+		t.Errorf("expected %s to match ~/.local/share/dotsecenv/vault pattern", target)
+	}
+}
+
+func TestApply_NoVaultPolicy_VaultsUnchanged(t *testing.T) {
+	cfg := config.Config{
+		Vault: []string{"/tmp/foo", "/tmp/bar"},
+	}
+	// Policy has approved_algorithms but no approved_vault_paths.
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", ApprovedAlgorithms: []config.ApprovedAlgorithm{
+			{Algo: "RSA", MinBits: 2048},
+		}},
+	}}
+	out, _ := Apply(cfg, p)
+	if len(out.Vault) != 2 {
+		t.Errorf("expected vaults unchanged when policy has no vault constraint, got %v", out.Vault)
 	}
 }


### PR DESCRIPTION
## Summary

Three related changes to the policy directory machinery from #114.

### 1. Fail-closed on broken policy

Any error loading policy (insecure permissions, malformed YAML, forbidden key, empty allow-list, **unreadable fragment**) aborts dotsecenv startup. A partially-readable policy directory is indistinguishable from tampering, so the only safe behavior is to refuse to run.

- New `policy.ErrUnreadableFragment` sentinel for the os.ReadFile-fails case (e.g., a file that's in the directory listing but blocked at open time)
- Errors from `policy.Load` are now classified at the cli.go integration point via the same `classifyPolicyError` used by `dotsecenv policy validate`, so users see consistent exit codes regardless of which command surfaced the error
- New integration test in `internal/cli/cli_test.go` proving `NewCLIConfigOnly` aborts on insecure policy with `ExitAccessDenied`

### 2. \`dotsecenv policy validate --json\`

Matches the convention from \`vault doctor --json\` and \`vault describe --json\`: raw \`json.NewEncoder\` output to stdout, no envelope wrapper. Schema:

\`\`\`json
{
  \"dir\": \"/etc/dotsecenv/policy.d\",
  \"valid\": true,
  \"fragment_count\": 3
}
\`\`\`

On failure, an \`error: { exit_code, message }\` block is included and \`valid\` is forced to false. Errors are surfaced both in the JSON object AND via the non-zero process exit code. \`policy list --json\` was also refactored from the WriteJSON envelope pattern to the same direct-encoder pattern for consistency with the rest of the CLI.

### 3. New \`approved_vault_paths\` policy field

Allow-list of glob patterns that constrain user vault locations:

\`\`\`yaml
# /etc/dotsecenv/policy.d/00-corp-baseline.yaml
approved_vault_paths:
  - /var/lib/dotsecenv/vault
  - ~/.local/share/dotsecenv/vault
  - ~/work/*/.dotsecenv/vault
\`\`\`

- **Cross-fragment merge:** deduped union with per-pattern origin attribution for \`policy list\`
- **User vs policy:** the user's \`cfg.Vault\` is filtered to entries matching at least one pattern; dropped paths emit stderr warnings explaining the policy attribution
- **Explicit \`-v\` flags** are subject to the same filter and are *rejected* (not silently dropped) when not allowed by policy, with \`ExitAccessDenied\`
- **Glob matching:** \`path/filepath.Match\` (single-segment wildcards: \`*\`, \`?\`, \`[abc]\`); no \`**\` recursive matching; \`~\` expansion via \`vault.ExpandPath\`
- \`Policy.IsVaultPathAllowed(path)\` exposes the per-path check so \`newCLI\`'s \`-v\` branch can use it without knowing about merge internals
- Empty \`approved_vault_paths: []\` is rejected at \`policy.Load\` (same hygiene as \`approved_algorithms\`)
- \`dotsecenv policy list\` (text and \`--json\`) gains an \`approved_vault_paths:\` section

## Test plan

- [ ] \`make test\` — passes (verified locally)
- [ ] \`make test-race\` — clean (verified locally)
- [ ] \`make lint\` — clean (verified locally; lefthook ran on commit)
- [ ] Manual: \`./bin/dotsecenv policy {list,validate}\` (text and \`--json\`) work against missing /etc/dotsecenv/policy.d/
- [ ] Manual: existing commands (vault, secret, identity) work unchanged when no policy is in effect
- [ ] CI lint passes (Makefile pin to v2.11.4 from prior PR)

## Out of scope (for a follow-on PR)

- \`behavior.*\` and \`gpg.program\` policy fields — coming next
- \`**\` recursive glob support
- Project-level \`.dotsecenv/policy.yaml\`
- Windows policy support

## Related

- PR #114: trusted policy directory at /etc/dotsecenv/policy.d/ (machinery + \`approved_algorithms\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)