### PR TITLE
feat: behavior.* and gpg.program policy fields (last-set-wins)

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,10 +537,12 @@ behaves exactly as before (today's behavior is preserved). When the directory
 exists, fragments are loaded in lexical filename order and merged into an
 effective policy that constrains every user.
 
-### Supported allow-list fields
+### Supported policy fields
 
 ```yaml
 # /etc/dotsecenv/policy.d/00-corp-baseline.yaml
+
+# Allow-list fields: cross-fragment union; user vs policy is intersection.
 approved_algorithms:
   - algo: ECC
     curves: [P-384, P-521]
@@ -553,24 +555,64 @@ approved_vault_paths:
   - /var/lib/dotsecenv/vault
   - ~/.local/share/dotsecenv/vault
   - ~/work/*/.dotsecenv/vault
+
+# Scalar fields: cross-fragment last-wins; policy overrides user.
+behavior:
+  restrict_to_configured_vaults: true
+  require_explicit_vault_upgrade: true
+
+gpg:
+  program: /usr/bin/gpg
 ```
 
-**Cross-fragment merge** (allow-lists): union of all fragments' entries.
-For `approved_algorithms`, same-`algo` entries collapse — curves union and
+**Allow-list cross-fragment merge** (`approved_algorithms`,
+`approved_vault_paths`): union of all fragments' entries. For
+`approved_algorithms`, same-`algo` entries collapse — curves union and
 `min_bits` takes the minimum (most-permissive reconciliation). For
-`approved_vault_paths`, the merged result is the deduped union of patterns.
+`approved_vault_paths`, deduped union of patterns.
 
-**User vs policy** (intersection): the user's `approved_algorithms` is
-intersected with the policy's; the user's `cfg.Vault` is filtered to entries
-matching at least one `approved_vault_paths` pattern. Policy is a ceiling;
-users can be stricter locally; users cannot exceed policy. Dropped entries
-emit stderr warnings explaining what changed (suppressed by `-s`).
+**Allow-list user vs policy** (intersection): the user's `approved_algorithms`
+is intersected with the policy's; the user's `cfg.Vault` is filtered to
+entries matching at least one `approved_vault_paths` pattern. Policy is a
+ceiling; users can be stricter locally; users cannot exceed policy. Dropped
+entries emit stderr warnings explaining what changed (suppressed by `-s`).
 
 **Vault path matching** uses `path/filepath.Match` (single-segment globs:
 `*`, `?`, `[abc]`); `~` expands to the user's home. There is no `**`
 recursive globbing — admins enumerate explicitly or use single-segment
 patterns. Explicit `-v` flags are subject to the same filter and are
 *rejected* (not silently dropped) when not allowed by policy.
+
+**Scalar cross-fragment merge** (`behavior.*` per sub-field, `gpg.program`):
+**last-fragment-to-set wins** in lexical filename order, matching the Unix
+`*.d` drop-in convention used by `sudoers.d`, `systemd unit drop-ins`,
+`nginx conf.d`, etc. Naming: `00-base, 50-team, 99-overrides` — `99-`
+outranks `00-` for scalars. When a later fragment overrides an earlier
+*different* value, dotsecenv emits a stderr warning citing both:
+
+```
+warning: policy conflict on gpg.program: overridden to "/usr/bin/gpg" by /etc/dotsecenv/policy.d/99-team.yaml; previous value "/opt/homebrew/bin/gpg" from /etc/dotsecenv/policy.d/00-corp-baseline.yaml
+```
+
+Same value across fragments emits no warning (it's redundant, not a
+conflict). For `behavior.*`, sub-fields are independent — fragment A
+setting `behavior.X` and fragment B setting `behavior.Y` do not conflict.
+
+**Scalar user vs policy** (policy overrides user): if policy sets a scalar,
+that value replaces the user's. When the user had a *different* value, a
+stderr warning surfaces the override:
+
+```
+warning: policy overrides user gpg.program: user value "/opt/homebrew/bin/gpg" replaced by "/usr/bin/gpg" from /etc/dotsecenv/policy.d/00-corp-baseline.yaml
+```
+
+For `behavior.*`, "set" detection uses pointer nil-ness (`*bool`): an
+omitted field is "no opinion"; `false` is a real value distinct from
+omitted. For `gpg.program`, empty string is "no opinion"; the `"PATH"`
+sentinel is a real value distinct from empty.
+
+Conflict warnings and user-override warnings both respect the `-s` silent
+flag.
 
 ### Fail-closed on broken policy
 
@@ -585,9 +627,8 @@ even when policy is broken (so admins can diagnose).
 
 Hard-rejected at load with an explicit error citing the offending fragment:
 
-- `login` — identity is per-user, not org-wide
+- `login` — identity is per-user (cryptographically bound to a private key)
 - `vault` — would erase user vaults; use `approved_vault_paths` instead
-- `behavior`, `gpg` — reserved for future phases
 
 ### Permissions
 
@@ -620,14 +661,14 @@ dotsecenv policy validate --json   # error embedded in JSON object
 | 8    | Insecure permissions or unreadable fragment |
 | 1    | Empty allow-list field (omit the field instead) |
 
-### Out of scope (current phase)
+### Out of scope
 
-- `behavior.*` and `gpg.program` policy fields — coming in a follow-on PR
 - Project-level `.dotsecenv/policy.yaml`
 - Remote/centralized policy distribution
 - Encrypted/signed policy fragments
-- Windows policy support
+- Windows policy support (Linux/macOS only)
 - `**` recursive glob support in `approved_vault_paths`
+- Per-command policy re-evaluation for stale logins
 
 ## Vault File Format
 

--- a/internal/cli/policy.go
+++ b/internal/cli/policy.go
@@ -119,7 +119,36 @@ func writePolicyListText(out *output.Handler, p policy.Policy) *Error {
 		}
 	}
 
