### PR TITLE
docs: add context7.json for Context7 indexing

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "dotsecenv",
+  "description": "Go CLI for securely managing environment secrets with GPG-based encryption, multi-user support, and FIPS 186-5 compliant defaults.",
+  "folders": [],
+  "excludeFolders": [
+    "vendor",
+    "internal",
+    "cmd",
+    "pkg",
+    "scripts",
+    ".github",
+    ".vscode",
+    ".claude-plugin"
+  ],
+  "excludeFiles": [
+    "go.mod",
+    "go.sum",
+    ".goreleaser.yaml",
+    "lefthook.yml",
+    "renovate.json",
+    "Makefile",
+    ".mise.toml",
+    ".mise.local.toml"
+  ],
+  "rules": [
+    "Vault files use the .secenv extension and are GPG-encrypted",
+    "Use the dotsecenv CLI to init, store, retrieve, share, and revoke secrets",
+    "Recipients are GPG public keys; users must hold the corresponding secret key in gpg-agent to decrypt",
+    "Policy fragments live in /etc/dotsecenv/policy.d/*.yaml and load in lexical order (00-base, 50-team, 99-overrides)",
+    "FIPS 186-5 compliant algorithms are the default; review approved_algorithms policy when integrating in regulated environments"
+  ],
+  "previousVersions": []
+}


### PR DESCRIPTION
## Description

Adds a `context7.json` at the repo root so [Context7](https://context7.com) indexes this repo with sensible scoping. Context7 serves up-to-date library documentation to LLM coding tools via the Context7 MCP server; the config controls which files get parsed.

### What's configured

- **Excluded folders**: `vendor`, `internal`, `cmd`, `pkg`, `scripts`, `.github`, `.vscode`, `.claude-plugin` — Go source/build/CI noise that isn't user-facing docs.
- **Excluded files**: `go.mod`, `go.sum`, `.goreleaser.yaml`, `lefthook.yml`, `renovate.json`, `Makefile`, `.mise*.toml`.
- **Kept (default-included)**: `README.md`, `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, `SECURITY.md`, `action.yml`, `examples/`, `demos/`, `contrib/`, `skills/`.
- **Rules**: short usage hints surfaced to LLM users (vault format, GPG recipients, policy.d ordering, FIPS defaults).

Default Context7 exclusions already cover `CODE_OF_CONDUCT.md`, `LICENSE`, and changelog files, so they're not listed.

After merge, submit the repo at https://context7.com/add-library?tab=github to trigger indexing. The `context7.json` also enables claiming ownership for the Context7 admin dashboard.

## Related Issue

N/A

## Type of Change

- [x] Documentation update

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and fixed any issues — N/A (config-only, no code)
- [x] I have run `make test` and all tests pass — N/A (config-only, no code)
- [ ] I have added tests that prove my fix/feature works — N/A
- [x] I have updated documentation (if applicable)
- [x] My commit messages follow the conventional commit format
- [x] I have not included any secrets or credentials

## Testing

JSON validates against the schema declared via `$schema`. No code paths affected; this is a metadata file consumed by Context7's parser.

## Screenshots

N/A