### PR TITLE
docs(recipes): cross-link to canonical website pages and humanize prose

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ dotsecenv secret get TEST_SECRET # should output "xyz"
 
 > **Encryption defaults.** Vaults use **AES-256-GCM** symmetric
 > encryption (RFC 9580 / NIST SP 800-38D) wrapped in GPG
-> multi-recipient asymmetric encryption, with FIPS-compliant
-> defaults out of the box — no extra flags needed at `init` time.
+> multi-recipient asymmetric encryption. FIPS-compliant defaults are
+> applied out of the box, with no extra flags at `init` time.
 > To enforce specific algorithms across a team (or narrow them
 > further), drop a `policy.d/*.yaml` fragment with
 > `approved_algorithms`; see [example 04](./examples/04-policy-directory/).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -115,7 +115,7 @@ This is a deliberate trade-off: append-only preserves a verifiable
 audit trail at the cost of being unable to "unsay" past
 ciphertext. If you need ciphertext to be unrecoverable from the
 vault file itself, the only option is to rewrite git history (e.g.
-`git filter-repo`) and force every consumer to re-clone — and even
+`git filter-repo`) and force every consumer to re-clone. Even
 then, anyone who already cloned the old history retains the old
 encrypted entries.
 

--- a/recipes/add-secret.md
+++ b/recipes/add-secret.md
@@ -1,7 +1,15 @@
 # Add a secret to a vault
 
