### PR TITLE
feat(login): filter sign-only keys + blank line before login summary

### DIFF
--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -62,6 +62,10 @@ func InitConfig(configPath string, initialVaults []string, gpgProgram string, lo
 			return NewError(fmt.Sprintf("failed to get public key for fingerprint '%s': %v\nMake sure your GPG key is available in gpg-agent", loginFingerprint, pubKeyErr), ExitGPGError)
 		}
 
+		if capErr := requireEncryptionCapableKey(publicKeyInfo, loginFingerprint); capErr != nil {
+			return capErr
+		}
+
 		_, _ = fmt.Fprintf(out.Stderr(), "Creating signed login for: %s (%s)\n", publicKeyInfo.UID, loginFingerprint)
 
 		// Create signed login proof

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -41,32 +41,46 @@ func CreateSignedLogin(gpgClient gpg.Client, fingerprint string) (*config.Login,
 	return createSignedLogin(gpgClient, fingerprint)
 }
 
-// selectSecretKey lists available secret keys and prompts the user to select one.
+// selectSecretKey lists encryption-capable secret keys and prompts the user
+// to select one. Sign-only keys are filtered out: login eventually needs a
+// key that can also encrypt secrets, so catching that mismatch here yields a
+// clearer error than letting the first `secret put` fail later.
 func (c *CLI) selectSecretKey() (string, *Error) {
-	keys, err := c.gpgClient.ListSecretKeys()
+	allKeys, err := c.gpgClient.ListSecretKeys()
 	if err != nil {
 		return "", NewError(fmt.Sprintf("failed to list secret keys: %v", err), ExitGPGError)
 	}
 
-	if len(keys) == 0 {
+	if len(allKeys) == 0 {
 		return "", NewError("no secret keys found in GPG keyring.\nCreate a GPG key first with: dotsecenv identity create", ExitGPGError)
 	}
 
-	// If only one key, auto-select it
+	keys, skipped := filterEncryptionCapableKeys(c.gpgClient, allKeys)
+
+	if len(keys) == 0 {
+		return "", NewError(
+			"no encryption-capable secret keys found in GPG keyring.\n"+
+				"All available keys are signing-only or could not be loaded.\n"+
+				"Create an encryption-capable GPG key with: dotsecenv identity create",
+			ExitGPGError,
+		)
+	}
+
+	if skipped > 0 {
+		_, _ = fmt.Fprintf(c.output.Stderr(), "Skipped %d signing-only or unreadable key(s).\n", skipped)
+	}
+
+	// If only one capable key, auto-select it
 	if len(keys) == 1 {
-		_, _ = fmt.Fprintf(c.output.Stdout(), "Auto-selecting the only available key: %s (%s)\n", keys[0].UID, keys[0].Fingerprint[:16]+"...")
+		_, _ = fmt.Fprintf(c.output.Stdout(), "Auto-selecting the only available key: %s (%s)\n", keys[0].UID, shortFingerprint(keys[0].Fingerprint))
+		_, _ = fmt.Fprintln(c.output.Stdout())
 		return keys[0].Fingerprint, nil
 	}
 
 	// Build display options for interactive selection
 	var options []string
 	for _, key := range keys {
-		// Show first 16 chars of fingerprint for readability
-		shortFP := key.Fingerprint
-		if len(shortFP) > 16 {
-			shortFP = shortFP[:16] + "..."
-		}
-		options = append(options, fmt.Sprintf("%s (%s)", key.UID, shortFP))
+		options = append(options, fmt.Sprintf("%s (%s)", key.UID, shortFingerprint(key.Fingerprint)))
 	}
 
 	_, _ = fmt.Fprintf(c.output.Stdout(), "Available secret keys:\n")
@@ -77,7 +91,35 @@ func (c *CLI) selectSecretKey() (string, *Error) {
 		return "", selectErr
 	}
 
+	_, _ = fmt.Fprintln(c.output.Stdout())
 	return keys[idx].Fingerprint, nil
+}
+
+// filterEncryptionCapableKeys returns the subset of `keys` whose public key
+// loads successfully and is encryption-capable. Both load failures and
+// sign-only keys are filtered out — neither is usable for storing secrets.
+// `IsKeyEncryptionCapable` (used by GetPublicKeyInfo) inspects subkeys and
+// algorithm flags directly, so a separate in-memory encrypt probe would be
+// redundant.
+func filterEncryptionCapableKeys(client gpg.Client, keys []gpg.SecretKeyInfo) (capable []gpg.SecretKeyInfo, skipped int) {
+	for _, k := range keys {
+		info, err := client.GetPublicKeyInfo(k.Fingerprint)
+		if err != nil || info == nil || !info.CanEncrypt {
+			skipped++
+			continue
+		}
+		capable = append(capable, k)
+	}
+	return capable, skipped
+}
+
+// shortFingerprint returns the first 16 hex chars of a GPG fingerprint with
+// a trailing ellipsis, suitable for terse list display.
+func shortFingerprint(fp string) string {
+	if len(fp) <= 16 {
+		return fp
+	}
+	return fp[:16] + "..."
 }
 
 // Login initializes the user's identity with a signed login proof.

--- a/internal/cli/login.go
+++ b/internal/cli/login.go
@@ -122,6 +122,23 @@ func shortFingerprint(fp string) string {
 	return fp[:16] + "..."
 }
 
+// requireEncryptionCapableKey returns an error if `info` represents a
+// sign-only key. Login enforces this regardless of how the fingerprint
+// reached it: interactive selection filters sign-only keys out, but
+// `dotsecenv login FP` and `init config --login FP` bypass that filter
+// and would otherwise produce a "successful" login that fails at the
+// next `secret put`.
+func requireEncryptionCapableKey(info *gpg.KeyInfo, fingerprint string) *Error {
+	if info != nil && info.CanEncrypt {
+		return nil
+	}
+	return NewError(fmt.Sprintf(
+		"key %s is signing-only and cannot decrypt secrets.\n"+
+			"Use a key with an encryption-capable subkey, or create one with: dotsecenv identity create",
+		fingerprint,
+	), ExitGPGError)
+}
+
 // Login initializes the user's identity with a signed login proof.
 // If fingerprint is empty, it will interactively prompt the user to select from available secret keys.
 func (c *CLI) Login(fingerprint string) *Error {
@@ -137,6 +154,10 @@ func (c *CLI) Login(fingerprint string) *Error {
 	publicKeyInfo, pubKeyErr := c.gpgClient.GetPublicKeyInfo(fingerprint)
 	if pubKeyErr != nil {
 		return NewError(fmt.Sprintf("failed to get public key for fingerprint '%s': %v\nMake sure your GPG key is available in gpg-agent", fingerprint, pubKeyErr), ExitGPGError)
+	}
+
+	if capErr := requireEncryptionCapableKey(publicKeyInfo, fingerprint); capErr != nil {
+		return capErr
 	}
 
 	// Display login info

--- a/internal/cli/login_test.go
+++ b/internal/cli/login_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/gpg"
@@ -83,6 +84,52 @@ func TestFilterEncryptionCapableKeys(t *testing.T) {
 			for i, want := range tt.wantFPs {
 				if got[i].Fingerprint != want {
 					t.Errorf("keys[%d].Fingerprint = %s, want %s", i, got[i].Fingerprint, want)
+				}
+			}
+		})
+	}
+}
+
+func TestRequireEncryptionCapableKey(t *testing.T) {
+	const fp = "1E378219F90018AB2102B2131C238966B12A6F21"
+
+	tests := []struct {
+		name    string
+		info    *gpg.KeyInfo
+		wantErr bool
+	}{
+		{
+			name:    "encryption-capable",
+			info:    &gpg.KeyInfo{Fingerprint: fp, CanEncrypt: true},
+			wantErr: false,
+		},
+		{
+			name:    "sign-only",
+			info:    &gpg.KeyInfo{Fingerprint: fp, CanEncrypt: false},
+			wantErr: true,
+		},
+		{
+			name:    "nil info",
+			info:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := requireEncryptionCapableKey(tt.info, fp)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("requireEncryptionCapableKey(...) err=%v, wantErr=%v", err, tt.wantErr)
+			}
+			if err != nil {
+				if !strings.Contains(err.Message, fp) {
+					t.Errorf("error message should mention fingerprint %q: %s", fp, err.Message)
+				}
+				if !strings.Contains(err.Message, "signing-only") {
+					t.Errorf("error message should explain why: %s", err.Message)
+				}
+				if err.ExitCode != ExitGPGError {
+					t.Errorf("exit code = %v, want ExitGPGError", err.ExitCode)
 				}
 			}
 		})

