### PR TITLE
docs: add examples/ with self-contained scenarios

### DIFF
--- a/examples/01-quickstart/README.md
+++ b/examples/01-quickstart/README.md
@@ -1,0 +1,103 @@
+# Example 01 — Quickstart
+
+The minimum useful flow: encrypt one secret, decrypt it, and inspect the
+vault. End-to-end runnable in under ten seconds with zero state outside a
+tempdir.
+
+## What this demonstrates
+
+- The four bootstrap commands every dotsecenv user runs once: `init config`,
+  `init vault`, `login`, plus `identity create` if you do not already have a
+  GPG key.
+- The two everyday commands: `secret store` (stdin -> encrypted vault entry)
+  and `secret get` (vault entry -> stdout).
+- Two read-only inspection commands: `vault describe` (identities and secret
+  keys) and `validate` (structural sanity check on config and vault).
+
+## Run it
+
+From inside this directory:
+
+```bash
+./run.sh
+```
+
+The script generates an ephemeral RSA-4096 key in an isolated `GNUPGHOME`,
+walks through the full flow against a tempdir-only config and vault, and
+removes everything on exit.
+
+## Expected output
+
+You should see a sequence that looks roughly like this (timestamps and
+fingerprints will differ):
+
+```
+==> using binary: /path/to/dotsecenv
+==> tempdir: /tmp/tmp.XXXXXXXX
+==> GNUPGHOME: /tmp/tmp.XXXXXXXX/gnupg
+==> generating CI-only RSA-4096 key (no passphrase)
+==> fingerprint: FA5760BB43B4949DDD46342735EF443EF68A9396
+==> dotsecenv init config (pointing -v at our isolated vault path)
+Initialized config file: /tmp/tmp.XXXXXXXX/config
+==> dotsecenv init vault
+Initialized empty vault: /tmp/tmp.XXXXXXXX/vault
+==> dotsecenv login (records a signed login proof in the config)
+Logging in with identity: Quickstart Demo <quickstart@example.invalid> (RSA 4096-bit)
+Login successful! Signed proof stored in config.
+==> dotsecenv secret store DATABASE_PASSWORD
+Secret 'DATABASE_PASSWORD' stored successfully
+==> dotsecenv secret get DATABASE_PASSWORD
+my-database-password
+==> dotsecenv secret get  (no args -> list keys, never values)
+DATABASE_PASSWORD
+==> dotsecenv vault describe
+Vault 1 (/tmp/tmp.XXXXXXXX/vault):
+  Identities:
+    - Quickstart Demo <quickstart@example.invalid> (FA5760BB43B...)
+  Secrets:
+    - DATABASE_PASSWORD
+==> dotsecenv validate
+... all checks passed ...
+==> done.
+```
+
+You will also see a "decrypting in non-interactive terminal" warning printed
+to stderr by `secret get`. That warning is correct: real-world workflows
+should run inside a TTY (or behind the shell plugin) so the GPG agent can
+prompt for the passphrase. The script suppresses it would defeat the purpose
+of the warning, so we leave it visible.
+
+## Files
+
+- `run.sh` — the full, runnable flow. Idempotent (re-runnable from scratch
+  every time because every artifact lives in a fresh tempdir).
+- `README.md` — this file.
+
+## Cleanup
+
+The script's `trap ... EXIT` removes the tempdir and shuts down the
+per-tempdir gpg-agent on every exit path (success, failure, Ctrl-C). There is
+nothing to clean up by hand.
+
+## Adapting this to your machine
+
+Three things change when you run dotsecenv outside a script:
+
+1. **Use your real GPG key** instead of generating one. Drop the
+   `identity create` block; capture the fingerprint with
+   `gpg --list-keys --with-colons | awk -F: '/^fpr/ {print $10; exit}'`
+   (or whichever key you prefer).
+2. **Drop the `-c "$CONFIG"` flags.** dotsecenv uses
+   `$XDG_CONFIG_HOME/dotsecenv/config` (typically
+   `~/.config/dotsecenv/config`) by default — that is the right place for
+   your real config to live.
+3. **Pick a real vault location.** `~/.local/share/dotsecenv/vault` is the
+   convention used by `install.sh`; project-local vaults live at
+   `./.dotsecenv/vault` and are picked up by the shell plugin.
+
+## Related
+
+- Tutorial: <https://dotsecenv.com/tutorials/quickstart/>
+- Concepts (vault format, append-only history): <https://dotsecenv.com/concepts/>
+- The `demos/demo.sh` recording in this repo is the asciinema source for the
+  homepage demo and follows the same flow.

--- a/examples/01-quickstart/README.md
+++ b/examples/01-quickstart/README.md
@@ -64,8 +64,8 @@ Vault 1 (/tmp/tmp.XXXXXXXX/vault):
 You will also see a "decrypting in non-interactive terminal" warning printed
 to stderr by `secret get`. That warning is correct: real-world workflows
 should run inside a TTY (or behind the shell plugin) so the GPG agent can
-prompt for the passphrase. The script suppresses it would defeat the purpose
-of the warning, so we leave it visible.
+prompt for the passphrase. The script could suppress the warning, but doing
+so would defeat its purpose, so we leave it visible.
 
 ## Files
 
@@ -83,15 +83,15 @@ nothing to clean up by hand.
 
 Three things change when you run dotsecenv outside a script:
 
-1. **Use your real GPG key** instead of generating one. Drop the
-   `identity create` block; capture the fingerprint with
+1. Use your real GPG key instead of generating one. Drop the
+   `identity create` block and capture the fingerprint with
    `gpg --list-keys --with-colons | awk -F: '/^fpr/ {print $10; exit}'`
    (or whichever key you prefer).
-2. **Drop the `-c "$CONFIG"` flags.** dotsecenv uses
+2. Drop the `-c "$CONFIG"` flags. dotsecenv uses
    `$XDG_CONFIG_HOME/dotsecenv/config` (typically
-   `~/.config/dotsecenv/config`) by default — that is the right place for
+   `~/.config/dotsecenv/config`) by default, which is the right place for
    your real config to live.
-3. **Pick a real vault location.** `~/.local/share/dotsecenv/vault` is the
+3. Pick a real vault location. `~/.local/share/dotsecenv/vault` is the
    convention used by `install.sh`; project-local vaults live at
    `./.dotsecenv/vault` and are picked up by the shell plugin.
 

--- a/examples/01-quickstart/run.sh
+++ b/examples/01-quickstart/run.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# 01-quickstart/run.sh
+#
+# Demonstrates the canonical dotsecenv workflow:
+#   1. Generate an ephemeral GPG key (CI-only, no passphrase)
+#   2. dotsecenv init config           -- create a config pointing at our vault
+#   3. dotsecenv init vault            -- create the encrypted vault file
+#   4. dotsecenv login <FINGERPRINT>   -- record a signed login proof in config
+#   5. dotsecenv secret store NAME     -- encrypt and append a secret
+#   6. dotsecenv secret get NAME       -- decrypt and print the secret
+#   7. dotsecenv vault describe        -- show identities and secret keys
+#   8. dotsecenv validate              -- structural sanity check
+#
+# Everything happens inside a tempdir; no file outside $TMP is written.
+# See ../README.md ("Safety conventions") for the isolation rules.
+
+set -euo pipefail
+
+# --- locate the binary -------------------------------------------------------
+
+if command -v dotsecenv >/dev/null 2>&1; then
+  BIN="$(command -v dotsecenv)"
+elif [[ -x "$(git rev-parse --show-toplevel 2>/dev/null)/bin/dotsecenv" ]]; then
+  BIN="$(git rev-parse --show-toplevel)/bin/dotsecenv"
+else
+  cat >&2 <<'EOF'
+error: dotsecenv binary not found.
+  - Install via https://get.dotsecenv.com/install.sh, or
+  - Run `make build` from the repo root and re-run this script.
+EOF
+  exit 1
+fi
+echo "==> using binary: $BIN"
+
+# --- isolated tempdir --------------------------------------------------------
+
+TMP="$(mktemp -d)"
+# Always clean up: remove the tempdir and shut down the per-tempdir gpg-agent.
+trap 'rm -rf "$TMP"; gpgconf --kill all >/dev/null 2>&1 || true' EXIT
+
+export GNUPGHOME="$TMP/gnupg"
+mkdir -p "$GNUPGHOME"
+chmod 700 "$GNUPGHOME"
+
+CONFIG="$TMP/config"
+VAULT="$TMP/vault"
+
+echo "==> tempdir: $TMP"
+echo "==> GNUPGHOME: $GNUPGHOME"
+
+# --- generate an ephemeral GPG key ------------------------------------------
+
+# RSA4096 is the most portable choice across GPG versions on CI runners and
+# old Linux distributions. ED25519 is preferable on a modern machine.
+echo "==> generating CI-only RSA-4096 key (no passphrase)"
+"$BIN" identity create \
+  --algo RSA4096 \
+  --name "Quickstart Demo" \
+  --email "quickstart@example.invalid" \
+  --no-passphrase \
+  >"$TMP/keygen.log" 2>&1
+
+# Pull the fingerprint of the just-created key out of the keyring.
+FINGERPRINT="$(gpg --list-keys --with-colons quickstart@example.invalid \
+  | awk -F: '/^fpr:/ { print $10; exit }')"
+echo "==> fingerprint: $FINGERPRINT"
+
+# --- dotsecenv setup --------------------------------------------------------
+
+echo "==> dotsecenv init config (pointing -v at our isolated vault path)"
+"$BIN" -c "$CONFIG" init config -v "$VAULT"
+
+echo "==> dotsecenv init vault"
+"$BIN" -c "$CONFIG" init vault -v "$VAULT"
+
+echo "==> dotsecenv login (records a signed login proof in the config)"
+"$BIN" -c "$CONFIG" login "$FINGERPRINT"
+
+# --- the actual secret roundtrip --------------------------------------------
+
+echo "==> dotsecenv secret store DATABASE_PASSWORD"
+# Read the value from stdin; that is the only way to write to a vault.
+echo "my-database-password" | "$BIN" -c "$CONFIG" secret store DATABASE_PASSWORD
+
+echo "==> dotsecenv secret get DATABASE_PASSWORD"
+"$BIN" -c "$CONFIG" secret get DATABASE_PASSWORD
+
+echo "==> dotsecenv secret get  (no args -> list keys, never values)"
+"$BIN" -c "$CONFIG" secret get
+
+# --- inspect & validate -----------------------------------------------------
+
+echo "==> dotsecenv vault describe"
+"$BIN" -c "$CONFIG" vault describe
+
+echo "==> dotsecenv validate"
+"$BIN" -c "$CONFIG" validate
+
+echo
+echo "==> done. Tempdir $TMP will be removed on exit."