+	behavior, behaviorOrigins, _ := p.MergedBehavior()
+	if hasBehaviorSet(behavior) {
+		out.WriteLine("  behavior:")
+		if behavior.RequireExplicitVaultUpgrade != nil {
+			out.WriteLine(fmt.Sprintf("    require_explicit_vault_upgrade: %v  [%s]",
+				*behavior.RequireExplicitVaultUpgrade,
+				filepath.Base(behaviorOrigins["behavior.require_explicit_vault_upgrade"]),
+			))
+		}
+		if behavior.RestrictToConfiguredVaults != nil {
+			out.WriteLine(fmt.Sprintf("    restrict_to_configured_vaults: %v  [%s]",
+				*behavior.RestrictToConfiguredVaults,
+				filepath.Base(behaviorOrigins["behavior.restrict_to_configured_vaults"]),
+			))
+		}
+	}
+
+	gpgProgram, gpgOrigin, _ := p.MergedGPGProgram()
+	if gpgProgram != "" {
+		out.WriteLine(fmt.Sprintf("  gpg.program: %s  [%s]",
+			gpgProgram, filepath.Base(gpgOrigin),
+		))
+	}
+
 	return nil
+}
+
+// hasBehaviorSet reports whether at least one BehaviorConfig sub-field is set.
+func hasBehaviorSet(b config.BehaviorConfig) bool {
+	return b.RequireExplicitVaultUpgrade != nil || b.RestrictToConfiguredVaults != nil
 }
 
 // writePolicyListJSON emits the effective policy as raw JSON to stdout,
@@ -134,11 +163,22 @@ func writePolicyListJSON(stdout io.Writer, p policy.Policy) *Error {
 		Pattern string   `json:"pattern"`
 		Origins []string `json:"origins"`
 	}
+	type behaviorEntry struct {
+		Field  string `json:"field"`
+		Value  bool   `json:"value"`
+		Origin string `json:"origin"`
+	}
+	type gpgEntry struct {
+		Program string `json:"program"`
+		Origin  string `json:"origin"`
+	}
 	type listOutput struct {
-		Dir                string       `json:"dir,omitempty"`
-		Fragments          []string     `json:"fragments,omitempty"`
-		ApprovedAlgorithms []algoEntry  `json:"approved_algorithms,omitempty"`
-		ApprovedVaultPaths []vaultEntry `json:"approved_vault_paths,omitempty"`
+		Dir                string          `json:"dir,omitempty"`
+		Fragments          []string        `json:"fragments,omitempty"`
+		ApprovedAlgorithms []algoEntry     `json:"approved_algorithms,omitempty"`
+		ApprovedVaultPaths []vaultEntry    `json:"approved_vault_paths,omitempty"`
+		Behavior           []behaviorEntry `json:"behavior,omitempty"`
+		GPG                *gpgEntry       `json:"gpg,omitempty"`
 	}
 
 	data := listOutput{}
@@ -162,6 +202,28 @@ func writePolicyListJSON(stdout io.Writer, p policy.Policy) *Error {
 				Pattern: pat,
 				Origins: basenames(vaultOrigins[pat]),
 			})
+		}
+		behavior, behaviorOrigins, _ := p.MergedBehavior()
+		if behavior.RequireExplicitVaultUpgrade != nil {
+			data.Behavior = append(data.Behavior, behaviorEntry{
+				Field:  "require_explicit_vault_upgrade",
+				Value:  *behavior.RequireExplicitVaultUpgrade,
+				Origin: filepath.Base(behaviorOrigins["behavior.require_explicit_vault_upgrade"]),
+			})
+		}
+		if behavior.RestrictToConfiguredVaults != nil {
+			data.Behavior = append(data.Behavior, behaviorEntry{
+				Field:  "restrict_to_configured_vaults",
+				Value:  *behavior.RestrictToConfiguredVaults,
+				Origin: filepath.Base(behaviorOrigins["behavior.restrict_to_configured_vaults"]),
+			})
+		}
+		gpgProgram, gpgOrigin, _ := p.MergedGPGProgram()
+		if gpgProgram != "" {
+			data.GPG = &gpgEntry{
+				Program: gpgProgram,
+				Origin:  filepath.Base(gpgOrigin),
+			}
 		}
 	}
 

