### PR TITLE
fix(demo): write recording to a path that survives sandbox cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,14 +154,19 @@ demo: build
 		cp ../plugin/_dotsecenv_core.sh "$$DEMO_HOME/.local/share/dotsecenv/" 2>/dev/null || true; \
 		cp ../plugin/dotsecenv.plugin.bash "$$DEMO_HOME/.local/share/dotsecenv/" 2>/dev/null || true; \
 		cp ../plugin/dotsecenv.plugin.zsh "$$DEMO_HOME/.local/share/dotsecenv/" 2>/dev/null || true; \
+		printf '%s\n' \
+			'# dotsecenv demo bashrc' \
+			'[ -f "$$XDG_DATA_HOME/dotsecenv/dotsecenv.plugin.bash" ] && source "$$XDG_DATA_HOME/dotsecenv/dotsecenv.plugin.bash"' \
+			> "$$DEMO_HOME/.bashrc"; \
 	fi && \
-	echo "Generating GPG key for demo..." && \
-	GNUPGHOME="$$DEMO_HOME/.gnupg" gpg --batch --gen-key <<< $$'Key-Type: EDDSA\nKey-Curve: ed25519\nName-Real: Demo User\nName-Email: demo@dotsecenv\n%no-protection\n%commit' && \
+	echo "Generating GPG key for demo (via dotsecenv identity create)..." && \
+	HOME="$$DEMO_HOME" GNUPGHOME="$$DEMO_HOME/.gnupg" "$$DEMO_HOME/bin/dotsecenv" identity create --no-passphrase --name "Demo User" --email "demo@dotsecenv" && \
 	echo "" && \
 	echo "Demo environment ready at: $$DEMO_HOME" && \
-	echo "To record: asciinema rec -c 'HOME=$$DEMO_HOME bash $$DEMO_HOME/demos/demo.sh'" && \
+	echo "To record (asciinema v3+): asciinema rec -c 'HOME=$$DEMO_HOME bash $$DEMO_HOME/demos/demo.sh' --overwrite <output.cast>" && \
 	echo "" && \
 	echo "Entering demo shell (type 'exit' when done)..." && \
+	cd "$$DEMO_HOME" && \
 	HOME="$$DEMO_HOME" \
 	PATH="$$DEMO_HOME/bin:$$PATH" \
 	GNUPGHOME="$$DEMO_HOME/.gnupg" \

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ demo: build
 	echo "                             (outside the sandbox so it survives cleanup)" && \
 	echo "" && \
 	echo "To record (asciinema v3+), paste:" && \
-	echo "  asciinema rec -c 'HOME=$$DEMO_HOME bash $$DEMO_HOME/demos/demo.sh' --overwrite '$$DEMO_OUT'" && \
+	echo "  asciinema record -c 'HOME=$$DEMO_HOME bash demos/demo.sh' --title 'DotSecEnv demo' --overwrite '$$DEMO_OUT'" && \
 	echo "" && \
 	echo "Entering demo shell (type 'exit' when done)..." && \
 	cd "$$DEMO_HOME" && \

--- a/Makefile
+++ b/Makefile
@@ -161,9 +161,18 @@ demo: build
 	fi && \
 	echo "Generating GPG key for demo (via dotsecenv identity create)..." && \
 	HOME="$$DEMO_HOME" GNUPGHOME="$$DEMO_HOME/.gnupg" "$$DEMO_HOME/bin/dotsecenv" identity create --no-passphrase --name "Demo User" --email "demo@dotsecenv" && \
+	if [ -d ../website/public ]; then \
+		DEMO_OUT="$$(cd ../website/public && pwd)/demo.cast"; \
+	else \
+		DEMO_OUT="$$(pwd)/demo.cast"; \
+	fi && \
 	echo "" && \
-	echo "Demo environment ready at: $$DEMO_HOME" && \
-	echo "To record (asciinema v3+): asciinema rec -c 'HOME=$$DEMO_HOME bash $$DEMO_HOME/demos/demo.sh' --overwrite <output.cast>" && \
+	echo "Demo environment ready at:   $$DEMO_HOME" && \
+	echo "Recording will be saved to:  $$DEMO_OUT" && \
+	echo "                             (outside the sandbox so it survives cleanup)" && \
+	echo "" && \
+	echo "To record (asciinema v3+), paste:" && \
+	echo "  asciinema rec -c 'HOME=$$DEMO_HOME bash $$DEMO_HOME/demos/demo.sh' --overwrite '$$DEMO_OUT'" && \
 	echo "" && \
 	echo "Entering demo shell (type 'exit' when done)..." && \
 	cd "$$DEMO_HOME" && \
@@ -174,6 +183,7 @@ demo: build
 	XDG_DATA_HOME="$$DEMO_HOME/.local/share" \
 	XDG_STATE_HOME="$$DEMO_HOME/.local/state" \
 	XDG_CACHE_HOME="$$DEMO_HOME/.cache" \