--- a/examples/02-team-share-revoke/README.md
+++ b/examples/02-team-share-revoke/README.md
@@ -1,0 +1,105 @@
+# Example 02 — Team share + revoke + rotate
+
+How dotsecenv's multi-recipient encryption and revocation actually work in
+practice, with two ephemeral identities sharing a single vault and an honest
+demonstration of the append-only history semantics.
+
+## What this demonstrates
+
+- **Multi-recipient encryption.** Alice stores `API_KEY` and shares it with
+  Bob; both can decrypt it independently with their own private keys.
+- **Independent keyrings.** The script uses two separate `GNUPGHOME`
+  directories — one per identity — to keep each user's secret key isolated
+  from the other (matching the production model of one-key-per-machine).
+  Public keys are exported and imported between them, exactly as you would
+  do over email or chat.
+- **Revoke is forward-looking.** `secret revoke FP` removes a fingerprint
+  from the recipient set for *future* writes; it does not rewrite history.
+- **Rotation is what hides a secret.** After Alice revokes Bob she rotates
+  the value with `secret store`; the new entry is encrypted only to her.
+  Bob's `secret get` falls back to the most recent entry he was a recipient
+  of (the old v1 value), and `secret get --all` shows decryption errors for
+  the rotated entry he is no longer a recipient of.
+
+## Run it
+
+```bash
+./run.sh
+```
+
+## Expected output (key moments)
+
+```
+==> [Bob] login with Bob's keyring and decrypt API_KEY
+    expected: v1-shared
+    actual:   v1-shared
+
+==> [Alice] revoke Bob from API_KEY, then rotate API_KEY=v2
+... revoked access to secret 'API_KEY' for <Bob's fingerprint>
+Secret 'API_KEY' stored successfully
+
+==> [Alice] reads the latest value (expected: v2-rotated)
+    actual:   v2-rotated
+
+==> [Bob] tries to read after revoke + rotate.
+    actual:   v1-shared        # <-- the OLD value, NOT v2-rotated
+
+==> [Bob] secret get --all shows every entry he can decrypt.
+    Notice v2-rotated is absent: it was only ever encrypted to Alice.
+... warning: failed to decrypt value from <timestamp>: ... No secret key
+... <ciphertext entries Bob is not a recipient of fail>
+2026-... v1-shared           # <-- the only entry Bob can still decrypt
+```
+
+The decryption-failure warnings on Bob's `--all` listing are the demo's
+punchline: the v2 ciphertext exists in the vault file (the format is
+append-only) but Bob does not hold the right private key to read it.
+
+## Why two `GNUPGHOME` directories?
+
+If you put both Alice's and Bob's secret keys in a single keyring the demo
+becomes misleading: the GPG agent will silently use whichever key works,
+which masks the access-control story. With one `GNUPGHOME` per identity,
+each `dotsecenv` invocation can only succeed if the *invoker's* private key
+is allowed to decrypt the entry — which is the real production constraint.
+
+In real life:
+- Alice's machine has her secret key only.
+- Bob exports his **public** key (`gpg --armor --export FP`) and sends it to
+  Alice (email, chat, key server, however).
+- Alice imports it (`gpg --import bob.pub`) and shares secrets to Bob's
+  fingerprint.
+- Each laptop only ever holds its owner's secret key.
+
+The script collapses both keyrings into one tempdir for repeatability, but
+keeps them strictly partitioned via `GNUPGHOME=...` on every command.
+
+## Operational guidance
+
+- **Revoke before rotating, not after.** If you forget to revoke, the next
+  write still encrypts to the old recipient set. The order in this example
+  (`revoke`, then `store` to rotate) is the right one.
+- **Bob's old plaintext still leaks if he saved it.** Revocation is about
+  ciphertext access, not memory: a former teammate who already decrypted
+  v1 still knows v1. Rotation requires a value change at the source
+  (database password rotation, new API key, etc.).
+- **`secret share --all`** does the same encryption to all vaults where the
+  secret already exists; useful when you have prod/staging vaults
+  side-by-side. See `dotsecenv secret share --help`.
+- **`secret revoke --all`** does the symmetric operation for revocation.
+
+## Files
+
+- `run.sh` — full end-to-end demonstration with two isolated `GNUPGHOME`s.
+- `README.md` — this file.
+
+## Cleanup
+
+The script's `trap ... EXIT` removes the tempdir and shuts down per-tempdir
+gpg-agents on every exit path.
+
+## Related
+
+- Concepts (append-only vault, threat model): <https://dotsecenv.com/concepts/>
+- Guide: <https://dotsecenv.com/guides/team-collaboration/>
+- Example 01 (the basic vault flow this builds on): [../01-quickstart/](../01-quickstart/)

--- a/examples/02-team-share-revoke/README.md
+++ b/examples/02-team-share-revoke/README.md
@@ -1,25 +1,25 @@
 # Example 02 — Team share + revoke + rotate
 
-How dotsecenv's multi-recipient encryption and revocation actually work in
-practice, with two ephemeral identities sharing a single vault and an honest
-demonstration of the append-only history semantics.
+How dotsecenv's multi-recipient encryption and revocation work in practice.
+Two ephemeral identities share a vault, then walk through the append-only
+history semantics that make `revoke` a forward-looking operation rather than
+a delete.
 
 ## What this demonstrates
 
-- **Multi-recipient encryption.** Alice stores `API_KEY` and shares it with
-  Bob; both can decrypt it independently with their own private keys.
-- **Independent keyrings.** The script uses two separate `GNUPGHOME`
-  directories — one per identity — to keep each user's secret key isolated
-  from the other (matching the production model of one-key-per-machine).
-  Public keys are exported and imported between them, exactly as you would
-  do over email or chat.
-- **Revoke is forward-looking.** `secret revoke FP` removes a fingerprint
-  from the recipient set for *future* writes; it does not rewrite history.
-- **Rotation is what hides a secret.** After Alice revokes Bob she rotates
-  the value with `secret store`; the new entry is encrypted only to her.
-  Bob's `secret get` falls back to the most recent entry he was a recipient
-  of (the old v1 value), and `secret get --all` shows decryption errors for
-  the rotated entry he is no longer a recipient of.
+- Multi-recipient encryption: Alice stores `API_KEY` and shares it with Bob;
+  both can decrypt it independently with their own private keys.
+- Independent keyrings: the script uses two separate `GNUPGHOME` directories,
+  one per identity, to keep each user's secret key isolated from the other.
+  This matches production (one key per machine). Public keys move between
+  them just as they would over email or chat.
+- Revoke is forward-looking: `secret revoke FP` removes a fingerprint from
+  the recipient set for *future* writes. It does not rewrite history.
+- Rotation is what actually hides a value. After Alice revokes Bob she
+  rotates the secret with `secret store`; the new entry is encrypted only
+  to her. Bob's `secret get` falls back to the most recent entry he was a
+  recipient of (the old v1), and `secret get --all` produces decryption
+  errors for the rotated entry he is no longer a recipient of.
 
 ## Run it
 
@@ -76,17 +76,17 @@ keeps them strictly partitioned via `GNUPGHOME=...` on every command.
 
 ## Operational guidance
 
-- **Revoke before rotating, not after.** If you forget to revoke, the next
-  write still encrypts to the old recipient set. The order in this example
+- Revoke before rotating, not after. If you forget to revoke, the next write
+  still encrypts to the old recipient set. The order in this example
   (`revoke`, then `store` to rotate) is the right one.
-- **Bob's old plaintext still leaks if he saved it.** Revocation is about
-  ciphertext access, not memory: a former teammate who already decrypted
-  v1 still knows v1. Rotation requires a value change at the source
-  (database password rotation, new API key, etc.).
-- **`secret share --all`** does the same encryption to all vaults where the
-  secret already exists; useful when you have prod/staging vaults
-  side-by-side. See `dotsecenv secret share --help`.
-- **`secret revoke --all`** does the symmetric operation for revocation.
+- Bob's old plaintext still leaks if he saved it anywhere. Revocation is
+  about ciphertext access, not memory: a former teammate who already
+  decrypted v1 still knows v1. Hiding the value for real requires changing
+  it at the source (rotate the database password, issue a new API key, etc.).
+- `secret share --all` shares to every vault where the secret already
+  exists, which is useful when you keep prod/staging vaults side by side.
+  See `dotsecenv secret share --help`.
+- `secret revoke --all` is the symmetric operation for revocation.
 
 ## Files
 