--- a/internal/cli/login_test.go
+++ b/internal/cli/login_test.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/gpg"
+)
+
+func TestFilterEncryptionCapableKeys(t *testing.T) {
+	const (
+		fpEnc1     = "AAAA1111AAAA1111AAAA1111AAAA1111AAAA1111"
+		fpEnc2     = "BBBB2222BBBB2222BBBB2222BBBB2222BBBB2222"
+		fpSignOnly = "CCCC3333CCCC3333CCCC3333CCCC3333CCCC3333"
+		fpUnknown  = "DDDD4444DDDD4444DDDD4444DDDD4444DDDD4444"
+	)
+
+	mock := NewMockGPGClient()
+	mock.PublicKeyInfo[fpEnc1] = gpg.KeyInfo{Fingerprint: fpEnc1, CanEncrypt: true}
+	mock.PublicKeyInfo[fpEnc2] = gpg.KeyInfo{Fingerprint: fpEnc2, CanEncrypt: true}
+	mock.PublicKeyInfo[fpSignOnly] = gpg.KeyInfo{Fingerprint: fpSignOnly, CanEncrypt: false}
+	// fpUnknown deliberately absent: GetPublicKeyInfo will error.
+
+	tests := []struct {
+		name        string
+		input       []gpg.SecretKeyInfo
+		wantFPs     []string
+		wantSkipped int
+	}{
+		{
+			name:        "empty input",
+			input:       nil,
+			wantFPs:     nil,
+			wantSkipped: 0,
+		},
+		{
+			name: "all capable",
+			input: []gpg.SecretKeyInfo{
+				{Fingerprint: fpEnc1, UID: "Alice"},
+				{Fingerprint: fpEnc2, UID: "Bob"},
+			},
+			wantFPs:     []string{fpEnc1, fpEnc2},
+			wantSkipped: 0,
+		},
+		{
+			name: "mixed capable and sign-only",
+			input: []gpg.SecretKeyInfo{
+				{Fingerprint: fpEnc1, UID: "Alice"},
+				{Fingerprint: fpSignOnly, UID: "Carol (sign-only)"},
+				{Fingerprint: fpEnc2, UID: "Bob"},
+			},
+			wantFPs:     []string{fpEnc1, fpEnc2},
+			wantSkipped: 1,
+		},
+		{
+			name: "unknown key (load failure) is filtered",
+			input: []gpg.SecretKeyInfo{
+				{Fingerprint: fpEnc1, UID: "Alice"},
+				{Fingerprint: fpUnknown, UID: "Dave (broken)"},
+			},
+			wantFPs:     []string{fpEnc1},
+			wantSkipped: 1,
+		},
+		{
+			name: "all filtered out",
+			input: []gpg.SecretKeyInfo{
+				{Fingerprint: fpSignOnly, UID: "Carol"},
+				{Fingerprint: fpUnknown, UID: "Dave"},
+			},
+			wantFPs:     nil,
+			wantSkipped: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, gotSkipped := filterEncryptionCapableKeys(mock, tt.input)
+			if gotSkipped != tt.wantSkipped {
+				t.Errorf("skipped = %d, want %d", gotSkipped, tt.wantSkipped)
+			}
+			if len(got) != len(tt.wantFPs) {
+				t.Fatalf("got %d keys, want %d: got=%v", len(got), len(tt.wantFPs), got)
+			}
+			for i, want := range tt.wantFPs {
+				if got[i].Fingerprint != want {
+					t.Errorf("keys[%d].Fingerprint = %s, want %s", i, got[i].Fingerprint, want)
+				}
+			}
+		})
+	}
+}
+
+func TestShortFingerprint(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"short", "ABCD", "ABCD"},
+		{"exactly 16", "0123456789ABCDEF", "0123456789ABCDEF"},
+		{"40-char fingerprint", "1E378219F90018AB2102B2131C238966B12A6F21", "1E378219F90018AB..."},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shortFingerprint(tt.in); got != tt.want {
+				t.Errorf("shortFingerprint(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Three small improvements to `dotsecenv login` (and `init config --login`):

### 1. Filter sign-only keys before the interactive picker

`selectSecretKey` now calls `GetPublicKeyInfo` for each candidate from `ListSecretKeys` and excludes any whose public key is sign-only or fails to load. Previously a user could select a sign-only key, get a "Login successful!" message, and then hit a hard failure on the next `secret put` (`signing-only key and cannot decrypt messages`). Catching it at login is clearer and shrinks the picker.

Filtering relies on `gpg.IsKeyEncryptionCapable` — which already inspects subkeys and algorithm flags via go-crypto — so a separate in-memory encrypt probe per candidate would be redundant and would add a GPG subprocess per key. If `GetPublicKeyInfo` errors (e.g., key the parser can't load), the key is also filtered out, since it's unusable for the rest of dotsecenv anyway. The skipped count is surfaced to stderr so users notice when filtering happened.

### 2. Reject sign-only keys passed by fingerprint

The picker filter only helps when there's a picker. `dotsecenv login FP` and `init config --login FP` bypass `selectSecretKey` entirely, so a sign-only fingerprint would still produce a "Login successful!" followed by a hard failure on the next `secret put`.

`requireEncryptionCapableKey` (in login.go) now runs right after `GetPublicKeyInfo` in both `Login` and `InitConfig`. Both paths fail fast with a clear message naming the fingerprint and pointing at `dotsecenv identity create`.

### 3. Blank line between selection and summary

Both the auto-select and interactive paths now print one trailing `\n` so the "Logging in with identity:" summary stands apart from the picker output:

```
> My test4 <noreply4@dse.org> (FD6E4A03D8AD58B4...)
                                                        <- blank line
Logging in with identity: My test4 <noreply4@dse.org> (RSA 4096-bit)
  Fingerprint: FD6E4A03D8AD58B4...
```

## Changes

| File | Change |
|---|---|
| `internal/cli/login.go` | Add `filterEncryptionCapableKeys`, `shortFingerprint`, `requireEncryptionCapableKey` helpers; wire filter into `selectSecretKey`; wire encryption-capability check into `Login`; trailing blank line on auto-select and interactive paths |
| `internal/cli/init.go` | Call `requireEncryptionCapableKey` in the `--login FP` branch of `InitConfig` |
| `internal/cli/login_test.go` | **New** — `TestFilterEncryptionCapableKeys`, `TestRequireEncryptionCapableKey`, `TestShortFingerprint` |

## Testing

- `make lint` — 0 issues
- `make test` — all packages green
- `make e2e` — passes (E2E uses encryption-capable fingerprints)

## Test plan

- [x] Unit tests cover the new filter + helpers
- [x] Local lint/test/e2e passes
- [ ] CI matrix passes
- [ ] Manual: `dotsecenv login` with multiple keys (some sign-only) shows only encryption-capable in the picker, with a stderr note about skipped keys
- [ ] Manual: `dotsecenv login` with one capable key auto-selects, then prints a blank line, then the login summary
- [ ] Manual: `dotsecenv login SIGN_ONLY_FP` fails before saving config, with the new error pointing at `dotsecenv identity create`
- [ ] Manual: `dotsecenv init config --login SIGN_ONLY_FP` fails before saving config, with the same error

🤖 Generated with [Claude Code](https://claude.com/claude-code)