### PR TITLE
docs: add recipes/ and Context7 retrieval coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,22 @@ echo "xyz" | dotsecenv secret store TEST_SECRET
 dotsecenv secret get TEST_SECRET # should output "xyz"
 ```
 
+> **Encryption defaults.** Vaults use **AES-256-GCM** symmetric
+> encryption (RFC 9580 / NIST SP 800-38D) wrapped in GPG
+> multi-recipient asymmetric encryption, with FIPS-compliant
+> defaults out of the box — no extra flags needed at `init` time.
+> To enforce specific algorithms across a team (or narrow them
+> further), drop a `policy.d/*.yaml` fragment with
+> `approved_algorithms`; see [example 04](./examples/04-policy-directory/).
+
+### Common recipes
+
+Short, self-contained how-tos for the workflows beyond the quickstart:
+
+- [Add a secret (and the append-only audit trail)](./recipes/add-secret.md)
+- [Migrate from a `.env` file](./recipes/migrate-from-dotenv.md)
+- [Rotate a compromised GPG key](./recipes/rotate-compromised-key.md)
+
 ### Installation
 
 #### Install Script (recommended)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -79,6 +79,46 @@ dotsecenv implements several security measures:
 
 For more details, see our [Security Model](https://dotsecenv.com/concepts/security-model/) documentation.
 
+## Recovering from a compromised GPG key
+
+If a private GPG key in your team's keyring is suspected or known
+to be compromised, work through the runbook in
+[`recipes/rotate-compromised-key.md`](recipes/rotate-compromised-key.md).
+
+The short version:
+
+1. Generate or import a replacement identity.
+2. `dotsecenv secret revoke <NAME> <COMPROMISED_FP> --all` per
+   affected secret.
+3. `dotsecenv secret share <NAME> <NEW_FP> --all` to add the
+   replacement.
+4. **Rotate each affected secret at its source** (new DB password,
+   new API key, …) and re-store with `dotsecenv secret store`.
+5. Verify with `dotsecenv vault doctor` and `vault describe`.
+6. Commit and push.
+
+### Limitations of the append-only design in this scenario
+
+dotsecenv vaults are append-only: past entries are not mutated by
+revoke or share. Two consequences follow that you must plan for:
+
+- The leaked private key can still decrypt every entry that was
+  ever written before the rotation, both in the current vault file
+  and in the repository's git history. Revocation prevents
+  *future* writes from being readable, not past ones.
+- Therefore, revocation alone is not a mitigation. To make a leaked
+  value safe, the only durable answer is to invalidate the value
+  upstream (rotate the database password, reissue the API key,
+  invalidate the session) and store the new value.
+
+This is a deliberate trade-off: append-only preserves a verifiable
+audit trail at the cost of being unable to "unsay" past
+ciphertext. If you need ciphertext to be unrecoverable from the
+vault file itself, the only option is to rewrite git history (e.g.
+`git filter-repo`) and force every consumer to re-clone — and even
+then, anyone who already cloned the old history retains the old
+encrypted entries.
+
 ## Acknowledgments
 
 We appreciate responsible disclosure and will acknowledge security researchers in our release notes (unless you prefer to remain anonymous).

--- a/context7.json
+++ b/context7.json
@@ -24,11 +24,16 @@
     ".mise.local.toml"
   ],
   "rules": [
-    "Vault files use the .secenv extension and are GPG-encrypted",
-    "Use the dotsecenv CLI to init, store, retrieve, share, and revoke secrets",
-    "Recipients are GPG public keys; users must hold the corresponding secret key in gpg-agent to decrypt",
-    "Policy fragments live in /etc/dotsecenv/policy.d/*.yaml and load in lexical order (00-base, 50-team, 99-overrides)",
-    "FIPS 186-5 compliant algorithms are the default; review approved_algorithms policy when integrating in regulated environments"
+    "Vault files have the .secenv extension and are GPG-encrypted, append-only signed JSONL. Each line is one entry; old entries are never mutated.",
+    "Add or update a secret with: echo VALUE | dotsecenv secret store NAME. There is no separate add/update command; store is the only write.",
+    "Inspect history with: dotsecenv vault describe (or --json). Read the latest value with secret get NAME, all historical values with secret get NAME --all.",
+    "Symmetric encryption is AES-256-GCM (RFC 9580 / NIST SP 800-38D) by default — FIPS-compliant out of the box. Enforce specific algorithms via /etc/dotsecenv/policy.d/*.yaml approved_algorithms (lexical load order: 00-base, 50-team, 99-overrides; allow-list fields union).",
+    "Recipients are GPG public-key fingerprints. Users must hold the matching private key in gpg-agent to decrypt.",
+    "Add a recipient with: dotsecenv secret share NAME FINGERPRINT [--all]. Remove with: dotsecenv secret revoke NAME FINGERPRINT [--all]. --all spans every vault that already contains NAME. Both operations affect FUTURE writes only — past entries are unchanged.",
+    "Rotate a compromised GPG key: revoke the compromised fingerprint per affected secret, share to a replacement fingerprint, then ROTATE THE UNDERLYING SECRET AT ITS SOURCE (new DB password, new API key, etc.) and re-store. The leaked key still decrypts past entries in the vault file and git history; only upstream rotation makes the old value safe.",
+    "There is no .env file import. Migrate by running secret store per key, then load values at runtime via the shell plugin: a .secenv file with KEY=value lines and {dotsecenv} or {dotsecenv/EXPLICIT_NAME} placeholders, chmod 600.",
+    "CI/CD: install via the official GitHub Action (action.yml in this repo) or the install.sh script; import a CI-only GPG key, dotsecenv login, then dotsecenv secret get NAME. Grant CI keys the minimum recipient set with secret share --all.",
+    "Vaults are designed to be committed to git. The threat model assumes the encrypted file is public; security comes from controlling who holds the GPG private keys."
   ],
   "previousVersions": []
 }

--- a/recipes/add-secret.md
+++ b/recipes/add-secret.md
@@ -1,0 +1,65 @@
+# Add a secret to a vault
+
+How to add (or update) a secret while preserving the append-only audit
+trail that dotsecenv vaults provide.
+
+## Command
+
+```bash
+echo "<value>" | dotsecenv secret store <NAME>
+```
+
+`secret store` reads the value from stdin and appends a new entry to
+the active vault. There is no `secret add` or `secret update` —
+storing a value is the single operation, whether the name exists or
+not.
+
+## How append-only works
+
+Each call to `secret store` writes a new line to the vault. Vaults
+are **append-only signed JSONL files**: every prior version of every
+secret remains in the file as its own line, encrypted to whichever
+recipients were valid at the time it was written.
+
+When you read with `secret get`, the latest entry wins. When you
+inspect with `vault describe`, you see the full history.
+
+## Inspect the audit trail
+
+```bash
+dotsecenv vault describe                # human-readable, lists every entry
+dotsecenv vault describe --json         # machine-readable
+dotsecenv secret get NAME --all         # all historical values for one secret
+dotsecenv secret get NAME --last        # the most recent value
+```
+
+`vault describe` lists every entry, the recipients each was
+encrypted to, and the signature on each line. Together with `git
+log` on the vault file, this is your audit trail.
+
+## Why this design
+
+- **Audit trail.** You can prove what value was stored, when, and
+  to whom it was encrypted.
+- **Rotation safety.** Adding a new value never overwrites or
+  destroys the prior one. To replace a value the new entry must be
+  written; the old entry remains as evidence.
+- **No edits in place.** No command mutates a past entry. The file
+  only grows forward.
+
+## Limitations
+
+Append-only means **history cannot be removed by the tool**. If a
+former recipient must lose access to a value, see
+[Rotate a compromised key](rotate-compromised-key.md): revocation
+hides future entries from a recipient, but old entries remain in
+the file (and in `git` history) and remain decryptable by anyone
+holding the matching private key. The durable mitigation is to
+rotate the underlying secret at its source.
+
+## See also
+
+- [Quickstart example](../examples/01-quickstart/)
+- [Team share + revoke + rotate example](../examples/02-team-share-revoke/)
+- [Rotate a compromised key](rotate-compromised-key.md)
+- [Concepts: append-only vault](https://dotsecenv.com/concepts/)

--- a/recipes/migrate-from-dotenv.md
+++ b/recipes/migrate-from-dotenv.md
@@ -1,0 +1,102 @@
+# Migrate from `.env` to dotsecenv
+
+Coming from a `.env` file? dotsecenv replaces it but with a different
+mental model: secrets are stored **per key**, not as a `.env` blob.
+There is no bulk-import command for a `.env` file because the unit of
+encryption and audit is the individual secret.
+
+## Mental model
+
+| `.env` file                          | dotsecenv                                    |
+|--------------------------------------|----------------------------------------------|
+| One file per project, plain text     | One vault file per project, encrypted        |
+| Edit a line to change a value        | `secret store NAME` writes a new entry       |
+| Cannot commit safely                 | Vault file commits safely to git             |
+| No history of who could read what    | Append-only; recipients tracked per entry    |
+| Loaded by `source .env` at runtime   | Loaded by the [shell plugin] at runtime      |
+
+[shell plugin]: ../examples/05-secenv-shell-plugin/
+
+## One-time migration
+
+Given a `.env` like:
+
+```
+DATABASE_URL=postgres://localhost/app
+API_KEY=sk_live_abc123
+SENTRY_DSN=https://x@sentry.io/1
+```
+
+Bootstrap the vault and store each line as a separate secret:
+
+```bash
+dotsecenv init config
+dotsecenv init vault -v ~/.local/share/dotsecenv/vault
+dotsecenv login <YOUR_GPG_FINGERPRINT>
+
+# Simple loop. Inspect quoted/multi-line values manually before relying
+# on this — IFS='=' splits on the first '=' only.
+while IFS='=' read -r name value; do
+  case "$name" in ''|\#*) continue ;; esac
+  printf '%s' "$value" | dotsecenv secret store "$name"
+done < .env
+```
+
+Then **delete the plaintext `.env`** and `.gitignore` it for safety:
+
+```bash
+rm .env
+echo '.env' >> .gitignore
+```
+
+Commit the encrypted vault. The `.secenv`-suffixed vault file is
+safe to track because every entry is encrypted to your team's
+public keys.
+
+## Loading at runtime
+
+Use the [shell plugin](../examples/05-secenv-shell-plugin/) to
+populate the environment when you `cd` into the project. This
+replaces `source .env`. Drop a `.secenv` file in the project root
+that references the secrets by name:
+
+```sh
+# project-root/.secenv  (chmod 600)
+APP_ENV=production
+DATABASE_URL={dotsecenv}
+API_KEY={dotsecenv}
+SENTRY_DSN={dotsecenv}
+```
+
+The `{dotsecenv}` placeholder fetches a secret with the same name
+as the variable. Other supported forms:
+
+- `{dotsecenv/EXPLICIT_NAME}` — fetch a differently-named secret.
+- `{dotsecenv/namespace::KEY}` — namespaced lookup.
+
+When you `cd` in, the plugin exports plain `KEY=value` lines as
+environment variables and shells out to `dotsecenv secret get` to
+resolve each `{dotsecenv}` reference. See
+[example 05](../examples/05-secenv-shell-plugin/) for the full
+syntax reference and the trust model (`chmod 600`, ownership,
+per-directory trust).
+
+## What changes about your workflow
+
+- **Editing values.** Instead of editing a line in `.env`, run
+  `echo NEW | dotsecenv secret store NAME`. The old value is
+  preserved in the vault for audit — see
+  [add a secret](add-secret.md).
+- **Sharing values.** Instead of pasting `.env` over Slack, add a
+  teammate as a recipient with
+  `dotsecenv secret share NAME <THEIR_FINGERPRINT> --all`.
+- **Rotating values.** Instead of "rotate everything when someone
+  leaves", revoke and rotate the affected secrets — see
+  [rotate a compromised key](rotate-compromised-key.md).
+
+## See also
+
+- [Quickstart example](../examples/01-quickstart/)
+- [Shell plugin example](../examples/05-secenv-shell-plugin/)
+- [Add a secret](add-secret.md)
+- [Rotate a compromised key](rotate-compromised-key.md)

--- a/recipes/rotate-compromised-key.md
+++ b/recipes/rotate-compromised-key.md
@@ -1,0 +1,106 @@
+# Rotate a compromised GPG key
+
+How to remove a compromised private key's access from your dotsecenv
+vaults — and what the append-only design means for the keys that
+already saw past secrets.
+
+The same workflow applies whether the compromised key is yours or a
+teammate's.
+
+## Mental model first
+
+dotsecenv vaults are **append-only** and entries are encrypted to
+GPG public keys. This has two consequences for rotation:
+
+1. **You cannot edit the past.** Old vault entries remain in the
+   file and in `git` history, encrypted to whoever held the
+   recipient list at the time. The compromised private key still
+   decrypts those entries — and any clone of the repo retains them.
+2. **Revoking a recipient only affects future writes.** After
+   `secret revoke`, new `secret store` entries are no longer
+   encrypted to the revoked recipient. Past entries are unchanged.
+
+The durable mitigation is therefore to **rotate the underlying
+secret at its source** (issue a new database password, regenerate
+the API key, etc.) and then store the new value. The leaked key can
+still decrypt the old value, but the old value no longer
+authenticates to anything.
+
+## Runbook
+
+### 1. Generate or import a replacement identity
+
+If the compromised key is yours, generate a new GPG key pair
+(`gpg --full-generate-key`), publish the new public key to your
+team, and import the new public key into each teammate's keyring so
+they can encrypt to you.
+
+### 2. Revoke the compromised recipient from each affected secret
+
+For every secret the compromised key could read, run:
+
+```bash
+dotsecenv secret revoke <SECRET_NAME> <COMPROMISED_FINGERPRINT> --all
+```
+
+`--all` extends the revoke to every vault that already holds
+`<SECRET_NAME>`. Repeat per secret name. After this step, future
+`secret store` calls will not encrypt to the compromised key.
+
+### 3. Add the replacement recipient
+
+```bash
+dotsecenv secret share <SECRET_NAME> <NEW_FINGERPRINT> --all
+```
+
+This adds the new identity to the recipient set going forward.
+
+### 4. Rotate each affected secret at its source
+
+For each secret the compromised key could decrypt, generate a new
+underlying value (rotate the DB password, reissue the API key) and
+store it:
+
+```bash
+echo "<new-value>" | dotsecenv secret store <SECRET_NAME>
+```
+
+This is the step that actually neutralizes the compromise. The
+leaked key can still decrypt every entry written before this point,
+but those entries hold values that no longer work.
+
+### 5. Verify
+
+```bash
+dotsecenv vault doctor                 # health checks
+dotsecenv vault describe               # confirm recipient lists
+```
+
+Every current secret should now list the replacement key as a
+recipient and **not** the compromised key. Past entries still show
+the compromised key — that is expected and unavoidable.
+
+### 6. Commit and push
+
+The new vault entries land in the file. Commit and push as usual.
+The git history retains the old entries; that is part of the audit
+trail.
+
+## What you cannot do
+
+- **Erase a leaked encrypted entry from the vault file.**
+  Append-only by design. Rewriting `git` history with
+  `git filter-repo` is possible, but anyone who already cloned the
+  repo still has the old data, and the compromised key still
+  decrypts it.
+- **Re-encrypt an existing entry to a different recipient set.**
+  `secret share` and `secret revoke` only affect future writes;
+  they do not mutate past entries.
+
+## See also
+
+- [Add a secret](add-secret.md)
+- [Migrate from .env](migrate-from-dotenv.md)
+- [Team share + revoke + rotate example](../examples/02-team-share-revoke/)
+- [SECURITY.md](../SECURITY.md)
+- [Threat model](https://dotsecenv.com/concepts/threat-model/)


### PR DESCRIPTION
## Description

Closes a set of retrieval gaps surfaced by a Context7 quality eval against this repo. Adds three single-question recipe pages, an AES-256-GCM clarifier in the Quick Start, a compromised-key runbook in `SECURITY.md`, and tighter `context7.json` rules.

### Why

The eval scored several common queries low because the relevant content was either scattered across the 34KB README, framed as a teammate-revoke (not a self-key-compromise) workflow, or missing entirely (the `.env` mental-model gap). Several criticisms were category mismatches (Python/JS API for a Go CLI, GitLab CI when we ship a GitHub Action) and were intentionally **not** addressed — see internal review notes for which scores we're not chasing.

### What's in the PR

- `recipes/add-secret.md` — the answer to "how do I add a secret while preserving the append-only audit trail" in one chunkable page (~60 lines). Targets eval question #6 (15/100).
- `recipes/rotate-compromised-key.md` — full runbook for a compromised GPG key, with an honest section on what the append-only design **cannot** do (history remains decryptable; upstream secret rotation is the durable mitigation). Targets eval question #9 (45/100).
- `recipes/migrate-from-dotenv.md` — addresses the per-secret-vs-`.env`-blob mental-model gap; documents the migration loop and `.secenv` shell-plugin runtime loading. Targets eval question #2 (42/100).
- `README.md` — `> Encryption defaults` callout in the Quick Start naming AES-256-GCM (RFC 9580 / NIST SP 800-38D), FIPS-compliant defaults, and `approved_algorithms` for enforcement. Targets eval question #1 (76/100). Also adds a "Common recipes" subsection so the new pages are discoverable from the root.
- `SECURITY.md` — "Recovering from a compromised GPG key" section with the short-form runbook plus an explicit "Limitations of the append-only design in this scenario" subsection.
- `context7.json` — rewrites `rules[]` as concrete, question-shaped hints (10 entries) that mirror the most common retrieval queries. The Context7 retriever surfaces these on some paths.

### What's intentionally not in this PR

- No `.env` bulk-import command. The repo intentionally exposes per-secret writes; the migration recipe documents the workflow without adding new surface.
- No GitLab CI examples, Python SDK, or JavaScript SDK — those criticisms were category mismatches.
- No "centralized key distribution" / "automated rotation at scale" content for the multi-repo design question. Those are IdP/KMS concerns, not dotsecenv's scope.
- `excludeFolders` in `context7.json` unchanged. Verified: `pkg/`, `cmd/`, `internal/` contain zero markdown files, so the existing exclusions cost nothing.

### Verification

- All `dotsecenv` commands referenced (`secret store/get/share/revoke`, `vault describe/doctor`) and flag semantics (`--all` = "every vault containing NAME"; affects future writes only) cross-checked against `README.md` and `examples/02-team-share-revoke/` before drafting.
- `.secenv` plugin syntax (`{dotsecenv}`, `{dotsecenv/EXPLICIT_NAME}`, `{dotsecenv/namespace::KEY}`) cross-checked against `examples/05-secenv-shell-plugin/`.
- All cross-links inside `recipes/` resolve to existing files (`../examples/0[1-5]-*`, `../SECURITY.md`, sibling recipes).
- `context7.json` validates as JSON.

## Related Issue

N/A — follow-up to #121 (initial Context7 indexing config).

## Type of Change

- [x] Documentation update

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and fixed any issues — N/A (docs-only, no Go changes)
- [x] I have run `make test` and all tests pass — N/A (docs-only, no Go changes)
- [ ] I have added tests that prove my fix/feature works — N/A
- [x] I have updated documentation (if applicable) — that's the whole PR
- [x] My commit messages follow the conventional commit format
- [x] I have not included any secrets or credentials

## Testing

Manual verification of internal links and command syntax against existing repo content. Empirical signal will come from re-running the Context7 quality eval against indexed content after merge.

## Screenshots

N/A