--- a/examples/02-team-share-revoke/run.sh
+++ b/examples/02-team-share-revoke/run.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+#
+# 02-team-share-revoke/run.sh
+#
+# Demonstrates dotsecenv's multi-recipient sharing model end-to-end.
+#
+# Real production use puts each identity on a different machine. To make that
+# faithful in a single shell, we run with TWO independent $GNUPGHOME
+# directories and keep each user's secret key isolated to their own home.
+# We then export only the *public* key when one user wants to share with the
+# other (the same dance you would do via `gpg --export | gpg --import` between
+# laptops).
+#
+# Flow:
+#   1. ALICE's GNUPGHOME has only Alice's key. Alice initializes the vault
+#      and stores API_KEY=v1.
+#   2. Alice imports BOB's public key into her keyring (so dotsecenv can
+#      encrypt to him) and `secret share`s the secret with Bob.
+#   3. BOB's GNUPGHOME (which has only Bob's key) decrypts the secret. He sees
+#      v1 because he was a recipient at the time it was stored.
+#   4. Alice revokes Bob, then rotates API_KEY=v2. Because dotsecenv vaults
+#      are append-only, all the old v1 entries are still there — but the new
+#      v2 entry is encrypted only to Alice.
+#   5. Bob can still decrypt the v1 entries (history doesn't get rewritten);
+#      Bob CANNOT decrypt v2.
+#
+# This is the right mental model for production:
+#   - `secret revoke FP` removes that fingerprint from the recipient set going
+#     forward, but it does NOT destroy ciphertext that was already encrypted
+#     to them.
+#   - To make a secret unreadable to a former recipient, ROTATE it (overwrite
+#     with a new value via `secret store`). That new entry is encrypted to
+#     the current recipient set only.
+
+set -euo pipefail
+
+# --- locate the binary -------------------------------------------------------
+
+if command -v dotsecenv >/dev/null 2>&1; then
+  BIN="$(command -v dotsecenv)"
+elif [[ -x "$(git rev-parse --show-toplevel 2>/dev/null)/bin/dotsecenv" ]]; then
+  BIN="$(git rev-parse --show-toplevel)/bin/dotsecenv"
+else
+  cat >&2 <<'EOF'
+error: dotsecenv binary not found.
+  - Install via https://get.dotsecenv.com/install.sh, or
+  - Run `make build` from the repo root and re-run this script.
+EOF
+  exit 1
+fi
+echo "==> using binary: $BIN"
+
+# --- isolated tempdir --------------------------------------------------------
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"; gpgconf --kill all >/dev/null 2>&1 || true' EXIT
+
+ALICE_GNUPG="$TMP/alice-gnupg"
+BOB_GNUPG="$TMP/bob-gnupg"
+mkdir -p "$ALICE_GNUPG" "$BOB_GNUPG"
+chmod 700 "$ALICE_GNUPG" "$BOB_GNUPG"
+
+CONFIG="$TMP/config"
+VAULT="$TMP/vault"
+
+echo "==> tempdir: $TMP"
+
+# --- generate Alice in her own keyring ---------------------------------------
+
+echo "==> [Alice's keyring] generate Alice's key"
+GNUPGHOME="$ALICE_GNUPG" "$BIN" identity create \
+  --algo RSA4096 \
+  --name "Alice (demo)" \
+  --email "alice@example.invalid" \
+  --no-passphrase \
+  >"$TMP/alice-keygen.log" 2>&1
+
+ALICE_FP="$(GNUPGHOME="$ALICE_GNUPG" gpg --list-keys --with-colons \
+  alice@example.invalid | awk -F: '/^fpr:/ { print $10; exit }')"
+echo "==> Alice fingerprint: $ALICE_FP"
+
+# --- generate Bob in his own keyring ----------------------------------------
+
+echo "==> [Bob's keyring] generate Bob's key"
+GNUPGHOME="$BOB_GNUPG" "$BIN" identity create \
+  --algo RSA4096 \
+  --name "Bob (demo)" \
+  --email "bob@example.invalid" \
+  --no-passphrase \
+  >"$TMP/bob-keygen.log" 2>&1
+
+BOB_FP="$(GNUPGHOME="$BOB_GNUPG" gpg --list-keys --with-colons \
+  bob@example.invalid | awk -F: '/^fpr:/ { print $10; exit }')"
+echo "==> Bob fingerprint:   $BOB_FP"
+
+# --- Bob exports his public key; Alice imports it ---------------------------
+
+# In production: Bob runs `gpg --armor --export FP`, sends the output by email
+# or chat, and Alice imports it. Same effect as the pipe below.
+GNUPGHOME="$BOB_GNUPG" gpg --armor --export "$BOB_FP" \
+  | GNUPGHOME="$ALICE_GNUPG" gpg --import 2>"$TMP/alice-import.log"
+
+echo "==> Alice imported Bob's public key"
+
+# --- bootstrap the vault as Alice -------------------------------------------
+
+echo
+echo "==> [Alice] init config + vault, login, store API_KEY=v1"
+GNUPGHOME="$ALICE_GNUPG" "$BIN" -c "$CONFIG" init config -v "$VAULT" >/dev/null
+GNUPGHOME="$ALICE_GNUPG" "$BIN" -c "$CONFIG" init vault  -v "$VAULT" >/dev/null
+GNUPGHOME="$ALICE_GNUPG" "$BIN" -c "$CONFIG" login "$ALICE_FP" >/dev/null
+echo "v1-shared" | GNUPGHOME="$ALICE_GNUPG" "$BIN" -c "$CONFIG" secret store API_KEY
+
+echo "==> [Alice] share API_KEY with Bob"
+GNUPGHOME="$ALICE_GNUPG" "$BIN" -c "$CONFIG" secret share API_KEY "$BOB_FP"
+
+echo
+echo "==> Vault now has both identities and one shared secret:"
+GNUPGHOME="$ALICE_GNUPG" "$BIN" -c "$CONFIG" vault describe
+
+# --- Bob reads the shared secret with his own keyring -----------------------
+
+echo
+echo "==> [Bob] login with Bob's keyring and decrypt API_KEY"
+GNUPGHOME="$BOB_GNUPG" "$BIN" -c "$CONFIG" login "$BOB_FP" >/dev/null
+echo "    expected: v1-shared"
+echo -n "    actual:   "
+GNUPGHOME="$BOB_GNUPG" "$BIN" -c "$CONFIG" secret get API_KEY
+
+# --- revoke Bob and rotate --------------------------------------------------
+
+echo
+echo "==> [Alice] revoke Bob from API_KEY, then rotate API_KEY=v2"
+GNUPGHOME="$ALICE_GNUPG" "$BIN" -c "$CONFIG" login "$ALICE_FP" >/dev/null
+GNUPGHOME="$ALICE_GNUPG" "$BIN" -c "$CONFIG" secret revoke API_KEY "$BOB_FP"
+echo "v2-rotated" | GNUPGHOME="$ALICE_GNUPG" "$BIN" -c "$CONFIG" secret store API_KEY
+
+echo
+echo "==> [Alice] reads the latest value (expected: v2-rotated)"
+echo -n "    actual:   "
+GNUPGHOME="$ALICE_GNUPG" "$BIN" -c "$CONFIG" secret get API_KEY
+
+# --- Bob tries again --------------------------------------------------------
+
+echo
+echo "==> [Bob] tries to read after revoke + rotate."
+echo "    The append-only vault still contains the v1 entries Bob was a"
+echo "    recipient of. dotsecenv falls back to the most recent entry Bob"
+echo "    can still decrypt — so 'secret get' prints v1, NOT v2."
+GNUPGHOME="$BOB_GNUPG" "$BIN" -c "$CONFIG" login "$BOB_FP" >/dev/null
+echo -n "    actual:   "
+GNUPGHOME="$BOB_GNUPG" "$BIN" -c "$CONFIG" secret get API_KEY
+
+echo
+echo "==> [Bob] secret get --all shows every entry he can decrypt."
+echo "    Notice v2-rotated is absent: it was only ever encrypted to Alice."
+GNUPGHOME="$BOB_GNUPG" "$BIN" -c "$CONFIG" secret get API_KEY --all
+
+echo
+echo "==> done. Tempdir $TMP will be removed on exit."

--- a/examples/03-ci-cd-github-action/README.md
+++ b/examples/03-ci-cd-github-action/README.md
@@ -19,14 +19,15 @@ secrets in GitHub repository secrets.
 
 Two reasons:
 
-1. **One private key in GitHub, many secrets in your repo.** With dotsecenv,
-   the private key is your CI identity; the actual secret values live in
-   the encrypted vault file inside the repo. Adding a new secret is a
+1. One private key in GitHub, many secrets in your repo. With dotsecenv the
+   private key is your CI identity; the actual secret values live in the
+   encrypted vault file inside the repo. Adding a new secret is a
    developer-machine `secret store` + `secret share` + commit — no GitHub
    repo-secret edit needed. Rotation is a developer-machine `secret store`
-   + commit. The list of secrets is visible to the team in the vault file.
-2. **Provenance.** Vault writes are signed by the identity that produced
-   them; you can audit who added or rotated each value.
+   + commit. The list of secret names is visible to the team in the vault
+   file.
+2. Provenance. Vault writes are signed by the identity that produced them,
+   so you can audit who added or rotated each value.
 
 If you need a single secret, use a GitHub repo secret directly. If you
 already manage many secrets and want them version-controlled and