--- a/pkg/dotsecenv/policy/apply.go
+++ b/pkg/dotsecenv/policy/apply.go
@@ -8,10 +8,21 @@ import (
 )
 
 // Apply intersects the user's config with the policy's effective allow-lists
-// and returns the constrained Config plus warnings describing what changed.
+// and overrides the user's scalar fields with policy's effective scalars.
+// Returns the constrained Config plus warnings describing what changed.
 // Returns cfg unchanged when p is empty (no policy enforced).
 //
-// PR #3 will add scalar overrides (behavior.*, gpg.program).
+// Allow-list semantics (intersection): user's `approved_algorithms` is
+// narrowed by policy; user's `vault` list is filtered by `approved_vault_paths`.
+//
+// Scalar semantics (policy overrides user): if policy sets `gpg.program` or
+// any `behavior.*` field, that value replaces the user's. Same value across
+// user and policy is silently honored (no warning); different value emits a
+// "policy overrides user X" warning so users know their config was overridden.
+//
+// Cross-fragment scalar conflicts (later fragment changes a value set by an
+// earlier one) are surfaced separately as `policy conflict` warnings —
+// independent of whether the policy overrides any user value.
 func Apply(cfg config.Config, p Policy) (config.Config, []string) {
 	if p.Empty() {
 		return cfg, nil
@@ -33,7 +44,48 @@ func Apply(cfg config.Config, p Policy) (config.Config, []string) {
 		warnings = append(warnings, w...)
 	}
 
+	// Scalar overrides (policy wins over user). Cross-fragment conflict
+	// warnings come from MergedBehavior/MergedGPGProgram; user-override
+	// warnings come from the merging step below.
+	polBehavior, behaviorOrigins, behaviorConflicts := p.MergedBehavior()
+	warnings = append(warnings, behaviorConflicts...)
+	cfg.Behavior, warnings = applyBehaviorOverride(cfg.Behavior, polBehavior, behaviorOrigins, warnings)
+
+	polGPGProgram, polGPGOrigin, gpgConflicts := p.MergedGPGProgram()
+	warnings = append(warnings, gpgConflicts...)
+	if polGPGProgram != "" {
+		if cfg.GPG.Program != "" && cfg.GPG.Program != polGPGProgram {
+			warnings = append(warnings, fmt.Sprintf(
+				"policy overrides user gpg.program: user value %q replaced by %q from %s",
+				cfg.GPG.Program, polGPGProgram, polGPGOrigin,
+			))
+		}
+		cfg.GPG.Program = polGPGProgram
+	}
+
 	return cfg, warnings
+}
+
+// applyBehaviorOverride applies each policy-set behavior.* sub-field to cfg.
+// When the user previously had a different value, appends a
+// "policy overrides user behavior.X" warning so the silent change is visible.
+// Returns the updated BehaviorConfig and warnings slice.
+func applyBehaviorOverride(user, pol config.BehaviorConfig, polOrigins map[string]string, warnings []string) (config.BehaviorConfig, []string) {
+	for _, fld := range behaviorFields {
+		polVal := fld.get(pol)
+		if polVal == nil {
+			continue // policy doesn't constrain this field
+		}
+		userVal := fld.get(user)
+		if userVal != nil && *userVal != *polVal {
+			warnings = append(warnings, fmt.Sprintf(
+				"policy overrides user %s: user value %v replaced by %v from %s",
+				fld.name, *userVal, *polVal, polOrigins[fld.name],
+			))
+		}
+		fld.set(&user, polVal)
+	}
+	return user, warnings
 }
 
 // intersectApprovedAlgorithms narrows the user's allow-list to entries also

--- a/pkg/dotsecenv/policy/merge.go
+++ b/pkg/dotsecenv/policy/merge.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"fmt"
 	"path/filepath"
 	"sort"
 
@@ -122,4 +123,91 @@ func normalizePath(p string) string {
 		return abs
 	}
 	return expanded
+}
+
+// MergedGPGProgram returns the cross-fragment merged gpg.program scalar.
+// Last-fragment-to-set wins (lexical filename order; matches sudoers.d/systemd
+// drop-in convention). Empty string in a fragment = "not set". Returns the
+// merged value, the origin path of the winning fragment (or "" if no fragment
+// set it), and conflict warnings — one per chained override where a later
+// fragment changed the value to something different from the previous setter.
+//
+// Same value across fragments emits no warning (it's redundant, not a
+// conflict). Different values emit "policy conflict on gpg.program: …".
+func (p Policy) MergedGPGProgram() (program string, origin string, conflicts []string) {
+	for _, f := range p.Fragments {
+		if f.GPG.Program == "" {
+			continue
+		}
+		if origin != "" && f.GPG.Program != program {
+			conflicts = append(conflicts, fmt.Sprintf(
+				"policy conflict on gpg.program: overridden to %q by %s; previous value %q from %s",
+				f.GPG.Program, f.Path, program, origin,
+			))
+		}
+		program = f.GPG.Program
+		origin = f.Path
+	}
+	return program, origin, conflicts
+}
+
+// behaviorField is one settable sub-field of config.BehaviorConfig. The
+// closure-based accessor pattern keeps MergedBehavior independent of how
+// many sub-fields the BehaviorConfig type has — adding a new behavior
+// field is a one-line append here, no merge-engine changes.
+type behaviorField struct {
+	name string
+	get  func(config.BehaviorConfig) *bool
+	set  func(*config.BehaviorConfig, *bool)
+}
+
+var behaviorFields = []behaviorField{
+	{
+		name: "behavior.require_explicit_vault_upgrade",
+		get:  func(b config.BehaviorConfig) *bool { return b.RequireExplicitVaultUpgrade },
+		set:  func(b *config.BehaviorConfig, v *bool) { b.RequireExplicitVaultUpgrade = v },
+	},
+	{
+		name: "behavior.restrict_to_configured_vaults",
+		get:  func(b config.BehaviorConfig) *bool { return b.RestrictToConfiguredVaults },
+		set:  func(b *config.BehaviorConfig, v *bool) { b.RestrictToConfiguredVaults = v },
+	},
+}
+
+// MergedBehavior returns the cross-fragment merged behavior.* fields.
+// Each sub-field independently uses last-fragment-to-set wins; nil = not set.
+// Returns the merged BehaviorConfig, per-field-name origin (which fragment
+// set the final value), and conflict warnings — one per chained override
+// per sub-field where a later fragment changed the value.
+//
+// Sub-fields are independent: behavior.A set by fragment 1 and behavior.B
+// set by fragment 2 produces no conflicts (they touch different fields).
+func (p Policy) MergedBehavior() (b config.BehaviorConfig, origins map[string]string, conflicts []string) {
+	origins = map[string]string{}
+
+	for _, fld := range behaviorFields {
+		var (
+			currentValue  *bool
+			currentOrigin string
+		)
+		for _, frag := range p.Fragments {
+			v := fld.get(frag.Behavior)
+			if v == nil {
+				continue
+			}
+			if currentValue != nil && *v != *currentValue {
+				conflicts = append(conflicts, fmt.Sprintf(
+					"policy conflict on %s: overridden to %v by %s; previous value %v from %s",
+					fld.name, *v, frag.Path, *currentValue, currentOrigin,
+				))
+			}
+			currentValue = v
+			currentOrigin = frag.Path
+		}
+		if currentValue != nil {
+			fld.set(&b, currentValue)
+			origins[fld.name] = currentOrigin
+		}
+	}
+	return b, origins, conflicts
 }

