### PR TITLE
docs: require PRs and tests for all changes to main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,8 +100,8 @@ test.
   `feat: behavior.* and gpg.program policy fields (last-set-wins) (#116)`.
   Allowed types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`,
   `style`. Breaking changes use `!`, e.g. `refactor!: drop SUID mode (#110)`.
-  Co-Authored-By footers are **not** used in this repo's history; don't add
-  them unless asked.
+  `Co-Authored-By` footers are welcome (e.g. for AI agents that helped
+  produce the change).
 - **Branches:** `feat/*`, `fix/*`, `docs/*`, etc. (see `CONTRIBUTING.md`).
 - **PRs only:** All changes land on `main` through pull requests. Don't
   push commits directly to `main`, even when your account holds a bypass

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,14 @@ test.
   Co-Authored-By footers are **not** used in this repo's history; don't add
   them unless asked.
 - **Branches:** `feat/*`, `fix/*`, `docs/*`, etc. (see `CONTRIBUTING.md`).
+- **PRs only:** All changes land on `main` through pull requests. Don't
+  push commits directly to `main`, even when your account holds a bypass
+  permission. Open a PR against `main` and let CI run.
+- **No change without tests:** Every behavior change ships with tests
+  that lock the new behavior in. New struct fields, new branches in
+  control flow, new flag handling, new error paths — each gets at least
+  one test that fails on the unchanged code. Pure refactors that go
+  through existing tests are the only exception.
 - **Linters:** `golangci-lint` v2.11.4 — pinned because v2.12.x had a
   checksum mismatch on release. Don't bump back to `latest` without verifying.
 - **Releases:** Triggered by pushing a signed semver tag. Use
@@ -144,6 +152,10 @@ making changes that look like they might violate them.
   `.goreleaser.yaml`.
 - **Don't bypass git hooks (`--no-verify`).** Pre-commit runs `make lint`;
   pre-push runs `make clean test build e2e`. If a hook fails, fix the cause.
+- **Don't push directly to `main`.** Branch protection allows bypass for
+  some accounts, but the convention is: branch, commit, push the branch,
+  open a PR. Direct pushes skip CI gates and review, and force-pushing
+  `main` to undo a direct push rewrites public history.
 - **Don't modify cryptographic invariants without explicit review.** This
   includes: vault entry signature checks, the SHA-256 hash chain in JSONL
   entries, the append-only writer, multi-recipient PGP encryption, and the


### PR DESCRIPTION
## Summary
Two related conventions added to AGENTS.md so future contributors (human or agent) follow the existing repo norms by default rather than discovering them at review time.

- **PRs only** — every change to `main` lands through a PR, even from accounts with branch-protection bypass. Calls out that direct pushes skip CI gates and that force-pushing `main` to undo a direct push rewrites public history.
- **No change without tests** — every behavior change ships with tests that lock the new behavior in. New struct fields, new branches in control flow, new flag handling, new error paths each need at least one test that would fail without the change. Pure refactors that pass through existing tests are the only exception.

Both rules are documented twice — positively under `## Conventions`, negatively (as `Don't`) under `## Don't do X` — matching the existing structure of the file.

## Test plan
- [x] `lefthook` lint passes (no Go changes; doc-only change)
- [x] `lefthook` test passes (no Go changes affect tests)