@@ -123,18 +124,16 @@ piped through `::add-mask::` before `$GITHUB_ENV`.
 
 ## Threat model notes
 
-- **`--no-passphrase` keys are sensitive.** Anyone who can read the GitHub
-  repo secret can decrypt every vault entry the key is a recipient of.
-  Keep the secret tightly scoped (per repo, per environment), and rotate
-  periodically.
-- **Use environment-scoped secrets for production.** GitHub's "deployment
+- `--no-passphrase` keys are sensitive. Anyone who can read the GitHub repo
+  secret can decrypt every vault entry the key is a recipient of. Keep the
+  secret tightly scoped (per repo, per environment) and rotate periodically.
+- Use environment-scoped secrets for production. GitHub's "deployment
   environments" let you put `DOTSECENV_GPG_PRIVATE_KEY` behind a manual
   approval gate before it is exposed to the deploy job.
-- **Grant minimum recipient set.** Only `secret share` to the CI key the
-  secrets that CI actually needs. Everything else stays encrypted to humans
-  only.
-- **Verify provenance is on.** `verify-provenance: true` is the default and
-  gates installation on a Sigstore attestation match. Don't turn it off.
+- Grant the minimum recipient set. Only `secret share` to the CI key for the
+  secrets CI actually needs; everything else stays encrypted to humans only.
+- Keep provenance verification on. `verify-provenance: true` is the default
+  and gates installation on a Sigstore attestation match. Don't turn it off.
 
 ## Related
 

--- a/examples/03-ci-cd-github-action/README.md
+++ b/examples/03-ci-cd-github-action/README.md
@@ -1,0 +1,147 @@
+# Example 03 — CI/CD with the dotsecenv GitHub Action
+
+A complete, production-shaped GitHub Actions workflow that installs
+dotsecenv, imports a CI-only GPG key, decrypts secrets out of a checked-in
+vault file, and hands them to a deploy step — all without storing plaintext
+secrets in GitHub repository secrets.
+
+## What this demonstrates
+
+- Calling the `dotsecenv/dotsecenv@v0` composite action with provenance
+  verification enabled (SHA-256 checksums, GPG signature on
+  `checksums.txt`, and the Sigstore attestation on the archive).
+- Importing a CI-only GPG private key from a sealed repo secret and using it
+  as the dotsecenv identity for the job.
+- Decrypting secrets out of a committed vault and exposing them as masked
+  env vars to subsequent steps via `::add-mask::` and `$GITHUB_ENV`.
+
+## Why a GPG key in a repo secret instead of just GitHub secrets?
+
+Two reasons:
+
+1. **One private key in GitHub, many secrets in your repo.** With dotsecenv,
+   the private key is your CI identity; the actual secret values live in
+   the encrypted vault file inside the repo. Adding a new secret is a
+   developer-machine `secret store` + `secret share` + commit — no GitHub
+   repo-secret edit needed. Rotation is a developer-machine `secret store`
+   + commit. The list of secrets is visible to the team in the vault file.
+2. **Provenance.** Vault writes are signed by the identity that produced
+   them; you can audit who added or rotated each value.
+
+If you need a single secret, use a GitHub repo secret directly. If you
+already manage many secrets and want them version-controlled and
+multi-recipient encrypted, dotsecenv is the right shape.
+
+## Bootstrap procedure (do this once)
+
+You need a CI identity, its private key as a repo secret, and the matching
+public key on the vault's recipient list.
+
+```bash
+# 1. On a developer machine, generate a CI-only key (NO PASSPHRASE because
+#    GitHub Actions cannot answer a pinentry prompt).
+dotsecenv identity create \
+  --algo RSA4096 \
+  --name "CI ($GITHUB_REPOSITORY)" \
+  --email "ci@your-org.example" \
+  --no-passphrase
+
+# 2. Capture the fingerprint and export the private key in ASCII-armored form.
+FP=$(gpg --list-secret-keys --with-colons "ci@your-org.example" \
+  | awk -F: '/^fpr:/ { print $10; exit }')
+gpg --armor --export-secret-keys "$FP" > /tmp/dotsecenv-ci.asc
+
+# 3. Add the contents of /tmp/dotsecenv-ci.asc as a GitHub repo secret named
+#    DOTSECENV_GPG_PRIVATE_KEY. Two ways:
+#       a. Settings -> Secrets and variables -> Actions -> New repository secret
+#       b. gh CLI:  gh secret set DOTSECENV_GPG_PRIVATE_KEY < /tmp/dotsecenv-ci.asc
+
+# 4. Wipe the file from disk.
+shred -u /tmp/dotsecenv-ci.asc
+
+# 5. Share each secret your CI needs with the CI fingerprint, from the
+#    developer machine that already has the secret stored:
+dotsecenv secret share DATABASE_URL "$FP"
+dotsecenv secret share DEPLOY_TOKEN "$FP"
+
+# 6. Commit the updated vault file (.dotsecenv/vault).
+git add .dotsecenv/vault
+git commit -m "ci: grant CI identity access to deploy secrets"
+git push
+```
+
+The CI identity is now ready. Drop `workflow.yml` into your repo at
+`.github/workflows/deploy.yml` and it will run on every push to `main`.
+
+## Run it
+
+This example is configuration, not a runnable script. To exercise the
+workflow:
+
+1. Copy `workflow.yml` to `.github/workflows/deploy.yml` in your application
+   repo.
+2. Make sure you have a vault at `.dotsecenv/vault` with `DATABASE_URL` and
+   `DEPLOY_TOKEN` shared to your CI identity (see bootstrap above), or
+   change the secret names in the workflow to whatever your project uses.
+3. Push to `main` (or trigger via `workflow_dispatch`) and watch the run.
+
+## Expected output
+
+In the GitHub Actions log you should see:
+
+```
+Run dotsecenv/dotsecenv@v0
+... Resolving latest released version ...
+... Verifying GPG signature on checksums.txt ...
+... Verifying SHA-256 checksum ...
+... Verifying attestation ...
+... dotsecenv version v0.X.Y installed at $RUNNER_TEMP/dotsecenv-bin/dotsecenv
+
+Run dotsecenv init config -v .dotsecenv/vault
+... Initialized config file ...
+Run dotsecenv login <fingerprint>
+... Login successful! ...
+
+Run dotsecenv secret get DATABASE_URL
+::add-mask::***
+Run dotsecenv secret get DEPLOY_TOKEN
+::add-mask::***
+
+Run echo "DATABASE_URL is set: ${DATABASE_URL:+yes}"
+DATABASE_URL is set: yes
+DEPLOY_TOKEN is set: yes
+```
+
+Both env-var values appear as `***` in any subsequent log because they were
+piped through `::add-mask::` before `$GITHUB_ENV`.
+
+## Files
+
+- `workflow.yml` — the complete workflow. Copy to
+  `.github/workflows/deploy.yml` in your project.
+- `README.md` — this file.
+
+## Threat model notes
+
+- **`--no-passphrase` keys are sensitive.** Anyone who can read the GitHub
+  repo secret can decrypt every vault entry the key is a recipient of.
+  Keep the secret tightly scoped (per repo, per environment), and rotate
+  periodically.
+- **Use environment-scoped secrets for production.** GitHub's "deployment
+  environments" let you put `DOTSECENV_GPG_PRIVATE_KEY` behind a manual
+  approval gate before it is exposed to the deploy job.
+- **Grant minimum recipient set.** Only `secret share` to the CI key the
+  secrets that CI actually needs. Everything else stays encrypted to humans
+  only.
+- **Verify provenance is on.** `verify-provenance: true` is the default and
+  gates installation on a Sigstore attestation match. Don't turn it off.
+
+## Related
+
+- Action source and inputs reference: [`action.yml`](../../action.yml) at
+  the repo root, plus
+  <https://github.com/marketplace/actions/setup-dotsecenv>.
+- CI/CD guide (full reference): <https://dotsecenv.com/guides/ci-cd/>
+- Threat model: <https://dotsecenv.com/concepts/threat-model/>
+- Example 02 (the `secret share` mechanics this relies on):
+  [../02-team-share-revoke/](../02-team-share-revoke/)

