### PR TITLE
docs: fix broken cross-refs and link examples to site tutorials

### DIFF
--- a/examples/01-quickstart/README.md
+++ b/examples/01-quickstart/README.md
@@ -97,7 +97,11 @@ Three things change when you run dotsecenv outside a script:
 
 ## Related
 
-- Tutorial: <https://dotsecenv.com/tutorials/quickstart/>
-- Concepts (vault format, append-only history): <https://dotsecenv.com/concepts/>
+- Tutorial: <https://dotsecenv.com/tutorials/first-secret/> (narrative
+  walkthrough of this same flow)
+- Tutorial: <https://dotsecenv.com/tutorials/installation/> (installer
+  reference: `install.sh`, package managers, `mise`)
+- Concepts (vault format, append-only history):
+  <https://dotsecenv.com/concepts/vault-format/>
 - The `demos/demo.sh` recording in this repo is the asciinema source for the
   homepage demo and follows the same flow.

--- a/examples/02-team-share-revoke/README.md
+++ b/examples/02-team-share-revoke/README.md
@@ -100,6 +100,10 @@ gpg-agents on every exit path.
 
 ## Related
 
-- Concepts (append-only vault, threat model): <https://dotsecenv.com/concepts/>
-- Guide: <https://dotsecenv.com/guides/team-collaboration/>
-- Example 01 (the basic vault flow this builds on): [../01-quickstart/](../01-quickstart/)
+- Tutorial: <https://dotsecenv.com/tutorials/share-secret/>
+- Tutorial: <https://dotsecenv.com/tutorials/revoke-access/>
+- Tutorial: <https://dotsecenv.com/tutorials/team-onboarding/>
+- Concepts (append-only vault, threat model):
+  <https://dotsecenv.com/concepts/threat-model/>
+- Example 01 (the basic vault flow this builds on):
+  [../01-quickstart/](../01-quickstart/)

--- a/examples/03-ci-cd-github-action/README.md
+++ b/examples/03-ci-cd-github-action/README.md
@@ -137,10 +137,11 @@ piped through `::add-mask::` before `$GITHUB_ENV`.
 
 ## Related
 
+- Tutorial: <https://dotsecenv.com/tutorials/ci-cd-secrets/>
+- Guide: <https://dotsecenv.com/guides/github-action/>
 - Action source and inputs reference: [`action.yml`](../../action.yml) at
   the repo root, plus
   <https://github.com/marketplace/actions/setup-dotsecenv>.
-- CI/CD guide (full reference): <https://dotsecenv.com/guides/ci-cd/>
 - Threat model: <https://dotsecenv.com/concepts/threat-model/>
 - Example 02 (the `secret share` mechanics this relies on):
   [../02-team-share-revoke/](../02-team-share-revoke/)

--- a/examples/04-policy-directory/README.md
+++ b/examples/04-policy-directory/README.md
@@ -142,6 +142,6 @@ so the only safe behaviour is to fail closed.
 
 ## Related
 
-- README "Policy Directory" section in this repo (the canonical reference).
-- Concepts: <https://dotsecenv.com/concepts/policy/>
+- Concepts: <https://dotsecenv.com/concepts/policy-directory/>
 - FIPS / compliance: <https://dotsecenv.com/concepts/compliance/>
+- README "Policy Directory" section in this repo (the canonical reference).

--- a/examples/05-secenv-shell-plugin/README.md
+++ b/examples/05-secenv-shell-plugin/README.md
@@ -105,6 +105,7 @@ canonical reference (and is what the dotsecenv Claude Code plugin uses).
 
 ## Related
 
+- Tutorial: <https://dotsecenv.com/tutorials/reload-secrets/>
 - Shell plugins guide: <https://dotsecenv.com/guides/shell-plugins/>
 - The canonical syntax reference: `skills/secenv/SKILL.md` in this repo.
 - Plugin source: <https://github.com/dotsecenv/plugin>


### PR DESCRIPTION
## Summary

The five example READMEs added in #117 shipped with four URLs that don't resolve on the live site, plus several missing pointers to tutorials that do exist. This PR fixes the broken links and rounds out the cross-references.

| Example | URL fix |
|---|---|
| \`01-quickstart\` | \`/tutorials/quickstart/\` → \`/tutorials/first-secret/\` (also adds \`/tutorials/installation/\` and a more specific concept link) |
| \`02-team-share-revoke\` | \`/guides/team-collaboration/\` → the three real tutorials: \`share-secret\`, \`revoke-access\`, \`team-onboarding\` |
| \`03-ci-cd-github-action\` | \`/guides/ci-cd/\` → \`/tutorials/ci-cd-secrets/\`; also adds \`/guides/github-action/\` |
| \`04-policy-directory\` | \`/concepts/policy/\` → \`/concepts/policy-directory/\` |
| \`05-secenv-shell-plugin\` | adds \`/tutorials/reload-secrets/\` (no broken link, just rounding out) |

## Why

Cross-referencing examples ↔ tutorials is the lightweight option for keeping prose-rich tutorials and runnable repo examples in sync without machinery. The companion PR on \`dotsecenv/website\` adds the reverse direction (a \"Runnable example\" Aside on each tutorial page).

## Test plan

- [x] Every URL in the new \`## Related\` blocks verified \`HTTP/2 200\` against \`https://dotsecenv.com/sitemap-0.xml\`
- [x] \`make lint\` clean (lefthook pre-commit)
- [x] No content changes besides the link blocks; runnable scripts and bodies untouched