### PR TITLE
feat: expose available_to and signed_by in --all JSON output

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,6 +169,9 @@ making changes that look like they might violate them.
 | Vulnerability reporting          | [SECURITY.md](./SECURITY.md)                    |
 | Code of Conduct                  | [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)      |
 | Full docs site (Diátaxis)        | <https://dotsecenv.com>                         |
+| Team-lead vault setup tutorial   | <https://dotsecenv.com/tutorials/team-vault-setup/> |
+| Audit trail concepts and queries | <https://dotsecenv.com/concepts/audit-trail/>   |
+| GPG agent operational reference  | <https://dotsecenv.com/guides/gpg-agent/>       |
 | Claude Code skill: `.secenv` files | [skills/secenv/SKILL.md](./skills/secenv/SKILL.md) |
 | Claude Code skill: vault ops     | [skills/secrets/SKILL.md](./skills/secrets/SKILL.md) |
 | Plugin manifest                  | [.claude-plugin/plugin.json](./.claude-plugin/plugin.json) |

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -1484,3 +1484,193 @@ func TestSecretGet_FallbackNotFound(t *testing.T) {
 		t.Errorf("Expected 'not found' in error message, got: %s", err.Message)
 	}
 }
+
+// TestSecretGet_JSONOutput_AllMode_IncludesAvailableToAndSignedBy verifies that
+// `secret get NAME --all --json` exposes per-value available_to and signed_by,
+// which are required for auditing access control across versions.
+func TestSecretGet_JSONOutput_AllMode_IncludesAvailableToAndSignedBy(t *testing.T) {
+	t.Setenv("DOTSECENV_CONFIG", "")
+
+	loggedInFP := "ALICEFP"
+	otherFP := "BOBFP"
+
+	now := time.Now().UTC()
+	older := now.Add(-1 * time.Hour)
+
+	mockVaultResolver := NewMockVaultResolver()
+	mockVaultResolver.Secrets[0] = map[string]vault.Secret{
+		"DB_PASSWORD": {
+			Key: "DB_PASSWORD",
+			Values: []vault.SecretValue{
+				{AddedAt: older, Value: "b2xk", AvailableTo: []string{loggedInFP}, SignedBy: loggedInFP},
+				{AddedAt: now, Value: "bmV3", AvailableTo: []string{loggedInFP, otherFP}, SignedBy: otherFP},
+			},
+		},
+	}
+	mockVaultResolver.VaultPaths = []string{"/vault.yaml"}
+	mockVaultResolver.VaultEntries = []vault.VaultEntry{{Path: "/vault.yaml"}}
+
+	mockGPGClient := &MockGPGClientWithDecrypt{
+		MockGPGClient: NewMockGPGClient(),
+		DecryptFunc: func(ciphertext []byte, fingerprint string) ([]byte, error) {
+			return []byte("plaintext"), nil
+		},
+	}
+
+	mockConfig := config.Config{
+		ApprovedAlgorithms: []config.ApprovedAlgorithm{{Algo: "RSA", MinBits: 2048}},
+		Login:              newTestSignedLogin(t, loggedInFP),
+	}
+
+	stdoutBuf := &bytes.Buffer{}
+	stderrBuf := &bytes.Buffer{}
+
+	cli := &CLI{
+		config:        mockConfig,
+		vaultResolver: mockVaultResolver,
+		gpgClient:     mockGPGClient,
+		stdin:         strings.NewReader(""),
+		output:        output.NewHandler(stdoutBuf, stderrBuf),
+	}
+
+	if err := cli.SecretGet("DB_PASSWORD", true, false, true, "", 0); err != nil {
+		t.Fatalf("SecretGet --all --json failed: %v", err)
+	}
+
+	var results []map[string]interface{}
+	if err := json.Unmarshal(stdoutBuf.Bytes(), &results); err != nil {
+		t.Fatalf("Failed to parse JSON output: %v\nOutput: %s", err, stdoutBuf.String())
+	}
+	if len(results) != 2 {
+		t.Fatalf("Expected 2 entries, got %d", len(results))
+	}
+
+	// Sorted newest-first: results[0] is the recent value (signed by Bob, shared with both)
+	got := results[0]
+	if got["signed_by"] != otherFP {
+		t.Errorf("Expected signed_by=%q on newest value, got: %v", otherFP, got["signed_by"])
+	}
+	availableTo, ok := got["available_to"].([]interface{})
+	if !ok {
+		t.Fatalf("Expected available_to to be an array on newest value, got %T: %v", got["available_to"], got["available_to"])
+	}
+	if len(availableTo) != 2 {
+		t.Errorf("Expected 2 fingerprints on newest value, got %d", len(availableTo))
+	}
+
+	// results[1] is the older value (signed by Alice, only Alice has access)
+	older2 := results[1]
+	if older2["signed_by"] != loggedInFP {
+		t.Errorf("Expected signed_by=%q on older value, got: %v", loggedInFP, older2["signed_by"])
+	}
+}
+
+// TestSecretGet_JSONOutput_NoAll_OmitsAvailableToAndSignedBy verifies that the
+// single-value JSON output stays lean and does not leak access metadata.
+func TestSecretGet_JSONOutput_NoAll_OmitsAvailableToAndSignedBy(t *testing.T) {
+	t.Setenv("DOTSECENV_CONFIG", "")
+
+	testFP := "TESTFP"
+
+	mockVaultResolver := NewMockVaultResolver()
+	mockVaultResolver.Secrets[0] = map[string]vault.Secret{
+		"API_KEY": {
+			Key: "API_KEY",
+			Values: []vault.SecretValue{
+				{AddedAt: time.Now().UTC(), Value: "c2VjcmV0", AvailableTo: []string{testFP}, SignedBy: testFP},
+			},
+		},
+	}
+	mockVaultResolver.VaultPaths = []string{"/vault.yaml"}
+	mockVaultResolver.VaultEntries = []vault.VaultEntry{{Path: "/vault.yaml"}}
+
+	mockGPGClient := &MockGPGClientWithDecrypt{
+		MockGPGClient: NewMockGPGClient(),
+		DecryptFunc: func(ciphertext []byte, fingerprint string) ([]byte, error) {
+			return []byte("plaintext"), nil
+		},
+	}
+
+	mockConfig := config.Config{
+		ApprovedAlgorithms: []config.ApprovedAlgorithm{{Algo: "RSA", MinBits: 2048}},
+		Login:              newTestSignedLogin(t, testFP),
+	}
+
+	stdoutBuf := &bytes.Buffer{}
+	stderrBuf := &bytes.Buffer{}
+
+	cli := &CLI{
+		config:        mockConfig,
+		vaultResolver: mockVaultResolver,
+		gpgClient:     mockGPGClient,
+		stdin:         strings.NewReader(""),
+		output:        output.NewHandler(stdoutBuf, stderrBuf),
+	}
+
+	if err := cli.SecretGet("API_KEY", false, false, true, "", 0); err != nil {
+		t.Fatalf("SecretGet --json failed: %v", err)
+	}
+
+	var result map[string]interface{}
+	if err := json.Unmarshal(stdoutBuf.Bytes(), &result); err != nil {
+		t.Fatalf("Failed to parse JSON: %v\nOutput: %s", err, stdoutBuf.String())
+	}
+
+	if _, present := result["available_to"]; present {
+		t.Errorf("Expected available_to to be omitted in non-all JSON output, got: %v", result["available_to"])
+	}
+	if _, present := result["signed_by"]; present {
+		t.Errorf("Expected signed_by to be omitted in non-all JSON output, got: %v", result["signed_by"])
+	}
+}
+
+// TestVaultDescribeSecretJSON_OmitemptyContract documents the JSON contract for
+// VaultDescribeSecretJSON: AvailableTo is omitted for deleted secrets and
+// secrets with no values, and present for active secrets with recipients.
+func TestVaultDescribeSecretJSON_OmitemptyContract(t *testing.T) {
+	cases := []struct {
+		name         string
+		input        VaultDescribeSecretJSON
+		wantContains []string
+		wantOmits    []string
+	}{
+		{
+			name:         "active secret with recipients",
+			input:        VaultDescribeSecretJSON{Key: "DB", AvailableTo: []string{"FP1", "FP2"}},
+			wantContains: []string{`"key":"DB"`, `"available_to":["FP1","FP2"]`},
+			wantOmits:    []string{`"deleted"`},
+		},
+		{
+			name:         "deleted secret",
+			input:        VaultDescribeSecretJSON{Key: "OLD", Deleted: true},
+			wantContains: []string{`"key":"OLD"`, `"deleted":true`},
+			wantOmits:    []string{`"available_to"`},
+		},
+		{
+			name:         "secret with no values",
+			input:        VaultDescribeSecretJSON{Key: "EMPTY"},
+			wantContains: []string{`"key":"EMPTY"`},
+			wantOmits:    []string{`"available_to"`, `"deleted"`},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := json.Marshal(tc.input)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			got := string(out)
+			for _, sub := range tc.wantContains {
+				if !strings.Contains(got, sub) {
+					t.Errorf("expected output to contain %q, got: %s", sub, got)
+				}
+			}
+			for _, sub := range tc.wantOmits {
+				if strings.Contains(got, sub) {
+					t.Errorf("expected output to omit %q, got: %s", sub, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -1674,3 +1674,88 @@ func TestVaultDescribeSecretJSON_OmitemptyContract(t *testing.T) {
 		})
 	}
 }
+
+// TestSecretValueJSON_OmitemptyContract documents the JSON contract for
+// SecretValueJSON: available_to and signed_by surface only when populated
+// (i.e. with --all), keeping the single-value JSON output unchanged.
+func TestSecretValueJSON_OmitemptyContract(t *testing.T) {
+	now := time.Date(2026, 4, 12, 10, 22, 1, 0, time.UTC)
+
+	cases := []struct {
+		name         string
+		input        SecretValueJSON
+		wantContains []string
+		wantOmits    []string
+	}{
+		{
+			name: "all-mode entry with access metadata",
+			input: SecretValueJSON{
+				AddedAt:     now,
+				Value:       "plaintext",
+				Vault:       "/path/to/vault",
+				AvailableTo: []string{"ALICE_FP", "BOB_FP"},
+				SignedBy:    "ALICE_FP",
+			},
+			wantContains: []string{
+				`"added_at":"2026-04-12T10:22:01Z"`,
+				`"value":"plaintext"`,
+				`"vault":"/path/to/vault"`,
+				`"available_to":["ALICE_FP","BOB_FP"]`,
+				`"signed_by":"ALICE_FP"`,
+			},
+		},
+		{
+			name: "single-value entry without access metadata",
+			input: SecretValueJSON{
+				AddedAt: now,
+				Value:   "plaintext",
+				Vault:   "/path/to/vault",
+			},
+			wantContains: []string{
+				`"added_at":"2026-04-12T10:22:01Z"`,
+				`"value":"plaintext"`,
+				`"vault":"/path/to/vault"`,
+			},
+			wantOmits: []string{
+				`"available_to"`,
+				`"signed_by"`,
+			},
+		},
+		{
+			name: "minimal entry omits all optional fields",
+			input: SecretValueJSON{
+				AddedAt: now,
+				Value:   "plaintext",
+			},
+			wantContains: []string{
+				`"added_at":"2026-04-12T10:22:01Z"`,
+				`"value":"plaintext"`,
+			},
+			wantOmits: []string{
+				`"vault"`,
+				`"available_to"`,
+				`"signed_by"`,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := json.Marshal(tc.input)
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			got := string(out)
+			for _, sub := range tc.wantContains {
+				if !strings.Contains(got, sub) {
+					t.Errorf("expected output to contain %q, got: %s", sub, got)
+				}
+			}
+			for _, sub := range tc.wantOmits {
+				if strings.Contains(got, sub) {
+					t.Errorf("expected output to omit %q, got: %s", sub, got)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/secret.go
+++ b/internal/cli/secret.go
@@ -16,11 +16,15 @@ import (
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/vault"
 )
 
-// SecretValueJSON is the JSON output structure for secret values
+// SecretValueJSON is the JSON output structure for secret values.
+// AvailableTo and SignedBy are populated when --all is used so the JSON
+// output is sufficient for auditing access control across versions.
 type SecretValueJSON struct {
-	AddedAt time.Time   `json:"added_at"`
-	Value   interface{} `json:"value"`
-	Vault   string      `json:"vault,omitempty"`
+	AddedAt     time.Time   `json:"added_at"`
+	Value       interface{} `json:"value"`
+	Vault       string      `json:"vault,omitempty"`
+	AvailableTo []string    `json:"available_to,omitempty"`
+	SignedBy    string      `json:"signed_by,omitempty"`
 }
 
 // smartJSONValue returns a json.RawMessage if the value is a JSON object or array,
@@ -387,9 +391,11 @@ func (c *CLI) SecretGet(secretKey string, all bool, last bool, jsonOutput bool, 
 			valStr := string(plaintext)
 			decryptedValues = append(decryptedValues, valStr)
 			decryptedValuesWithTime = append(decryptedValuesWithTime, SecretValueJSON{
-				AddedAt: val.AddedAt,
-				Value:   smartJSONValue(valStr),
-				Vault:   item.VaultPath,
+				AddedAt:     val.AddedAt,
+				Value:       smartJSONValue(valStr),
+				Vault:       item.VaultPath,
+				AvailableTo: val.AvailableTo,
+				SignedBy:    val.SignedBy,
 			})
 		}
 	} else {
@@ -521,9 +527,11 @@ func (c *CLI) vaultGetFromIndex(key string, index int, all bool, jsonOutput bool
 			valStr := string(plaintext)
 			decryptedValues = append(decryptedValues, valStr)
 			decryptedValuesWithTime = append(decryptedValuesWithTime, SecretValueJSON{
-				AddedAt: val.AddedAt,
-				Value:   smartJSONValue(valStr),
-				Vault:   vaultPath,
+				AddedAt:     val.AddedAt,
+				Value:       smartJSONValue(valStr),
+				Vault:       vaultPath,
+				AvailableTo: val.AvailableTo,
+				SignedBy:    val.SignedBy,
 			})
 		}
 	} else {

--- a/internal/cli/vault.go
+++ b/internal/cli/vault.go
@@ -114,10 +114,13 @@ func checkVaultWritable(vaultPath string) *Error {
 	return nil
 }
 
-// VaultDescribeSecretJSON represents a secret in the vault describe JSON output
+// VaultDescribeSecretJSON represents a secret in the vault describe JSON output.
+// AvailableTo reflects the current authorization snapshot (the most-recent value's
+// access list); it is omitted for deleted secrets and secrets without values.
 type VaultDescribeSecretJSON struct {
-	Key     string `json:"key"`
-	Deleted bool   `json:"deleted,omitempty"`
+	Key         string   `json:"key"`
+	Deleted     bool     `json:"deleted,omitempty"`
+	AvailableTo []string `json:"available_to,omitempty"`
 }
 
 // VaultDescribeIdentityJSON represents an identity in the vault describe JSON output
@@ -182,9 +185,14 @@ func (c *CLI) VaultDescribe(jsonOutput bool) *Error {
 				// Build secrets list
 				var secrets []VaultDescribeSecretJSON
 				for _, s := range vaultData.Secrets {
+					var availableTo []string
+					if !s.IsDeleted() && len(s.Values) > 0 {
+						availableTo = s.Values[len(s.Values)-1].AvailableTo
+					}
 					secrets = append(secrets, VaultDescribeSecretJSON{
-						Key:     s.Key,
-						Deleted: s.IsDeleted(),
+						Key:         s.Key,
+						Deleted:     s.IsDeleted(),
+						AvailableTo: availableTo,
 					})
 				}
 				sort.Slice(secrets, func(i, j int) bool {


### PR DESCRIPTION
## Summary
- Adds `available_to []string` and `signed_by string` to `SecretValueJSON` (populated only with `--all` so plain `secret get NAME --json` stays lean)
- Adds `available_to []string` to `VaultDescribeSecretJSON` (current authorization snapshot from the most-recent value's recipients; omitted for deleted/empty secrets)
- Makes `secret get NAME --all --json` and `vault describe --json` sufficient as the audit interface, removing the need to parse raw vault JSONL with `jq`

This is the CLI half of a paired set of changes addressing Context7 documentation feedback. The website PR (`docs/context7-feedback`) builds on these new fields for the new `concepts/audit-trail.mdx` page.

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] New tests: `TestSecretGet_JSONOutput_AllMode_IncludesAvailableToAndSignedBy`, `TestSecretGet_JSONOutput_NoAll_OmitsAvailableToAndSignedBy`, `TestVaultDescribeSecretJSON_OmitemptyContract`
- [x] Existing `TestSecretGet_JSONOutput` still passes (omitempty hides new fields when not in `--all` mode)
- [ ] Smoke test against a real 2-identity vault: `secret get NAME --all --json` shows `available_to`/`signed_by`; `secret get NAME --json` does not

🤖 Generated with [Claude Code](https://claude.com/claude-code)