--- a/examples/03-ci-cd-github-action/workflow.yml
+++ b/examples/03-ci-cd-github-action/workflow.yml
@@ -1,0 +1,130 @@
+# examples/03-ci-cd-github-action/workflow.yml
+#
+# A complete, copy-pasteable GitHub Actions workflow that:
+#   1. Installs dotsecenv from a verified release using the dotsecenv/dotsecenv
+#      composite action.
+#   2. Imports a CI-only GPG private key from a repository secret.
+#   3. Decrypts secrets out of the project's checked-in vault into job-scoped
+#      environment variables (and `$GITHUB_ENV` for downstream steps).
+#   4. Hands the decrypted secrets to a deploy step.
+#
+# Save this file at: .github/workflows/deploy.yml in your application repo.
+#
+# Required GitHub repository secrets:
+#   - DOTSECENV_GPG_PRIVATE_KEY  : ASCII-armored private key for the CI
+#                                  identity. Generated once on a developer
+#                                  machine and added as a sealed repo secret.
+#                                  See README.md for the bootstrap procedure.
+#
+# Required vault state in the repo:
+#   - .dotsecenv/vault           : the encrypted vault file, committed to git.
+#   - The CI identity's public key must be on the vault's recipient list for
+#     every secret this workflow needs (use `dotsecenv secret share` from a
+#     developer machine to grant CI access).
+
+name: deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    # All steps in this job inherit the GNUPGHOME the import step sets up.
+    env:
+      GNUPGHOME: ${{ runner.temp }}/gnupg
+
+    steps:
+      # ---------------------------------------------------------------------
+      # 1. Get the source (vault file lives at .dotsecenv/vault in the repo).
+      # ---------------------------------------------------------------------
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # ---------------------------------------------------------------------
+      # 2. Install dotsecenv from a verified release.
+      #
+      #    The composite action verifies SHA-256 checksums, GPG signatures on
+      #    `checksums.txt`, and the GitHub Actions attestation on the archive
+      #    (Sigstore). Set `version: 'v1.2.3'` to pin a specific release; the
+      #    default `latest` resolves the most recent published tag.
+      # ---------------------------------------------------------------------
+      - name: Install dotsecenv
+        uses: dotsecenv/dotsecenv@v0
+        with:
+          version: latest
+          # Set to false only if you fully trust the network path (you should
+          # not). Default is true.
+          verify-provenance: true
+
+      # ---------------------------------------------------------------------
+      # 3. Import the CI identity's private key and warm up gpg-agent.
+      #
+      #    The private key is generated ONCE on a developer machine with
+      #    `dotsecenv identity create --no-passphrase` (CI-only mode), then
+      #    added to the repo as a sealed secret called
+      #    DOTSECENV_GPG_PRIVATE_KEY. The "no-passphrase" choice is what makes
+      #    decryption non-interactive; protect the secret accordingly.
+      # ---------------------------------------------------------------------
+      - name: Import GPG private key
+        env:
+          DOTSECENV_GPG_PRIVATE_KEY: ${{ secrets.DOTSECENV_GPG_PRIVATE_KEY }}
+        run: |
+          mkdir -p "$GNUPGHOME"
+          chmod 700 "$GNUPGHOME"
+          echo "$DOTSECENV_GPG_PRIVATE_KEY" | gpg --batch --import
+          # Capture the fingerprint of the freshly-imported key for `login`.
+          FP=$(gpg --list-secret-keys --with-colons \
+            | awk -F: '/^fpr:/ { print $10; exit }')
+          echo "DOTSECENV_FP=$FP" >> "$GITHUB_ENV"
+
+      # ---------------------------------------------------------------------
+      # 4. Initialise dotsecenv against the project-local vault, then login.
+      # ---------------------------------------------------------------------
+      - name: Initialise dotsecenv
+        run: |
+          dotsecenv init config -v .dotsecenv/vault
+          dotsecenv login "$DOTSECENV_FP"
+
+      # ---------------------------------------------------------------------
+      # 5. Decrypt secrets and surface them to downstream steps.
+      #
+      #    Two patterns are shown:
+      #      a) ::add-mask::  to scrub the value from logs immediately.
+      #      b) >> $GITHUB_ENV  to make the value available as an env var to
+      #         every subsequent step (still automatically masked because we
+      #         called add-mask first).
+      #
+      #    NEVER `echo` a decrypted value to stdout without masking it first.
+      # ---------------------------------------------------------------------
+      - name: Decrypt secrets
+        run: |
+          set -euo pipefail
+          # Each secret you need: pull the value, mask it, then export it.
+          for SECRET in DATABASE_URL DEPLOY_TOKEN; do
+            VALUE=$(dotsecenv secret get "$SECRET")
+            echo "::add-mask::$VALUE"
+            # Use the heredoc form so values containing newlines or '=' are safe.
+            {
+              echo "$SECRET<<__DOTSECENV_EOF__"
+              echo "$VALUE"
+              echo "__DOTSECENV_EOF__"
+            } >> "$GITHUB_ENV"
+          done
+
+      # ---------------------------------------------------------------------
+      # 6. Use the secrets. They are present as $DATABASE_URL and
+      #    $DEPLOY_TOKEN, masked in logs by the add-mask calls above.
+      # ---------------------------------------------------------------------
+      - name: Run deploy
+        run: |
+          # Replace this with whatever your real deploy looks like.
+          echo "DATABASE_URL is set: ${DATABASE_URL:+yes}"
+          echo "DEPLOY_TOKEN is set: ${DEPLOY_TOKEN:+yes}"
+          # ./scripts/deploy.sh