--- a/pkg/dotsecenv/policy/policy.go
+++ b/pkg/dotsecenv/policy/policy.go
@@ -75,12 +75,14 @@ type Fragment struct {
 	Path               string                     `yaml:"-"` // populated by loader
 	ApprovedAlgorithms []config.ApprovedAlgorithm `yaml:"approved_algorithms,omitempty"`
 	ApprovedVaultPaths []string                   `yaml:"approved_vault_paths,omitempty"`
-	// PR #3 will add: Behavior config.BehaviorConfig and GPG config.GPGConfig
+	Behavior           config.BehaviorConfig      `yaml:"behavior,omitempty"`
+	GPG                config.GPGConfig           `yaml:"gpg,omitempty"`
 }
 
-// forbiddenKeysPhase1 are top-level YAML keys rejected at fragment load.
-// PR #3 will lift "behavior" and "gpg" from this list.
-var forbiddenKeysPhase1 = []string{"login", "vault", "behavior", "gpg"}
+// forbiddenKeys are top-level YAML keys rejected at fragment load.
+// `login` is per-user (cryptographically bound to a private key); `vault`
+// would erase user vaults wholesale (use `approved_vault_paths` instead).
+var forbiddenKeys = []string{"login", "vault"}
 
 // Load enumerates *.yaml in DefaultDir (lexical order), validates each
 // fragment, and returns the assembled Policy plus per-fragment warnings.
