### PR TITLE
docs(example-05): align debugging table with real plugin messages

### DIFF
--- a/examples/05-secenv-shell-plugin/README.md
+++ b/examples/05-secenv-shell-plugin/README.md
@@ -92,13 +92,15 @@ for you on `cd`; only manual sourcing trips on it.
 
 ## Debugging
 
-| Symptom                                       | Likely cause                                    | Fix                                                                          |
-| --------------------------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------- |
-| Plugin doesn't activate on `cd`               | Plugin not installed or not sourced             | Reinstall via `install.sh`; restart shell                                    |
-| "refusing to load .secenv: insecure perms"    | World-writable file                             | `chmod 600 .secenv`                                                          |
-| "refusing to load .secenv: untrusted dir"     | First time loading from this dir                | Run the trust prompt or `dotsecenv ...` whatever the plugin suggests          |
-| "secret X not found in any configured vault"  | Vault path mismatch or secret key not in vault  | `dotsecenv vault describe` to inspect; `dotsecenv secret get` to list keys   |
-| "secret X failed to decrypt"                  | Your fingerprint isn't a recipient              | Have a teammate run `dotsecenv secret share X $YOUR_FINGERPRINT`             |
+| Symptom                                                         | Likely cause                                    | Fix                                                                        |
+| --------------------------------------------------------------- | ----------------------------------------------- | -------------------------------------------------------------------------- |
+| Plugin doesn't activate on `cd`                                 | Plugin not installed or not sourced             | Reinstall via `install.sh`; restart shell                                  |
+| `refusing to load <file> - world-writable`                      | `.secenv` mode has the world-write bit set      | `chmod go-w .secenv` (`chmod 600` also works)                              |
+| `refusing to load <file> - not owned by current user or root`   | File belongs to another non-root user           | `chown $(id -u) .secenv`                                                   |
+| `skipping <dir>/.secenv - no TTY for trust prompt`              | Running in CI or a non-interactive shell        | Skip the plugin in CI; call `dotsecenv secret get` directly                |
+| Trust prompt asks every new shell                               | Answered `y` (session) instead of `a` (always)  | Re-enter the directory and answer `a` to persist trust                     |
+| `secret X not found in any configured vault`                    | Vault path mismatch or secret key not in vault  | `dotsecenv vault describe` to inspect; `dotsecenv secret get` to list keys |
+| `secret X failed to decrypt`                                    | Your GPG fingerprint isn't a recipient          | Have a teammate run `dotsecenv secret share X $YOUR_FINGERPRINT`           |
 
 For deeper debugging the in-repo skill `skills/secenv/SKILL.md` is the
 canonical reference (and is what the dotsecenv Claude Code plugin uses).


### PR DESCRIPTION
## Summary
The plugin actually emits:
- `dotsecenv: refusing to load <file> - world-writable`
- `dotsecenv: refusing to load <file> - not owned by current user or root`
- `dotsecenv: skipping <dir>/.secenv - no TTY for trust prompt`

(verified in [`dotsecenv/plugin` `_dotsecenv_core.sh`](https://github.com/dotsecenv/plugin/blob/main/_dotsecenv_core.sh) lines ~92-105 and 160-168, and the matching fish version in `conf.d/dotsecenv.fish`).

The debugging table in `examples/05-secenv-shell-plugin/README.md` referenced two strings the plugin never prints (`"insecure perms"`, `"untrusted dir"`) and implied `chmod 600` was required when the actual check only rejects world-writable files (`chmod go-w` is sufficient — and the second half of the security check, ownership, was missing entirely).

This PR replaces those rows with the real messages, adds the matching ownership-check row, documents the no-TTY/CI behavior, and notes the session-vs-always trust distinction so users know to answer `a` when they want trust to persist across shells.

## Test plan
- [x] All listed messages cross-checked against `dotsecenv/plugin` source
- [x] `chmod go-w` confirmed as the minimum to satisfy the world-writable check
- [ ] Render the updated table on GitHub and eyeball column widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)