--- a/examples/04-policy-directory/00-corp-baseline.yaml
+++ b/examples/04-policy-directory/00-corp-baseline.yaml
@@ -1,0 +1,69 @@
+# /etc/dotsecenv/policy.d/00-corp-baseline.yaml
+#
+# Org-wide baseline policy. Every dotsecenv user on this machine is
+# constrained by the union of the fragments in /etc/dotsecenv/policy.d/.
+# Lower-numbered files load first; for scalar fields ("last fragment to set
+# wins" — see 99-team-overrides.yaml) higher-numbered files override them.
+#
+# Required permissions for this file (and the parent directory):
+#   - Owned by root:root
+#   - Mode 0644 (or 0640) for files; 0755 for /etc/dotsecenv/policy.d/
+#   - NOT group-writable, NOT other-writable
+# dotsecenv refuses to start if the policy directory has insecure perms.
+
+# --- Allow-listed crypto algorithms ----------------------------------------
+#
+# Cross-fragment merge: union (most-permissive). Same-`algo` entries collapse:
+# curves take the union, min_bits takes the minimum.
+#
+# User vs policy: intersection. The user's `approved_algorithms` is narrowed
+# to the entries that also pass policy. Users can be stricter locally; users
+# cannot exceed the policy.
+#
+# This baseline matches FIPS 186-5: P-384/P-521 ECC, Ed25519/Ed448 EdDSA,
+# RSA >= 3072. Notably stricter than the dotsecenv default (RSA >= 2048).
+approved_algorithms:
+  - algo: ECC
+    curves:
+      - P-384
+      - P-521
+    min_bits: 384
+  - algo: EdDSA
+    curves:
+      - Ed25519
+      - Ed448
+    min_bits: 255
+  - algo: RSA
+    min_bits: 3072
+
+# --- Allow-listed vault locations ------------------------------------------
+#
+# Cross-fragment merge: deduped union of patterns.
+#
+# User vs policy: intersection. The user's `vault:` entries are filtered to
+# those matching at least one pattern below. Explicit `-v` flags pointing at
+# unmatched paths are REJECTED (not silently dropped).
+#
+# Pattern syntax: path/filepath.Match (single-segment globs `*`, `?`,
+# `[abc]`); `~` expands to the invoking user's home. There is no recursive
+# `**` glob; enumerate or use single-segment patterns.
+approved_vault_paths:
+  - ~/.local/share/dotsecenv/vault   # the install.sh default
+  - ~/work/*/.dotsecenv/vault         # one project per top-level work dir
+
+# --- Behaviour flags -------------------------------------------------------
+#
+# `behavior.*` is a set of independent scalar booleans. Cross-fragment merge:
+# last-set-wins per sub-field, in lexical filename order. A later fragment
+# can override one sub-field without disturbing the others.
+#
+# User vs policy: policy wins. If policy sets a behavior, the user's value
+# is replaced (and a stderr warning is emitted unless -s).
+behavior:
+  # Forbid CLI -v paths outside `vault:` in the user config.
+  # Combined with `approved_vault_paths` above this gives admins a tight
+  # leash on where vaults can live.
+  restrict_to_configured_vaults: true
+  # Require a one-time `dotsecenv vault doctor` to upgrade vault format
+  # rather than upgrading silently on first read.
+  require_explicit_vault_upgrade: true

--- a/examples/04-policy-directory/99-team-overrides.yaml
+++ b/examples/04-policy-directory/99-team-overrides.yaml
@@ -1,0 +1,26 @@
+# /etc/dotsecenv/policy.d/99-team-overrides.yaml
+#
+# Late-loading fragment that overrides the corporate baseline's scalar
+# settings for this team. Naming convention follows /etc/sudoers.d,
+# /etc/systemd/system/<unit>.d/, /etc/nginx/conf.d/ etc.: `00-` for
+# org-wide baselines, `50-` for team policy, `99-` for last-mile overrides.
+#
+# Allow-list fields (approved_algorithms, approved_vault_paths) merge across
+# fragments by UNION; you cannot remove an entry the baseline added. Scalar
+# fields (gpg.program, behavior.*) merge by LAST-FRAGMENT-WINS in lexical
+# filename order — `99-` outranks `00-`.
+
+# --- Pin GPG to the team's known-good binary -------------------------------
+#
+# `gpg.program` is a scalar. With this fragment present, every dotsecenv
+# command on the machine resolves `gpg` through this exact path, regardless
+# of what the user has in their config or PATH. That gives admins one place
+# to flip when patching CVEs in GnuPG.
+gpg:
+  program: /usr/bin/gpg
+
+# Allow-list additions stack onto whatever 00-corp-baseline.yaml declared:
+# users can use vaults on a personal-projects path in addition to
+# the corporate `~/work/...` glob.
+approved_vault_paths:
+  - ~/personal/dotsecenv/vault

--- a/examples/04-policy-directory/README.md
+++ b/examples/04-policy-directory/README.md
@@ -1,0 +1,147 @@
+# Example 04 — System policy fragments
+
+System administrators can constrain every dotsecenv user on a machine by
+dropping YAML fragments into `/etc/dotsecenv/policy.d/`. This example ships
+a two-file baseline showing the conventions: a `00-corp-baseline.yaml` with
+org-wide constraints and a `99-team-overrides.yaml` showing how to override
+scalar fields without touching the baseline.
+
+## What this demonstrates
+
+- Fragment-based policy composition (lexical-order load, with allow-lists
+  merged by **union** and scalars merged by **last-fragment-wins**).
+- All four supported policy fields:
+  `approved_algorithms`, `approved_vault_paths`, `behavior.*`, `gpg.program`.
+- The naming convention used by `sudoers.d`, `nginx conf.d`, etc. (`00-` for
+  baselines, `99-` for overrides) and how it interacts with merge rules.
+- The fail-closed posture: any error loading policy aborts startup. There is
+  no "ignore broken fragment and continue".
+
+## When to use the policy directory
+
+Reach for `/etc/dotsecenv/policy.d/` when:
+
+- You are a fleet admin (Mac DEP, MDM, configuration management) and want to
+  enforce minimum crypto across every employee laptop.
+- You need to constrain where vaults can live (`approved_vault_paths`) so
+  developers cannot accidentally store a vault in a backed-up location.
+- You want to pin `gpg.program` to a specific binary across the org (e.g. a
+  patched build of GnuPG, or one specific install root on shared machines).
+
+If you are a single-user developer the policy directory is unnecessary —
+your user config already gives you full control. The policy directory exists
+so admins can constrain users without rewriting the user config.
+
+## Install the fragments
+
+The directory and its files must be **owned by root** with permissions that
+disallow non-root writes. dotsecenv enforces this at load time.
+
+```bash
+# Create the directory once.
+sudo mkdir -p /etc/dotsecenv/policy.d
+sudo chown root:root /etc/dotsecenv/policy.d
+sudo chmod 0755 /etc/dotsecenv/policy.d
+
+# Drop the baseline.
+sudo install -m 0644 -o root -g root \
+  00-corp-baseline.yaml /etc/dotsecenv/policy.d/00-corp-baseline.yaml
+
+# Drop the team overrides.
+sudo install -m 0644 -o root -g root \
+  99-team-overrides.yaml /etc/dotsecenv/policy.d/99-team-overrides.yaml
+```
+
+Then verify both fragments parse and the merge result is what you expect:
+
+```bash
+dotsecenv policy validate
+dotsecenv policy list
+```
+
+## Expected output
+
+`dotsecenv policy validate` on a valid two-fragment install:
+
+```
+policy valid (2 fragment(s) in /etc/dotsecenv/policy.d)
+```
+
+`dotsecenv policy list` shows the merged effective policy with per-field
+origin attribution (which fragment contributed each field):
+
+```
+Policy directory: /etc/dotsecenv/policy.d (2 fragment(s))
+  approved_algorithms:
+    - algo: ECC, curves: [P-384, P-521], min_bits: 384  [00-corp-baseline.yaml]
+    - algo: EdDSA, curves: [Ed25519, Ed448], min_bits: 255  [00-corp-baseline.yaml]
+    - algo: RSA, min_bits: 3072  [00-corp-baseline.yaml]
+  approved_vault_paths:
+    - ~/.local/share/dotsecenv/vault  [00-corp-baseline.yaml]
+    - ~/work/*/.dotsecenv/vault  [00-corp-baseline.yaml]
+    - ~/personal/dotsecenv/vault  [99-team-overrides.yaml]
+  behavior:
+    require_explicit_vault_upgrade: true  [00-corp-baseline.yaml]
+    restrict_to_configured_vaults: true  [00-corp-baseline.yaml]
+  gpg.program: /usr/bin/gpg  [99-team-overrides.yaml]
+```
+
+Notice:
+- `approved_vault_paths` is a deduped union of both fragments.
+- `gpg.program` came from `99-team-overrides.yaml` (last-set-wins for scalars).
+- `behavior.*` came from `00-corp-baseline.yaml` because no later fragment
+  set those sub-fields.
+
+`dotsecenv policy list --json` returns the same data as a structured object
+suitable for compliance tooling. The `--json` form is also available on
+`policy validate`.
+
+## Merge rules cheat sheet
+
+| Field                   | Cross-fragment merge | User vs policy                     |
+| ----------------------- | -------------------- | ---------------------------------- |
+| `approved_algorithms`   | Union (per-algo collapse: curves union, min_bits min) | Intersection (user narrowed by policy) |
+| `approved_vault_paths`  | Deduped union of patterns | Filter (user vault entries that match a pattern) |
+| `behavior.*`            | Per-sub-field last-set-wins (lex order) | Policy overrides user; warning printed |
+| `gpg.program`           | Last-set-wins (lex order) | Policy overrides user; warning printed |
+
+Forbidden top-level keys (rejected at load time): `login:`, `vault:`. A
+fragment that contains either fails the load with `forbidden policy key`.
+`login` is per-user (cryptographically bound to the user's private key);
+`vault` would erase user vaults wholesale, so admins use
+`approved_vault_paths` instead.
+
+## Files
+
+- `00-corp-baseline.yaml` — org-wide baseline. Sets approved algorithms,
+  approved vault paths, and two strict behavior flags.
+- `99-team-overrides.yaml` — late-loading override. Pins `gpg.program` and
+  appends one extra `approved_vault_paths` pattern.
+- `README.md` — this file.
+
+## Recovering from a broken policy
+
+If you install a malformed fragment, `dotsecenv` will refuse to start with a
+clear error message identifying the offending file. To recover:
+
+```bash
+# See exactly what is wrong:
+sudo dotsecenv policy validate
+
+# Remove or fix the offending fragment:
+sudo rm /etc/dotsecenv/policy.d/<broken>.yaml
+
+# Confirm the policy is healthy again:
+sudo dotsecenv policy validate
+```
+
+Until policy parses cleanly, `dotsecenv` (including normal `secret get`
+calls by every user on the machine) refuses to run. This is intentional:
+a partially-readable policy directory is indistinguishable from tampering,
+so the only safe behaviour is to fail closed.
+
+## Related
+
+- README "Policy Directory" section in this repo (the canonical reference).
+- Concepts: <https://dotsecenv.com/concepts/policy/>
+- FIPS / compliance: <https://dotsecenv.com/concepts/compliance/>

--- a/examples/05-secenv-shell-plugin/.secenv
+++ b/examples/05-secenv-shell-plugin/.secenv
@@ -1,0 +1,114 @@
+# =============================================================================
+# .secenv — reference example
+#
+# A `.secenv` file lives in a project directory and is loaded by the
+# dotsecenv shell plugin (zsh, bash, fish) when you `cd` into that
+# directory. It looks like a `.env` file with one extension: a value can be
+# a `{dotsecenv...}` placeholder that the plugin replaces with a decrypted
+# secret from a dotsecenv vault.
+#
+# Lines fall into one of three buckets:
+#   - `KEY=value`          plain export, exactly like `.env`
+#   - `KEY={dotsecenv...}` secret reference, resolved at load time via
+#                          `dotsecenv secret get`
+#   - blank / `# ...`      ignored
+#
+# Loading is two-phase:
+#   1. All plain `KEY=value` lines export first (so they're available to any
+#      tool that reads env on `cd`).
+#   2. All `{dotsecenv...}` placeholders resolve via the CLI in a second pass.
+#
+# Ancestor `.secenv` files load too: if `/project/.secenv` and
+# `/project/services/api/.secenv` both exist, entering
+# `/project/services/api/` loads both, with child values shadowing parents.
+#
+# This file demonstrates every supported syntax. Copy what you need into
+# your real `.secenv`; chmod the result to 600 so the plugin trusts it.
+#
+# Reference: skills/secenv/SKILL.md in this repo, and
+#            https://dotsecenv.com/guides/shell-plugins/
+# =============================================================================
+
+
+# -----------------------------------------------------------------------------
+# 1. Plain values. Exported first, before any secret resolution. Suitable
+#    for non-sensitive config that everyone on the team agrees on.
+# -----------------------------------------------------------------------------
+
+APP_NAME=my-application
+APP_ENV=development
+DATABASE_HOST=localhost
+DATABASE_PORT=5432
+
+# Quoted strings: the surrounding " or ' is stripped on load. Use quotes
+# when the value contains spaces or characters the shell would otherwise
+# interpret.
+DESCRIPTION="My Application — runs on the dev box"
+SINGLE_QUOTED='Has spaces and a literal $variable that wont expand'
+
+
+# -----------------------------------------------------------------------------
+# 2. Secret references. Phase-2 placeholders that the plugin resolves by
+#    calling the dotsecenv CLI.
+#
+#    Syntax:                            Means:
+#      KEY={dotsecenv}                  Fetch the secret named KEY (same name
+#                                       as the env var)
+#      KEY={dotsecenv/}                 Same as above (empty after the slash)
+#      KEY={dotsecenv/SECRET_NAME}      Fetch the secret named SECRET_NAME and
+#                                       export it as KEY
+#      KEY={dotsecenv/ns::SECRET_NAME}  Namespaced lookup (`ns::SECRET_NAME` is
+#                                       the canonical secret key)
+#
+#    Constraints:
+#      - Only ONE `/` is allowed inside `{dotsecenv/...}`. A second `/` is
+#        a parse error.
+#      - Variable names must match `^[A-Za-z_][A-Za-z0-9_]*$`.
+#      - Secret keys are namespace::KEY_NAME; namespace lowercases, key
+#        UPPERCASES on store.
+# -----------------------------------------------------------------------------
+
+# 2a. Same-name reference (most common). Both forms below are equivalent.
+DATABASE_PASSWORD={dotsecenv}
+SLACK_WEBHOOK_URL={dotsecenv/}
+
+# 2b. Explicit-name reference. The env var name and the secret key differ.
+#     This is what you use when one secret is reused under different env
+#     names, e.g. `STRIPE_SECRET_KEY` in dev where the variable the SDK
+#     wants is `STRIPE_API_KEY`.
+STRIPE_API_KEY={dotsecenv/STRIPE_SECRET_KEY}
+
+# 2c. Namespaced reference. Use when one project has multiple environments
+#     in the same vault. Stored as `prod::DB_PASSWORD`, exported here as
+#     a named-after-it variable.
+PROD_DB_PASSWORD={dotsecenv/prod::DB_PASSWORD}
+
+# 2d. Combine: plain values that depend on a secret can use `${VAR}` AFTER
+#     phase-2 resolves. dotsecenv does NOT do this expansion for you — the
+#     shell does, when something downstream (your tool) reads the env. If
+#     you need shell expansion at load time, set it in your shell rc, not
+#     here.
+# DATABASE_URL=postgres://app:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/app
+
+
+# -----------------------------------------------------------------------------
+# 3. Comments and blank lines. Lines starting with `#` are skipped. Blank
+#    lines are skipped. Inline `# trailing` comments are NOT supported —
+#    everything after the `=` is part of the value.
+# -----------------------------------------------------------------------------
+
+
+# -----------------------------------------------------------------------------
+# 4. File permissions. The plugin refuses to load a `.secenv` that:
+#      - is not owned by you (or root), or
+#      - is world-writable (`other` write bit set), or
+#      - lives in a directory you have not trusted.
+#
+#    First load in a directory prompts you to trust it. Set permissions
+#    explicitly:
+#
+#      chmod 600 .secenv
+#
+#    The plugin's stricter `set -e`-on-untrusted behaviour is documented at
+#    https://dotsecenv.com/guides/shell-plugins/#trust-model .
+# -----------------------------------------------------------------------------

