### PR TITLE
docs: claim Context7 library ownership in context7.json

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,5 +1,7 @@
 {
   "$schema": "https://context7.com/schema/context7.json",
+  "url": "https://context7.com/dotsecenv/dotsecenv",
+  "public_key": "pk_2roJOPCKyA0N9cvHBCjPr",
   "projectTitle": "dotsecenv",
   "description": "Go CLI for securely managing environment secrets with GPG-based encryption, multi-user support, and FIPS 186-5 compliant defaults.",
   "folders": [],


### PR DESCRIPTION
## Summary
- Add the paired `url` and `public_key` fields to `context7.json` so the indexed library at https://context7.com/dotsecenv/dotsecenv is claimed by the dotsecenv team.
- Both fields are required together by the Context7 schema for ownership verification.

## Test plan
- [ ] Verify Context7 picks up the ownership claim after merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)