+	DEMO_OUT="$$DEMO_OUT" \
 	bash -i && \
 	echo "Cleaning up $$DEMO_HOME" && \
 	rm -rf "$$DEMO_HOME"

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,7 @@ demo: build
 	chmod 700 "$$DEMO_HOME/.gnupg" && \
 	cp bin/dotsecenv "$$DEMO_HOME/bin/" && \
 	cp demos/demo.sh "$$DEMO_HOME/demos/" && \
+	chmod +x "$$DEMO_HOME/demos/demo.sh" && \
 	echo "Downloading demo-magic..." && \
 	curl -fsSL https://raw.githubusercontent.com/paxtonhare/demo-magic/master/demo-magic.sh -o "$$DEMO_HOME/demos/_demo-magic.sh" && \
 	if [ -d ../plugin ]; then \
@@ -172,7 +173,7 @@ demo: build
 	echo "                             (outside the sandbox so it survives cleanup)" && \
 	echo "" && \
 	echo "To record (asciinema v3+), paste:" && \
-	echo "  asciinema record -c 'HOME=$$DEMO_HOME bash demos/demo.sh' --title 'DotSecEnv demo' --overwrite '$$DEMO_OUT'" && \
+	echo "  asciinema record -c 'demos/demo.sh' --title 'DotSecEnv demo' --overwrite '$$DEMO_OUT'" && \
 	echo "" && \
 	echo "Entering demo shell (type 'exit' when done)..." && \
 	cd "$$DEMO_HOME" && \

--- a/demos/demo.sh
+++ b/demos/demo.sh
@@ -81,7 +81,15 @@ pe "echo 'DATABASE_PASSWORD={dotsecenv}' > .secenv"
 p ""
 p "# Since we have previously installed the shell plugin from <https://github.com/dotsecenv/plugin>,"
 p "# cd-ing into a directory with a .secenv file will use dotsecenv to define the env secret automatically."
-pe "cd ."
+pe "cd \"\$PWD\""
+# demo-magic uses eval, so bash never redraws its prompt between commands and
+# PROMPT_COMMAND-based hooks don't fire. In a real interactive shell the cd
+# above would trigger this automatically; here we invoke the hook directly so
+# the recording reflects real-world behavior.
+# Pre-trust the dir for the session so the plugin's first-time trust prompt
+# (read -r) doesn't hang the recorded shell, which has a TTY but no typist.
+_dotsecenv_trust_session "$PWD" 2>/dev/null || true
+_dotsecenv_chpwd_hook 2>/dev/null || true
 p "# DATABASE_PASSWORD is now available as an env var:"
 pe "echo \$DATABASE_PASSWORD"
 


### PR DESCRIPTION
## Summary

Follow-up to #124. Two distinct fixes, both noticed while actually trying to refresh the website's `public/demo.cast`:

### 1. Recordings vanished into the cleaned-up sandbox

`make demo` `cd`s into `$DEMO_HOME` (a `mktemp -d`) before launching `bash -i`, so any `asciinema record ... --overwrite 1.cast` writes inside the sandbox dir. The trailing `rm -rf "$DEMO_HOME"` on shell exit then wipes the recording — re-recording in a loop produces no visible change anywhere.

Fix: resolve an absolute `DEMO_OUT` path *before* entering the sandbox.

- if the sibling website repo is present (`../website/public/`), use `<absolute>/demo.cast` — the natural target for the published demo;
- otherwise fall back to `<launch-dir>/demo.cast` (the dotsecenv repo root).

`DEMO_OUT` is also exported into the sandbox shell for power users.

### 2. Polish the printed asciinema command

- `asciinema rec` → `asciinema record` (full subcommand name; matches upstream docs).
- `bash $DEMO_HOME/demos/demo.sh` → `bash demos/demo.sh` (sandbox already starts with `cd $DEMO_HOME`; relative form reads better in the recording header's `command` field).
- Add `--title 'DotSecEnv demo'` so the resulting `.cast` carries the title in its v3 header. Players (the embedded one on the site, asciinema.org) use this for tab/share metadata; without it the recording is anonymous.

### Combined output

```
Demo environment ready at:   /var/folders/.../tmp.XXXX
Recording will be saved to:  /Users/you/git/dotsecenv/dse2/website/public/demo.cast
                             (outside the sandbox so it survives cleanup)

To record (asciinema v3+), paste:
  asciinema record -c 'HOME=/var/folders/.../tmp.XXXX bash demos/demo.sh' --title 'DotSecEnv demo' --overwrite '/Users/you/git/dotsecenv/dse2/website/public/demo.cast'
```

## Test plan

- [x] PR is `CLEAN` / `MERGEABLE` after merging `main` (#124 squash-merged into the same area).
- [ ] `make demo` from `dotsecenv/` (with `../website/` sibling) prints a hint pointing at `website/public/demo.cast`.
- [ ] `make demo` without the sibling falls back to `$(pwd)/demo.cast`.
- [ ] Pasting the printed command, exiting the sandbox, and inspecting `head -1 $DEMO_OUT` shows `"title":"DotSecEnv demo"` in the v3 header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)