--- a/examples/05-secenv-shell-plugin/README.md
+++ b/examples/05-secenv-shell-plugin/README.md
@@ -1,0 +1,112 @@
+# Example 05 — `.secenv` shell plugin reference
+
+A heavily-commented `.secenv` file demonstrating every placeholder syntax
+the dotsecenv shell plugin understands. Drop the patterns you need into
+your own project's `.secenv` and the plugin will export plain values and
+decrypted secrets when you `cd` into the directory.
+
+## What this demonstrates
+
+- Plain `KEY=value` exports (single-quoted, double-quoted, unquoted).
+- Secret references with all four forms:
+  - `{dotsecenv}` — fetch a secret with the same name as the variable.
+  - `{dotsecenv/}` — same; empty after the slash.
+  - `{dotsecenv/EXPLICIT_NAME}` — fetch a differently-named secret.
+  - `{dotsecenv/namespace::KEY}` — namespaced lookup.
+- Two-phase loading semantics (plain values phase 1, secret resolution
+  phase 2).
+- Trust model: ownership, permissions, and per-directory trust.
+
+## Run it
+
+This example is configuration, not a script. To exercise it:
+
+1. Install the dotsecenv shell plugin: see
+   <https://dotsecenv.com/guides/shell-plugins/> for distro-specific
+   commands. The `install.sh` from <https://get.dotsecenv.com/install.sh>
+   auto-detects your plugin manager (Oh My Zsh, Zinit, Antidote, Oh My Bash,
+   Fisher, Oh My Fish) and installs the plugin where it belongs.
+2. Drop a vault next to a project, e.g. `~/projects/my-app/.dotsecenv/vault`.
+3. Copy the patterns you want from `.secenv` in this directory into
+   `~/projects/my-app/.secenv` and adjust the secret names.
+4. `chmod 600 ~/projects/my-app/.secenv` so the plugin trusts the file.
+5. `cd ~/projects/my-app/`. The plugin sources the file, exports the plain
+   values, and shells out to `dotsecenv secret get` for the secret
+   references.
+6. Verify with: `echo $APP_NAME; echo $DATABASE_PASSWORD`.
+
+## What to look for
+
+When you `cd` into the directory the plugin runs (roughly):
+
+```
+.secenv loaded: 6 plain export(s), 4 secret reference(s)
+```
+
+If the plugin can't decrypt a secret you'll see:
+
+```
+.secenv: secret 'DATABASE_PASSWORD' not found in any configured vault
+```
+
+Common causes (with diagnoses): see "Debugging" below.
+
+## Files
+
+- `.secenv` — the reference file. Every supported syntax appears at least
+  once with comments explaining what it means.
+- `README.md` — this file.
+
+## Cleanup
+
+Nothing to clean up — `.secenv` files are inert until the plugin loads them.
+If you copied this `.secenv` somewhere and want to undo: just delete it.
+
+## Loading order — important detail
+
+The plugin loads `.secenv` files **bottom-up to root**, so deeper directories
+shadow shallower ones for the same key. Concretely:
+
+```
+~/projects/my-app/.secenv          APP_ENV=production  DATABASE_URL={dotsecenv}
+~/projects/my-app/services/api/.secenv  SERVICE_NAME=api
+```
+
+Entering `~/projects/my-app/services/api/` loads BOTH files. `APP_ENV` and
+`DATABASE_URL` come from the parent; `SERVICE_NAME` comes from the child.
+If `services/api/.secenv` also set `APP_ENV=staging`, the staging value
+would win because it's closer to the cwd.
+
+## Vault path resolution gotcha
+
+Relative vault paths in your dotsecenv config (e.g. `.dotsecenv/vault`) are
+resolved relative to the **current working directory** when the plugin
+calls the CLI, NOT relative to the config file. The plugin always `cd`s to
+the directory containing the `.secenv` before invoking dotsecenv, so
+`./dotsecenv/vault` works as you'd expect.
+
+If you have a project-local vault and the plugin reports "vault not found",
+the most common culprit is that you sourced the `.secenv` from a different
+directory than the one containing the vault. The shell plugin handles this
+for you on `cd`; only manual sourcing trips on it.
+
+## Debugging
+
+| Symptom                                       | Likely cause                                    | Fix                                                                          |
+| --------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------- |
+| Plugin doesn't activate on `cd`               | Plugin not installed or not sourced             | Reinstall via `install.sh`; restart shell                                    |
+| "refusing to load .secenv: insecure perms"    | World-writable file                             | `chmod 600 .secenv`                                                          |
+| "refusing to load .secenv: untrusted dir"     | First time loading from this dir                | Run the trust prompt or `dotsecenv ...` whatever the plugin suggests          |
+| "secret X not found in any configured vault"  | Vault path mismatch or secret key not in vault  | `dotsecenv vault describe` to inspect; `dotsecenv secret get` to list keys   |
+| "secret X failed to decrypt"                  | Your fingerprint isn't a recipient              | Have a teammate run `dotsecenv secret share X $YOUR_FINGERPRINT`             |
+
+For deeper debugging the in-repo skill `skills/secenv/SKILL.md` is the
+canonical reference (and is what the dotsecenv Claude Code plugin uses).
+
+## Related
+
+- Shell plugins guide: <https://dotsecenv.com/guides/shell-plugins/>
+- The canonical syntax reference: `skills/secenv/SKILL.md` in this repo.
+- Plugin source: <https://github.com/dotsecenv/plugin>
+- Example 01 (the vault that the `{dotsecenv}` references read from):
+  [../01-quickstart/](../01-quickstart/)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,12 +1,12 @@
 # dotsecenv examples
 
 Self-contained, copy-pasteable scenarios that exercise the dotsecenv CLI end to
-end. Each example lives in its own subdirectory and is designed to be read,
-copied, and adapted by humans and AI coding agents alike.
+end. Each example lives in its own subdirectory. The audience is humans and AI
+coding agents in roughly equal measure: both copy from these.
 
-The examples favour **runnability and correctness** over breadth: every command
-shown is a real `dotsecenv` invocation that has been verified against the CLI
-help surface and (where possible) executed in an isolated environment.
+The examples favour runnability over breadth. Every command shown is a real
+`dotsecenv` invocation, verified against the CLI help surface and, where
+possible, executed in an isolated environment.
 
 For narrative documentation see <https://dotsecenv.com>. For the canonical CLI
 reference see `dotsecenv --help` or the man pages installed by
@@ -33,23 +33,20 @@ is nothing to "run".
 Every runnable script in this directory follows the same isolation pattern,
 borrowed from `scripts/sandbox.sh` and `demos/demo.sh`:
 