-How to add (or update) a secret while preserving the append-only audit
-trail that dotsecenv vaults provide.
+Add or update a secret in a dotsecenv vault. Every `secret store`
+call appends a new entry, so the vault keeps a full history of
+prior values.
+
+> **Looking for a step-by-step walkthrough?** The canonical
+> long-form versions live on dotsecenv.com:
+> [First Secret tutorial](https://dotsecenv.com/tutorials/first-secret/)
+> for the guided path, and
+> [Create a Secret how-to](https://dotsecenv.com/how-to/#create-a-secret)
+> for short reference snippets (stdin, file, namespace, specific vault).
 
 ## Command
 
@@ -10,19 +18,19 @@ echo "<value>" | dotsecenv secret store <NAME>
 ```
 
 `secret store` reads the value from stdin and appends a new entry to
-the active vault. There is no `secret add` or `secret update` —
-storing a value is the single operation, whether the name exists or
+the active vault. There is no `secret add` or `secret update`.
+Storing a value is the single operation, whether the name exists or
 not.
 
 ## How append-only works
 
 Each call to `secret store` writes a new line to the vault. Vaults
-are **append-only signed JSONL files**: every prior version of every
+are append-only signed JSONL files: every prior version of every
 secret remains in the file as its own line, encrypted to whichever
 recipients were valid at the time it was written.
 
-When you read with `secret get`, the latest entry wins. When you
-inspect with `vault describe`, you see the full history.
+When you read with `secret get`, the latest entry wins. `vault
+describe` shows the full history.
 
 ## Inspect the audit trail
 
@@ -59,7 +67,8 @@ rotate the underlying secret at its source.
 
 ## See also
 
-- [Quickstart example](../examples/01-quickstart/)
-- [Team share + revoke + rotate example](../examples/02-team-share-revoke/)
-- [Rotate a compromised key](rotate-compromised-key.md)
-- [Concepts: append-only vault](https://dotsecenv.com/concepts/)
+- Tutorial: [First Secret](https://dotsecenv.com/tutorials/first-secret/)
+- How-to: [Create a Secret](https://dotsecenv.com/how-to/#create-a-secret)
+- Concept: [Vault Format](https://dotsecenv.com/concepts/vault-format/)
+- Runnable example: [`examples/01-quickstart/`](../examples/01-quickstart/)
+- Recipe: [Rotate a compromised key](rotate-compromised-key.md)

--- a/recipes/migrate-from-dotenv.md
+++ b/recipes/migrate-from-dotenv.md
@@ -1,9 +1,15 @@
 # Migrate from `.env` to dotsecenv
 
-Coming from a `.env` file? dotsecenv replaces it but with a different
-mental model: secrets are stored **per key**, not as a `.env` blob.
-There is no bulk-import command for a `.env` file because the unit of
-encryption and audit is the individual secret.
+dotsecenv replaces a `.env` file with one important difference: it
+stores secrets one key at a time, not as a single text blob. There is
+no bulk-import command, because the unit of encryption and audit is
+the individual secret.
+
+> **Looking for a step-by-step walkthrough?** The canonical version
+> is the [Migrate from .env tutorial](https://dotsecenv.com/tutorials/migrate-from-dotenv/)
+> on dotsecenv.com. The [.env how-to section](https://dotsecenv.com/how-to/#work-with-env-files)
+> has additional patterns (`.env` for non-sensitive config alongside
+> `.secenv` for secrets).
 
 ## Mental model
 
@@ -71,8 +77,8 @@ SENTRY_DSN={dotsecenv}
 The `{dotsecenv}` placeholder fetches a secret with the same name
 as the variable. Other supported forms:
 
-- `{dotsecenv/EXPLICIT_NAME}` — fetch a differently-named secret.
-- `{dotsecenv/namespace::KEY}` — namespaced lookup.
+- `{dotsecenv/EXPLICIT_NAME}`: fetch a differently-named secret.
+- `{dotsecenv/namespace::KEY}`: namespaced lookup.
 
 When you `cd` in, the plugin exports plain `KEY=value` lines as
 environment variables and shells out to `dotsecenv secret get` to
@@ -85,18 +91,20 @@ per-directory trust).
 
 - **Editing values.** Instead of editing a line in `.env`, run
   `echo NEW | dotsecenv secret store NAME`. The old value is
-  preserved in the vault for audit — see
-  [add a secret](add-secret.md).
+  preserved in the vault for audit (see
+  [add a secret](add-secret.md)).
 - **Sharing values.** Instead of pasting `.env` over Slack, add a
   teammate as a recipient with
   `dotsecenv secret share NAME <THEIR_FINGERPRINT> --all`.
 - **Rotating values.** Instead of "rotate everything when someone
-  leaves", revoke and rotate the affected secrets — see
+  leaves", revoke and rotate the affected secrets. See
   [rotate a compromised key](rotate-compromised-key.md).
 
 ## See also
 
-- [Quickstart example](../examples/01-quickstart/)
-- [Shell plugin example](../examples/05-secenv-shell-plugin/)
-- [Add a secret](add-secret.md)
-- [Rotate a compromised key](rotate-compromised-key.md)
+- Tutorial: [Migrate from .env](https://dotsecenv.com/tutorials/migrate-from-dotenv/)
+- How-to: [Work with .env Files](https://dotsecenv.com/how-to/#work-with-env-files)
+- Guide: [Shell Plugins](https://dotsecenv.com/guides/shell-plugins/)
+- Runnable example: [`examples/05-secenv-shell-plugin/`](../examples/05-secenv-shell-plugin/)
+- Recipe: [Add a secret](add-secret.md)
+- Recipe: [Rotate a compromised key](rotate-compromised-key.md)

--- a/recipes/rotate-compromised-key.md
+++ b/recipes/rotate-compromised-key.md
@@ -1,30 +1,35 @@
 # Rotate a compromised GPG key
 
-How to remove a compromised private key's access from your dotsecenv
-vaults — and what the append-only design means for the keys that
-already saw past secrets.
+How to remove a compromised private key from your dotsecenv vaults,
+and what the append-only design means for the entries that key
+already saw.
 
 The same workflow applies whether the compromised key is yours or a
 teammate's.
 
+> **Looking for the canonical version?** A consolidated walkthrough
+> lives in the [Recover from a Compromised GPG Key how-to](https://dotsecenv.com/how-to/#recover-from-a-compromised-gpg-key)
+> on dotsecenv.com. Background reading: the
+> [Threat Model](https://dotsecenv.com/concepts/threat-model/) and
+> [Revoke Access tutorial](https://dotsecenv.com/tutorials/revoke-access/).
+
 ## Mental model first
 
-dotsecenv vaults are **append-only** and entries are encrypted to
-GPG public keys. This has two consequences for rotation:
+dotsecenv vaults are append-only and entries are encrypted to GPG
+public keys. Two consequences for rotation:
 
 1. **You cannot edit the past.** Old vault entries remain in the
    file and in `git` history, encrypted to whoever held the
    recipient list at the time. The compromised private key still
-   decrypts those entries — and any clone of the repo retains them.
+   decrypts those entries, and any clone of the repo retains them.
 2. **Revoking a recipient only affects future writes.** After
    `secret revoke`, new `secret store` entries are no longer
    encrypted to the revoked recipient. Past entries are unchanged.
 
-The durable mitigation is therefore to **rotate the underlying
-secret at its source** (issue a new database password, regenerate
-the API key, etc.) and then store the new value. The leaked key can
-still decrypt the old value, but the old value no longer
-authenticates to anything.
+The durable mitigation is to rotate the underlying secret at its
+source (issue a new database password, reissue the API key) and
+then store the new value. The leaked key can still decrypt the old
+value, but the old value no longer authenticates to anything.
 
 ## Runbook
 
@@ -65,9 +70,9 @@ store it:
 echo "<new-value>" | dotsecenv secret store <SECRET_NAME>
 ```
 
-This is the step that actually neutralizes the compromise. The
-leaked key can still decrypt every entry written before this point,
-but those entries hold values that no longer work.
+This is the step that neutralizes the compromise. The leaked key
+can still decrypt every entry written before this point, but those
+entries hold values that no longer work.
 
 ### 5. Verify
 
@@ -78,7 +83,7 @@ dotsecenv vault describe               # confirm recipient lists
 
 Every current secret should now list the replacement key as a
 recipient and **not** the compromised key. Past entries still show
-the compromised key — that is expected and unavoidable.
+the compromised key, which is expected and unavoidable.
 
 ### 6. Commit and push
 
@@ -99,8 +104,10 @@ trail.
 
 ## See also
 
-- [Add a secret](add-secret.md)
-- [Migrate from .env](migrate-from-dotenv.md)
-- [Team share + revoke + rotate example](../examples/02-team-share-revoke/)
-- [SECURITY.md](../SECURITY.md)
-- [Threat model](https://dotsecenv.com/concepts/threat-model/)
+- How-to: [Recover from a Compromised GPG Key](https://dotsecenv.com/how-to/#recover-from-a-compromised-gpg-key)
+- Tutorial: [Revoke Access](https://dotsecenv.com/tutorials/revoke-access/)
+- Concept: [Threat Model](https://dotsecenv.com/concepts/threat-model/)
+- Concept: [Vault Format](https://dotsecenv.com/concepts/vault-format/)
+- Runnable example: [`examples/02-team-share-revoke/`](../examples/02-team-share-revoke/)
+- Recipe: [Add a secret](add-secret.md)
+- Repo: [SECURITY.md](../SECURITY.md)


### PR DESCRIPTION
## Description

Follow-up to #122. Two related cleanups in the same diff:

### 1. Cross-link recipes to canonical website pages

Each recipe now points to the long-form canonical version on dotsecenv.com at the top, and lists tutorial / how-to / concept page links in "See also". The repo recipes stay as quick-reference chunks for readers landing via GitHub or via Context7's index of the CLI repo.

The mapping:

| Recipe                            | Canonical on dotsecenv.com                                  |
|-----------------------------------|-------------------------------------------------------------|
| `recipes/add-secret.md`           | `/tutorials/first-secret/`, `/how-to/#create-a-secret`      |
| `recipes/migrate-from-dotenv.md`  | `/tutorials/migrate-from-dotenv/`, `/how-to/#work-with-env-files` |
| `recipes/rotate-compromised-key.md` | `/how-to/#recover-from-a-compromised-gpg-key` (new), `/tutorials/revoke-access/`, `/concepts/threat-model/` |

The `/how-to/#recover-from-a-compromised-gpg-key` anchor is being added to the website in a parallel PR. The link will 404 briefly until that lands; once both are merged, the reference resolves.

### 2. Humanize prose

Editorial pass to reduce em-dash overuse and other patterns flagged as overly-formulaic:

- Reframed openers in all three recipes to be more direct.
- In-line bullet lists with em-dashes (`{dotsecenv/EXPLICIT_NAME} — fetch a differently-named secret`) switched to colons (`{dotsecenv/EXPLICIT_NAME}: fetch a differently-named secret`).
- `recipes/rotate-compromised-key.md`: `actually neutralizes` -> `neutralizes`; em-dash sentence breaks rewritten as periods or commas.
- `README.md`: AES-256-GCM callout split into two sentences rather than one em-dashed clause.
- `SECURITY.md`: rewrites the `re-clone — and even then` em-dash clause into a separate sentence.

No semantic changes. Commands, flag semantics, and behavior descriptions are unchanged.

## Related Issue

Follow-up to #121 (initial Context7 indexing config) and #122 (recipes/ directory).

## Type of Change

- [x] Documentation update

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and fixed any issues — N/A (docs-only)
- [x] I have run `make test` and all tests pass — N/A (docs-only)
- [ ] I have added tests that prove my fix/feature works — N/A
- [x] I have updated documentation (if applicable) — that's the whole PR
- [x] My commit messages follow the conventional commit format
- [x] I have not included any secrets or credentials

## Testing

Manually verified:
- All canonical website links resolve to existing pages on dotsecenv.com (except `/how-to/#recover-from-a-compromised-gpg-key`, which is added in the parallel website PR).
- Existing relative links inside `recipes/` still resolve.
- No content semantically changed; only wording and link targets.

## Screenshots

N/A