@@ -162,7 +164,7 @@ func rejectForbiddenKeys(path string, data []byte) error {
 	if err := yaml.Unmarshal(data, &raw); err != nil {
 		return nil // primary parse will surface this as ErrMalformedFragment
 	}
-	for _, key := range forbiddenKeysPhase1 {
+	for _, key := range forbiddenKeys {
 		if _, ok := raw[key]; ok {
 			return fmt.Errorf("%w: %s contains '%s:' (not allowed in policy fragments)", ErrForbiddenKey, path, key)
 		}

--- a/pkg/dotsecenv/policy/policy_test.go
+++ b/pkg/dotsecenv/policy/policy_test.go
@@ -155,14 +155,14 @@ func TestLoadFromDir_NonYamlFilesIgnored(t *testing.T) {
 }
 
 func TestLoadFromDir_ForbiddenKey(t *testing.T) {
+	// `behavior` and `gpg` were forbidden in PR #1 but became legitimate
+	// policy keys in PR #3; only `login` and `vault` remain forbidden.
 	cases := []struct {
 		key  string
 		body string
 	}{
 		{"login", "login:\n  fingerprint: ABCD\n"},
 		{"vault", "vault:\n  - /tmp/v\n"},
-		{"behavior", "behavior:\n  restrict_to_configured_vaults: true\n"},
-		{"gpg", "gpg:\n  program: /usr/bin/gpg\n"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.key, func(t *testing.T) {
@@ -183,6 +183,32 @@ func TestLoadFromDir_ForbiddenKey(t *testing.T) {
 				t.Errorf("error should cite fragment path, got: %v", err)
 			}
 		})
+	}
+}
+
+// TestLoadFromDir_BehaviorAndGPGAccepted proves PR #3 lifted these keys
+// from the forbidden list — they're now valid policy fields.
+func TestLoadFromDir_BehaviorAndGPGAccepted(t *testing.T) {
+	dir := t.TempDir()
+	writeFragment(t, dir, "00.yaml", `
+behavior:
+  restrict_to_configured_vaults: true
+gpg:
+  program: /usr/bin/gpg
+`)
+	pol, _, err := loadFromDir(dir, secureStat(0))
+	if err != nil {
+		t.Fatalf("loadFromDir: %v", err)
+	}
+	if len(pol.Fragments) != 1 {
+		t.Fatalf("expected 1 fragment, got %d", len(pol.Fragments))
+	}
+	f := pol.Fragments[0]
+	if f.Behavior.RestrictToConfiguredVaults == nil || !*f.Behavior.RestrictToConfiguredVaults {
+		t.Errorf("expected RestrictToConfiguredVaults=&true, got %v", f.Behavior.RestrictToConfiguredVaults)
+	}
+	if f.GPG.Program != "/usr/bin/gpg" {
+		t.Errorf("expected GPG.Program=/usr/bin/gpg, got %q", f.GPG.Program)
 	}
 }
 
@@ -697,6 +723,330 @@ func TestIsVaultPathAllowed_TildeExpansion(t *testing.T) {
 	target := filepath.Join(home, ".local/share/dotsecenv/vault")
 	if !p.IsVaultPathAllowed(target) {
 		t.Errorf("expected %s to match ~/.local/share/dotsecenv/vault pattern", target)
+	}
+}
+
+// --- MergedGPGProgram tests ---
+
+func TestMergedGPGProgram_NoFragmentsSet(t *testing.T) {
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml"}, // GPG omitted entirely
+		{Path: "50.yaml", GPG: config.GPGConfig{Program: ""}}, // empty = not set
+	}}
+	prog, origin, conflicts := p.MergedGPGProgram()
+	if prog != "" || origin != "" || len(conflicts) != 0 {
+		t.Errorf("expected empty result with no conflicts, got prog=%q origin=%q conflicts=%v", prog, origin, conflicts)
+	}
+}
+
+func TestMergedGPGProgram_SingleFragment(t *testing.T) {
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", GPG: config.GPGConfig{Program: "/usr/bin/gpg"}},
+	}}
+	prog, origin, conflicts := p.MergedGPGProgram()
+	if prog != "/usr/bin/gpg" {
+		t.Errorf("expected /usr/bin/gpg, got %q", prog)
+	}
+	if origin != "00.yaml" {
+		t.Errorf("expected origin 00.yaml, got %q", origin)
+	}
+	if len(conflicts) != 0 {
+		t.Errorf("expected no conflicts, got: %v", conflicts)
+	}
+}
+
+func TestMergedGPGProgram_SameValueAcrossFragments_NoConflict(t *testing.T) {
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", GPG: config.GPGConfig{Program: "/usr/bin/gpg"}},
+		{Path: "99.yaml", GPG: config.GPGConfig{Program: "/usr/bin/gpg"}}, // same value
+	}}
+	prog, origin, conflicts := p.MergedGPGProgram()
+	if prog != "/usr/bin/gpg" {
+		t.Errorf("expected /usr/bin/gpg, got %q", prog)
+	}
+	if origin != "99.yaml" {
+		t.Errorf("expected last-set origin 99.yaml, got %q", origin)
+	}
+	if len(conflicts) != 0 {
+		t.Errorf("same value across fragments should not produce a conflict, got: %v", conflicts)
+	}
+}
+
+func TestMergedGPGProgram_DifferentValues_LastWinsWithConflict(t *testing.T) {
+	p := Policy{Fragments: []Fragment{
+		{Path: "00-corp.yaml", GPG: config.GPGConfig{Program: "/opt/homebrew/bin/gpg"}},
+		{Path: "99-team.yaml", GPG: config.GPGConfig{Program: "/usr/bin/gpg"}},
+	}}
+	prog, origin, conflicts := p.MergedGPGProgram()
+	if prog != "/usr/bin/gpg" {
+		t.Errorf("expected last-wins /usr/bin/gpg, got %q", prog)
+	}
+	if origin != "99-team.yaml" {
+		t.Errorf("expected origin 99-team.yaml, got %q", origin)
+	}
+	if len(conflicts) != 1 {
+		t.Fatalf("expected 1 conflict warning, got %d: %v", len(conflicts), conflicts)
+	}
+	wantSubstrs := []string{
+		"policy conflict on gpg.program",
+		"overridden to \"/usr/bin/gpg\" by 99-team.yaml",
+		"previous value \"/opt/homebrew/bin/gpg\" from 00-corp.yaml",
+	}
+	for _, s := range wantSubstrs {
+		if !strings.Contains(conflicts[0], s) {
+			t.Errorf("conflict warning missing %q\ngot: %s", s, conflicts[0])
+		}
+	}
+}
+
+func TestMergedGPGProgram_ChainOfDifferingFragments_NWarnings(t *testing.T) {
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", GPG: config.GPGConfig{Program: "/a"}},
+		{Path: "50.yaml", GPG: config.GPGConfig{Program: "/b"}},
+		{Path: "99.yaml", GPG: config.GPGConfig{Program: "/c"}},
+	}}
+	prog, _, conflicts := p.MergedGPGProgram()
+	if prog != "/c" {
+		t.Errorf("expected last-wins /c, got %q", prog)
+	}
+	if len(conflicts) != 2 {
+		t.Fatalf("expected 2 conflicts (a→b, b→c), got %d: %v", len(conflicts), conflicts)
+	}
+}
+
+// --- MergedBehavior tests ---
+
+func ptrBool(v bool) *bool { return &v }
+
+func TestMergedBehavior_NoFragmentsSet(t *testing.T) {
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml"},
+	}}
+	b, origins, conflicts := p.MergedBehavior()
+	if b.RequireExplicitVaultUpgrade != nil || b.RestrictToConfiguredVaults != nil {
+		t.Errorf("expected zero behavior, got %+v", b)
+	}
+	if len(origins) != 0 || len(conflicts) != 0 {
+		t.Errorf("expected no origins/conflicts, got origins=%v conflicts=%v", origins, conflicts)
+	}
+}
+
+func TestMergedBehavior_SingleFragment_OneField(t *testing.T) {
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", Behavior: config.BehaviorConfig{
+			RestrictToConfiguredVaults: ptrBool(true),
+		}},
+	}}
+	b, origins, conflicts := p.MergedBehavior()
+	if b.RestrictToConfiguredVaults == nil || !*b.RestrictToConfiguredVaults {
+		t.Errorf("expected RestrictToConfiguredVaults=true, got %v", b.RestrictToConfiguredVaults)
+	}
+	if b.RequireExplicitVaultUpgrade != nil {
+		t.Errorf("expected RequireExplicitVaultUpgrade=nil, got %v", b.RequireExplicitVaultUpgrade)
+	}
+	if origins["behavior.restrict_to_configured_vaults"] != "00.yaml" {
+		t.Errorf("expected origin 00.yaml, got %v", origins)
+	}
+	if len(conflicts) != 0 {
+		t.Errorf("expected no conflicts, got: %v", conflicts)
+	}
+}
+
+func TestMergedBehavior_PerFieldIndependence(t *testing.T) {
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", Behavior: config.BehaviorConfig{
+			RequireExplicitVaultUpgrade: ptrBool(true),
+		}},
+		{Path: "99.yaml", Behavior: config.BehaviorConfig{
+			RestrictToConfiguredVaults: ptrBool(true),
+		}},
+	}}
+	b, origins, conflicts := p.MergedBehavior()
+	if b.RequireExplicitVaultUpgrade == nil || !*b.RequireExplicitVaultUpgrade {
+		t.Errorf("expected RequireExplicitVaultUpgrade=true, got %v", b.RequireExplicitVaultUpgrade)
+	}
+	if b.RestrictToConfiguredVaults == nil || !*b.RestrictToConfiguredVaults {
+		t.Errorf("expected RestrictToConfiguredVaults=true, got %v", b.RestrictToConfiguredVaults)
+	}
+	if origins["behavior.require_explicit_vault_upgrade"] != "00.yaml" {
+		t.Errorf("expected require_explicit origin 00.yaml, got %v", origins)
+	}
+	if origins["behavior.restrict_to_configured_vaults"] != "99.yaml" {
+		t.Errorf("expected restrict_to origin 99.yaml, got %v", origins)
+	}
+	if len(conflicts) != 0 {
+		t.Errorf("per-field independence should produce no conflicts, got: %v", conflicts)
+	}
+}
+
+func TestMergedBehavior_SameField_DifferentValues_LastWinsWithConflict(t *testing.T) {
+	p := Policy{Fragments: []Fragment{
+		{Path: "00-corp.yaml", Behavior: config.BehaviorConfig{
+			RestrictToConfiguredVaults: ptrBool(false),
+		}},
+		{Path: "99-team.yaml", Behavior: config.BehaviorConfig{
+			RestrictToConfiguredVaults: ptrBool(true),
+		}},
+	}}
+	b, origins, conflicts := p.MergedBehavior()
+	if b.RestrictToConfiguredVaults == nil || !*b.RestrictToConfiguredVaults {
+		t.Errorf("expected last-wins true, got %v", b.RestrictToConfiguredVaults)
+	}
+	if origins["behavior.restrict_to_configured_vaults"] != "99-team.yaml" {
+		t.Errorf("expected origin 99-team.yaml, got %v", origins)
+	}
+	if len(conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %d: %v", len(conflicts), conflicts)
+	}
+	if !strings.Contains(conflicts[0], "behavior.restrict_to_configured_vaults") ||
+		!strings.Contains(conflicts[0], "99-team.yaml") ||
+		!strings.Contains(conflicts[0], "00-corp.yaml") {
+		t.Errorf("conflict missing expected substrings: %s", conflicts[0])
+	}
+}
+
+func TestMergedBehavior_SameField_SameValue_NoConflict(t *testing.T) {
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", Behavior: config.BehaviorConfig{
+			RestrictToConfiguredVaults: ptrBool(true),
+		}},
+		{Path: "99.yaml", Behavior: config.BehaviorConfig{
+			RestrictToConfiguredVaults: ptrBool(true),
+		}},
+	}}
+	_, _, conflicts := p.MergedBehavior()
+	if len(conflicts) != 0 {
+		t.Errorf("same value across fragments should not produce a conflict, got: %v", conflicts)
+	}
+}
+
+// --- Apply scalar override tests ---
+
+func TestApply_GPGProgram_PolicySetUserUnset_NoWarning(t *testing.T) {
+	cfg := config.Config{GPG: config.GPGConfig{Program: ""}}
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", GPG: config.GPGConfig{Program: "/usr/bin/gpg"}},
+	}}
+	out, warnings := Apply(cfg, p)
+	if out.GPG.Program != "/usr/bin/gpg" {
+		t.Errorf("expected policy value /usr/bin/gpg, got %q", out.GPG.Program)
+	}
+	for _, w := range warnings {
+		if strings.Contains(w, "policy overrides user gpg.program") {
+			t.Errorf("did not expect override warning when user had no value, got: %s", w)
+		}
+	}
+}
+
+func TestApply_GPGProgram_PolicyOverridesUserDifferentValue_Warning(t *testing.T) {
+	cfg := config.Config{GPG: config.GPGConfig{Program: "/opt/homebrew/bin/gpg"}}
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", GPG: config.GPGConfig{Program: "/usr/bin/gpg"}},
+	}}
+	out, warnings := Apply(cfg, p)
+	if out.GPG.Program != "/usr/bin/gpg" {
+		t.Errorf("expected policy value /usr/bin/gpg, got %q", out.GPG.Program)
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "policy overrides user gpg.program") &&
+			strings.Contains(w, "/opt/homebrew/bin/gpg") &&
+			strings.Contains(w, "/usr/bin/gpg") &&
+			strings.Contains(w, "00.yaml") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected user-override warning, got: %v", warnings)
+	}
+}
+
+func TestApply_GPGProgram_PolicySameAsUser_NoWarning(t *testing.T) {
+	cfg := config.Config{GPG: config.GPGConfig{Program: "/usr/bin/gpg"}}
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", GPG: config.GPGConfig{Program: "/usr/bin/gpg"}},
+	}}
+	out, warnings := Apply(cfg, p)
+	if out.GPG.Program != "/usr/bin/gpg" {
+		t.Errorf("expected unchanged value, got %q", out.GPG.Program)
+	}
+	for _, w := range warnings {
+		if strings.Contains(w, "overrides user") {
+			t.Errorf("matched values should not produce override warning, got: %s", w)
+		}
+	}
+}
+
+func TestApply_Behavior_PolicyOverridesUserDifferentValue_Warning(t *testing.T) {
+	cfg := config.Config{Behavior: config.BehaviorConfig{
+		RestrictToConfiguredVaults: ptrBool(false),
+	}}
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", Behavior: config.BehaviorConfig{
+			RestrictToConfiguredVaults: ptrBool(true),
+		}},
+	}}
+	out, warnings := Apply(cfg, p)
+	if out.Behavior.RestrictToConfiguredVaults == nil || !*out.Behavior.RestrictToConfiguredVaults {
+		t.Errorf("expected policy value true, got %v", out.Behavior.RestrictToConfiguredVaults)
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, "policy overrides user behavior.restrict_to_configured_vaults") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected user-override warning, got: %v", warnings)
+	}
+}
+
+func TestApply_Behavior_NoPolicyConstraint_UserValueRetained(t *testing.T) {
+	cfg := config.Config{Behavior: config.BehaviorConfig{
+		RestrictToConfiguredVaults: ptrBool(true),
+	}}
+	// Policy has approved_algorithms but no behavior fields — just to make
+	// the policy non-empty; user behavior should be untouched.
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", ApprovedAlgorithms: []config.ApprovedAlgorithm{
+			{Algo: "RSA", MinBits: 2048},
+		}},
+	}}
+	out, _ := Apply(cfg, p)
+	if out.Behavior.RestrictToConfiguredVaults == nil || !*out.Behavior.RestrictToConfiguredVaults {
+		t.Errorf("expected user value retained when policy has no behavior constraint, got %v", out.Behavior.RestrictToConfiguredVaults)
+	}
+}
+
+func TestApply_ConflictWarningsAlsoSurfaceForUser(t *testing.T) {
+	// Two fragments disagree on gpg.program. The conflict should surface in
+	// Apply's warnings (in addition to the user-override warning).
+	cfg := config.Config{GPG: config.GPGConfig{Program: "/x/gpg"}}
+	p := Policy{Fragments: []Fragment{
+		{Path: "00.yaml", GPG: config.GPGConfig{Program: "/a/gpg"}},
+		{Path: "99.yaml", GPG: config.GPGConfig{Program: "/b/gpg"}},
+	}}
+	out, warnings := Apply(cfg, p)
+	if out.GPG.Program != "/b/gpg" {
+		t.Errorf("expected last-wins /b/gpg, got %q", out.GPG.Program)
+	}
+	var (
+		sawConflict bool
+		sawOverride bool
+	)
+	for _, w := range warnings {
+		if strings.Contains(w, "policy conflict on gpg.program") {
+			sawConflict = true
+		}
+		if strings.Contains(w, "policy overrides user gpg.program") {
+			sawOverride = true
+		}
+	}
+	if !sawConflict {
+		t.Errorf("expected cross-fragment conflict warning, got: %v", warnings)
+	}
+	if !sawOverride {
+		t.Errorf("expected user-override warning, got: %v", warnings)
 	}
 }
 


