### PR TITLE
fix(demo): make `make demo` produce a working asciinema recording

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,14 +154,19 @@ demo: build
 		cp ../plugin/_dotsecenv_core.sh "$$DEMO_HOME/.local/share/dotsecenv/" 2>/dev/null || true; \
 		cp ../plugin/dotsecenv.plugin.bash "$$DEMO_HOME/.local/share/dotsecenv/" 2>/dev/null || true; \
 		cp ../plugin/dotsecenv.plugin.zsh "$$DEMO_HOME/.local/share/dotsecenv/" 2>/dev/null || true; \
+		printf '%s\n' \
+			'# dotsecenv demo bashrc' \
+			'[ -f "$$XDG_DATA_HOME/dotsecenv/dotsecenv.plugin.bash" ] && source "$$XDG_DATA_HOME/dotsecenv/dotsecenv.plugin.bash"' \
+			> "$$DEMO_HOME/.bashrc"; \
 	fi && \
-	echo "Generating GPG key for demo..." && \
-	GNUPGHOME="$$DEMO_HOME/.gnupg" gpg --batch --gen-key <<< $$'Key-Type: EDDSA\nKey-Curve: ed25519\nName-Real: Demo User\nName-Email: demo@dotsecenv\n%no-protection\n%commit' && \
+	echo "Generating GPG key for demo (via dotsecenv identity create)..." && \
+	HOME="$$DEMO_HOME" GNUPGHOME="$$DEMO_HOME/.gnupg" "$$DEMO_HOME/bin/dotsecenv" identity create --no-passphrase --name "Demo User" --email "demo@dotsecenv" && \
 	echo "" && \
 	echo "Demo environment ready at: $$DEMO_HOME" && \
-	echo "To record: asciinema rec -c 'HOME=$$DEMO_HOME bash $$DEMO_HOME/demos/demo.sh'" && \
+	echo "To record (asciinema v3+): asciinema rec -c 'HOME=$$DEMO_HOME bash $$DEMO_HOME/demos/demo.sh' --overwrite <output.cast>" && \
 	echo "" && \
 	echo "Entering demo shell (type 'exit' when done)..." && \
+	cd "$$DEMO_HOME" && \
 	HOME="$$DEMO_HOME" \
 	PATH="$$DEMO_HOME/bin:$$PATH" \
 	GNUPGHOME="$$DEMO_HOME/.gnupg" \

--- a/demos/demo.sh
+++ b/demos/demo.sh
@@ -81,7 +81,15 @@ pe "echo 'DATABASE_PASSWORD={dotsecenv}' > .secenv"
 p ""
 p "# Since we have previously installed the shell plugin from <https://github.com/dotsecenv/plugin>,"
 p "# cd-ing into a directory with a .secenv file will use dotsecenv to define the env secret automatically."
-pe "cd ."
+pe "cd \"\$PWD\""
+# demo-magic uses eval, so bash never redraws its prompt between commands and
+# PROMPT_COMMAND-based hooks don't fire. In a real interactive shell the cd
+# above would trigger this automatically; here we invoke the hook directly so
+# the recording reflects real-world behavior.
+# Pre-trust the dir for the session so the plugin's first-time trust prompt
+# (read -r) doesn't hang the recorded shell, which has a TTY but no typist.
+_dotsecenv_trust_session "$PWD" 2>/dev/null || true
+_dotsecenv_chpwd_hook 2>/dev/null || true
 p "# DATABASE_PASSWORD is now available as an env var:"
 pe "echo \$DATABASE_PASSWORD"
 


### PR DESCRIPTION
## Summary

Fixes a series of bugs that made `make demo` unable to produce a usable asciinema recording against the current dotsecenv CLI and shell plugin. Discovered while trying to refresh the website's `public/demo.cast` from a stale 2025-12 cut.

### `Makefile`

- Update the asciinema record hint to v3+ syntax (positional `<output.cast>` + `--overwrite`).
- Replace the `gpg --batch --gen-key` invocation with `dotsecenv identity create --no-passphrase --name "Demo User" --email "demo@dotsecenv"`. The previous batch generated an Ed25519 *signing-only* key (no encryption subkey), so `dotsecenv secret store` rejected it. Adding `Subkey-Type: ECDH` to the batch then triggered `agent_genkey failed: Not supported` on some gpg-agent versions. Using the tool's own key generator sidesteps both issues, dogfoods the CLI, and respects `approved_algorithms`.
- `cd "$DEMO_HOME"` before launching `bash -i` so the user lands in the sandbox dir instead of `dotsecenv/`.
- Seed `$DEMO_HOME/.bashrc` to source the bash plugin from `$XDG_DATA_HOME/dotsecenv/dotsecenv.plugin.bash`, so `dse`, `reloadsecenv`, and the `cd` hook are available in the interactive sandbox shell for manual testing pre-record.

### `demos/demo.sh`

- demo-magic's `pe` runs commands via `eval`; bash never redraws its prompt between scripted commands, so the plugin's `PROMPT_COMMAND`-based hook never fires. The previous `cd .` was also a `$PWD` no-op (would be skipped by the hook's PWD-equality short-circuit anyway). Replaced with `cd "$PWD"` and an explicit `_dotsecenv_chpwd_hook` call so the recording mirrors what an interactive shell does.
- Pre-trust the dir with `_dotsecenv_trust_session "$PWD"` before the hook fires. Otherwise the plugin's first-time `_dotsecenv_prompt_trust` blocks on `read -r` — asciinema attaches a TTY but no typist is present, hanging the recording forever.

## Test plan

- [x] `make demo` succeeds end-to-end on macOS (no more `agent_genkey: Not supported`).
- [x] `dse` and `reloadsecenv` resolve in the interactive sandbox shell.
- [x] `asciinema rec --overwrite -c 'HOME=$DEMO_HOME bash $DEMO_HOME/demos/demo.sh' out.cast` exits 0 and the recording shows `my-database-password` after `echo $DATABASE_PASSWORD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)