-- **Ephemeral working directory.** `TMP=$(mktemp -d)` holds the config, the
-  vault, and a private GPG home. No file outside `$TMP` is touched.
-- **Isolated `GNUPGHOME`.** Every script sets `GNUPGHOME=$TMP/gnupg` before
-  invoking `gpg` or `dotsecenv`. **Your real keyring is never touched.**
-- **Explicit config and vault paths.** Scripts pass `-c "$TMP/config"` and
-  `-v "$TMP/vault"` to every command rather than relying on the XDG default
-  location.
-- **Cleanup on exit.** A `trap 'rm -rf "$TMP"; gpgconf --kill all || true'
-  EXIT` guarantees the tempdir is removed and the per-tempdir gpg-agent is
-  shut down even if the script fails partway through.
-- **`set -euo pipefail`.** Errors abort immediately so partial state is never
-  reported as success.
-- **Unattended GPG operations.** The example keys are generated with
-  `--no-passphrase` (CI-only mode) so the scripts do not block on a pinentry
-  prompt. **Do not use `--no-passphrase` for real keys.** See
-  <https://dotsecenv.com/concepts/threat-model/> for the threat model
-  motivating passphrase-protected keys.
+- `TMP=$(mktemp -d)` holds the config, vault, and a private GPG home. No
+  file outside `$TMP` is touched.
+- `GNUPGHOME=$TMP/gnupg` for every `gpg` and `dotsecenv` invocation, so your
+  real keyring stays untouched.
+- Scripts pass `-c "$TMP/config"` and `-v "$TMP/vault"` to every command
+  rather than relying on the XDG default location.
+- `trap 'rm -rf "$TMP"; gpgconf --kill all || true' EXIT` removes the tempdir
+  and shuts down the per-tempdir gpg-agent on every exit path, including
+  Ctrl-C and partial failures.
+- `set -euo pipefail` aborts on the first error so partial state cannot
+  masquerade as success.
+- Example keys use `--no-passphrase` (CI-only mode) so the scripts do not
+  block on a pinentry prompt. Do not use `--no-passphrase` for real keys —
+  see <https://dotsecenv.com/concepts/threat-model/> for why.
 
 ## Running an example
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,79 @@
+# dotsecenv examples
+
+Self-contained, copy-pasteable scenarios that exercise the dotsecenv CLI end to
+end. Each example lives in its own subdirectory and is designed to be read,
+copied, and adapted by humans and AI coding agents alike.
+
+The examples favour **runnability and correctness** over breadth: every command
+shown is a real `dotsecenv` invocation that has been verified against the CLI
+help surface and (where possible) executed in an isolated environment.
+
+For narrative documentation see <https://dotsecenv.com>. For the canonical CLI
+reference see `dotsecenv --help` or the man pages installed by
+`make install`/`install.sh`.
+
+## Index
+
+| #  | Example                                                  | What it shows                                                                | Prereqs                              |
+| -- | -------------------------------------------------------- | ---------------------------------------------------------------------------- | ------------------------------------ |
+| 01 | [quickstart](./01-quickstart/)                           | `init config` -> `init vault` -> `login` -> `secret store` -> `secret get`   | `dotsecenv`, `gpg`                   |
+| 02 | [team-share-revoke](./02-team-share-revoke/)             | Multi-recipient encryption with two ephemeral identities; share, then revoke | `dotsecenv`, `gpg`                   |
+| 03 | [ci-cd-github-action](./03-ci-cd-github-action/)         | Use the `dotsecenv/dotsecenv` GitHub Action to install and decrypt in CI     | A GitHub repo, a CI-only GPG key     |
+| 04 | [policy-directory](./04-policy-directory/)               | Drop YAML fragments into `/etc/dotsecenv/policy.d/` to constrain users       | Root or fakeroot for `/etc/...`      |
+| 05 | [secenv-shell-plugin](./05-secenv-shell-plugin/)         | Reference `.secenv` file demonstrating every supported placeholder syntax    | The dotsecenv shell plugin installed |
+
+Examples 01 and 02 ship a `run.sh` that executes the full flow end to end in
+an ephemeral working directory. Examples 03, 04, and 05 are configuration
+artifacts (a workflow YAML, two policy fragments, a `.secenv` file) — they
+ship with a `README.md` that explains how to install and use them, but there
+is nothing to "run".
+
+## Safety conventions
+
+Every runnable script in this directory follows the same isolation pattern,
+borrowed from `scripts/sandbox.sh` and `demos/demo.sh`:
+
+- **Ephemeral working directory.** `TMP=$(mktemp -d)` holds the config, the
+  vault, and a private GPG home. No file outside `$TMP` is touched.
+- **Isolated `GNUPGHOME`.** Every script sets `GNUPGHOME=$TMP/gnupg` before
+  invoking `gpg` or `dotsecenv`. **Your real keyring is never touched.**
+- **Explicit config and vault paths.** Scripts pass `-c "$TMP/config"` and
+  `-v "$TMP/vault"` to every command rather than relying on the XDG default
+  location.
+- **Cleanup on exit.** A `trap 'rm -rf "$TMP"; gpgconf --kill all || true'
+  EXIT` guarantees the tempdir is removed and the per-tempdir gpg-agent is
+  shut down even if the script fails partway through.
+- **`set -euo pipefail`.** Errors abort immediately so partial state is never
+  reported as success.
+- **Unattended GPG operations.** The example keys are generated with
+  `--no-passphrase` (CI-only mode) so the scripts do not block on a pinentry
+  prompt. **Do not use `--no-passphrase` for real keys.** See
+  <https://dotsecenv.com/concepts/threat-model/> for the threat model
+  motivating passphrase-protected keys.
+
+## Running an example
+
+Build the binary first (the scripts assume `bin/dotsecenv` exists in the repo
+root):
+
+```bash
+make build
+```
+
+Then `cd` into the example and run its script:
+
+```bash
+cd examples/01-quickstart
+./run.sh
+```
+
+If you have the dotsecenv binary on your `PATH` (via `install.sh`, Homebrew,
+the package managers, etc.) the scripts use that instead. To force the use
+of the repo-local build, run them from the repo root with `./bin/dotsecenv` on
+your `PATH` (`PATH="$PWD/bin:$PATH" ./examples/01-quickstart/run.sh`).
+
+## Where to next
+
+- Tutorials: <https://dotsecenv.com/tutorials/>
+- Concepts (threat model, FIPS compliance, append-only vault): <https://dotsecenv.com/concepts/>
+- Guides (CI/CD, shell plugins, Terraform, Claude Code): <https://dotsecenv.com/guides/>


### PR DESCRIPTION
## Summary

Adds an `examples/` directory with five copy-pasteable scenarios covering
the canonical dotsecenv flows. Two are runnable end-to-end against an
isolated `GNUPGHOME` and a tempdir-only config + vault; three are
configuration artifacts with prose READMEs explaining how to install and
use them.

```
examples/
├── README.md                         # index + safety conventions
├── 01-quickstart/                    # runnable
│   ├── README.md
│   └── run.sh
├── 02-team-share-revoke/             # runnable
│   ├── README.md
│   └── run.sh
├── 03-ci-cd-github-action/
│   ├── README.md
│   └── workflow.yml
├── 04-policy-directory/
│   ├── 00-corp-baseline.yaml
│   ├── 99-team-overrides.yaml
│   └── README.md
└── 05-secenv-shell-plugin/
    ├── .secenv
    └── README.md
```

## Why

The repo has tutorial-style docs at <https://dotsecenv.com> and a working
asciinema script at `demos/demo.sh`, but nothing that gives someone a
single subdirectory they can read, copy, and adapt to their project. AI
coding agents and humans both copy aggressively from examples; the value is
in correctness and runnability.

Both runnable scripts:

- Use `mktemp -d` for the working directory.
- Set `GNUPGHOME` to a tempdir, so the user's real keyring is never
  touched.
- Pass `-c "$TMP/config"` and `-v "$TMP/vault"` explicitly.
- `trap 'rm -rf "$TMP"; gpgconf --kill all || true' EXIT`.
- Use `set -euo pipefail`.
- Are shellcheck-clean and idempotent (re-runnable from scratch).

The shape mirrors `scripts/sandbox.sh` and `scripts/e2e.sh`.

## What each example shows

- **01-quickstart** — `init config` -> `init vault` -> `login` ->
  `secret store` -> `secret get` -> `vault describe` -> `validate`. The
  smallest useful flow.
- **02-team-share-revoke** — Two separate `GNUPGHOME` directories so
  each identity holds only its own private key. Demonstrates
  multi-recipient encryption, revocation, and the append-only history
  semantics: after Alice revokes Bob and rotates the secret, Bob's
  `secret get --all` shows decryption failures for the rotated entry he
  is no longer a recipient of.
- **03-ci-cd-github-action** — Complete `deploy.yml` using the
  `dotsecenv/dotsecenv@v0` action, importing a CI-only GPG key from a
  sealed repo secret, decrypting two secrets out of a checked-in vault,
  and exposing them as masked env vars to subsequent steps. README
  includes the bootstrap procedure for the `DOTSECENV_GPG_PRIVATE_KEY`
  secret.
- **04-policy-directory** — A two-fragment baseline showing all four
  supported policy fields (`approved_algorithms`, `approved_vault_paths`,
  `behavior.*`, `gpg.program`) and the union/last-set-wins merge rules.
- **05-secenv-shell-plugin** — Reference `.secenv` covering every
  placeholder syntax (`{dotsecenv}`, `{dotsecenv/}`,
  `{dotsecenv/EXPLICIT}`, `{dotsecenv/ns::KEY}`), plus the trust model.

## Verification

Every CLI invocation was verified against `bin/dotsecenv --help` and the
`cmd/dotsecenv/*.go` source. The two `run.sh` scripts were executed
end-to-end in an isolated `GNUPGHOME` during authoring with
`PATH="$PWD/bin:$PATH" bash examples/0X/run.sh`; both exit 0 and the
output matches the "Expected output" sections in their READMEs.

## Test plan

- [x] `make build` produces `bin/dotsecenv`
- [x] `make lint` clean (lefthook pre-commit)
- [x] `make clean test build e2e` clean (lefthook pre-push)
- [x] `shellcheck examples/*/run.sh` clean
- [x] `examples/01-quickstart/run.sh` exits 0 with isolated GNUPGHOME
- [x] `examples/02-team-share-revoke/run.sh` exits 0 with isolated GNUPGHOME and shows the documented revoke + rotate semantics
- [x] All YAML files parse (cross-checked with `gopkg.in/yaml.v3` and `policy.Fragment` struct unmarshalling)