### PR DESCRIPTION
## Summary

Phase 2 of the policy directory plan (PR #3 of 3, completing the design at \`~/.claude/plans/layered-config-system-user-override.md\`). Lifts \`behavior\` and \`gpg\` from the forbidden-keys list and treats them as scalar policy fields with **last-fragment-to-set-wins** semantics — matching the Unix \`*.d\` drop-in convention used by \`sudoers.d\`, \`systemd unit drop-ins\`, \`nginx conf.d\`, etc.

### Schema additions

\`\`\`yaml
# /etc/dotsecenv/policy.d/00-corp-baseline.yaml
behavior:
  restrict_to_configured_vaults: true
  require_explicit_vault_upgrade: true
gpg:
  program: /usr/bin/gpg
\`\`\`

### Cross-fragment merge (last-fragment-to-set wins)

- Lexical filename order — naming convention \`00-base, 50-team, 99-overrides\` where **\`99-\` outranks \`00-\`** for scalars
- Same value across fragments emits no warning (it's redundant, not a conflict)
- Different values emit one stderr warning per chained override:
  \`\`\`
  warning: policy conflict on gpg.program: overridden to \"/usr/bin/gpg\" by /etc/dotsecenv/policy.d/99-team.yaml; previous value \"/opt/homebrew/bin/gpg\" from /etc/dotsecenv/policy.d/00-corp-baseline.yaml
  \`\`\`
- For \`behavior.*\`, sub-fields are independent: fragment A setting \`behavior.X\` and fragment B setting \`behavior.Y\` do not conflict
- **\"Set\" detection:** \`behavior.*\` uses \`*bool\` nil-ness (\`false\` is a real value distinct from omitted); \`gpg.program\` uses empty-string (the \`\"PATH\"\` sentinel is a real value distinct from empty)

### User vs policy (policy overrides user)

When policy sets a scalar, it replaces the user's value. If the user had a *different* value, an override warning surfaces the silent change:

\`\`\`
warning: policy overrides user gpg.program: user value \"/opt/homebrew/bin/gpg\" replaced by \"/usr/bin/gpg\" from /etc/dotsecenv/policy.d/00-corp-baseline.yaml
\`\`\`

Same value = no warning. Both kinds of warnings respect \`-s\`.

### \`dotsecenv policy list\` (text + \`--json\`) extensions

Adds \`behavior:\` and \`gpg.program:\` sections with per-field origin attribution.

### Forbidden keys list narrowed

Only \`login\` (per-user identity, not org-wide) and \`vault\` (would erase user vaults; use \`approved_vault_paths\` instead) remain forbidden. \`behavior\` and \`gpg\` are now legitimate.

### Implementation notes

- \`behaviorFields\` closure-list pattern in \`merge.go\` keeps \`MergedBehavior\` independent of how many sub-fields \`BehaviorConfig\` has — adding a new behavior field is a one-line append, no merge-engine changes
- Cross-fragment conflict warnings come from \`MergedBehavior\` / \`MergedGPGProgram\`; user-override warnings come from the apply step; both surface in \`policy.Apply\`'s warnings slice and respect \`-s\`

## Test plan

- [x] \`make test\` — all tests pass (verified locally)
- [x] \`make test -race\` — clean (verified locally)
- [x] \`make lint\` — clean (verified locally; lefthook ran on commit)
- [x] Manual: \`./bin/dotsecenv policy list/validate\` (text + --json) work against missing /etc/dotsecenv/policy.d/

## Coverage

- Scalar merge: no fragments set, single fragment, same-value across fragments, different values with conflict warning, chain of N differing fragments → N-1 conflict warnings, per-field independence for behavior
- Apply: policy-set-user-unset (no override warning), policy-overrides-user-different-value (override warning), policy-same-as-user (no warning), no-policy-constraint (user value retained), conflict + override warnings both surface
- Schema: \`behavior:\` and \`gpg:\` accepted (was forbidden in PR #1)

## Related

- Design: \`~/.claude/plans/layered-config-system-user-override.md\`
- PR #1 #114: machinery + \`approved_algorithms\`
- PR #2 #115: \`approved_vault_paths\` + policy hardening + \`policy validate --json\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)