### PR TITLE
feat: reject backdated and far-future appends at write time

### DIFF
--- a/pkg/dotsecenv/vault/append_check.go
+++ b/pkg/dotsecenv/vault/append_check.go
@@ -1,0 +1,79 @@
+package vault
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// MaxClockSkew is the maximum drift tolerated between a new entry's
+// asserted added_at and the local clock at write time. Bounds:
+//   - Lower: a new entry must not be older than the most recent existing
+//     entry's added_at (rejects trivial backdating).
+//   - Upper: a new entry must not be more than MaxClockSkew in the future
+//     of the local clock (a forward-dated entry would block every
+//     subsequent legitimate write until real time caught up).
+//
+// This is a write-time speed bump, not a cryptographic guarantee. A holder
+// of a signing key can still hand-craft the JSONL with arbitrary
+// timestamps; see concepts/threat-model on the website.
+const MaxClockSkew = 5 * time.Minute
+
+// addedAtOnly is a minimal shape for extracting added_at from any entry.
+type addedAtOnly struct {
+	AddedAt time.Time `json:"added_at"`
+}
+
+// maxAddedAt walks the data section (after the header markers) and
+// returns the largest added_at found. Returns the zero time for an
+// empty vault. Lines that fail to parse are skipped — stricter
+// validators catch malformed lines elsewhere.
+func (w *Writer) maxAddedAt() time.Time {
+	var max time.Time
+	// lines[0]=HeaderMarker, lines[1]=header JSON, lines[2]=DataMarker
+	for i := 3; i < len(w.lines); i++ {
+		line := w.lines[i]
+		if line == "" {
+			continue
+		}
+		var entry Entry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			continue
+		}
+		var d addedAtOnly
+		if err := json.Unmarshal(entry.Data, &d); err != nil {
+			continue
+		}
+		if d.AddedAt.After(max) {
+			max = d.AddedAt
+		}
+	}
+	return max
+}
+
+// checkAppendTimestamps enforces the bounds described on MaxClockSkew
+// against every supplied added_at. Pass all new entries' timestamps for
+// a multi-entry write (e.g., AddSecretWithValues).
+func (w *Writer) checkAppendTimestamps(newAddedAts ...time.Time) error {
+	max := w.maxAddedAt()
+	now := time.Now().UTC()
+	upper := now.Add(MaxClockSkew)
+	for _, t := range newAddedAts {
+		if t.Before(max) {
+			return fmt.Errorf(
+				"refusing to append entry: added_at (%s) is older than the most recent existing entry's added_at (%s); the vault must remain in monotonic time order. If your local clock is wrong, fix it and retry",
+				t.UTC().Format(time.RFC3339),
+				max.UTC().Format(time.RFC3339),
+			)
+		}
+		if t.After(upper) {
+			return fmt.Errorf(
+				"refusing to append entry: added_at (%s) is more than %s in the future of the local clock (%s); a forward-dated entry would block subsequent legitimate writes",
+				t.UTC().Format(time.RFC3339),
+				MaxClockSkew,
+				now.Format(time.RFC3339),
+			)
+		}
+	}
+	return nil
+}

--- a/pkg/dotsecenv/vault/append_check_test.go
+++ b/pkg/dotsecenv/vault/append_check_test.go
@@ -1,0 +1,169 @@
+package vault
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/identity"
+)
+
+func newWriterForTest(t *testing.T) *Writer {
+	t.Helper()
+	w, err := NewWriter(filepath.Join(t.TempDir(), "vault"))
+	if err != nil {
+		t.Fatalf("NewWriter failed: %v", err)
+	}
+	return w
+}
+
+func TestCheckAppendTimestamps_EmptyVaultAcceptsAnyNonFutureTime(t *testing.T) {
+	w := newWriterForTest(t)
+	now := time.Now().UTC()
+	if err := w.checkAppendTimestamps(now); err != nil {
+		t.Fatalf("expected empty vault to accept now, got: %v", err)
+	}
+	// Far past also fine — no existing entries to compare against.
+	if err := w.checkAppendTimestamps(now.Add(-365 * 24 * time.Hour)); err != nil {
+		t.Fatalf("expected empty vault to accept past timestamps, got: %v", err)
+	}
+}
+
+func TestAddIdentity_RejectsBackdated(t *testing.T) {
+	w := newWriterForTest(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	if err := w.AddIdentity(identity.Identity{AddedAt: now, Fingerprint: "FP1"}); err != nil {
+		t.Fatalf("first AddIdentity failed: %v", err)
+	}
+
+	err := w.AddIdentity(identity.Identity{AddedAt: now.Add(-1 * time.Hour), Fingerprint: "FP2"})
+	if err == nil {
+		t.Fatal("expected backdated AddIdentity to be rejected")
+	}
+	if !strings.Contains(err.Error(), "older than the most recent existing entry") {
+		t.Errorf("expected backdating error, got: %v", err)
+	}
+}
+
+func TestAddIdentity_AcceptsEqualOrLater(t *testing.T) {
+	w := newWriterForTest(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	if err := w.AddIdentity(identity.Identity{AddedAt: now, Fingerprint: "FP1"}); err != nil {
+		t.Fatalf("first AddIdentity failed: %v", err)
+	}
+	// Equal added_at must succeed (two writes inside one second).
+	if err := w.AddIdentity(identity.Identity{AddedAt: now, Fingerprint: "FP2"}); err != nil {
+		t.Errorf("equal-time AddIdentity rejected: %v", err)
+	}
+	// Later timestamp must succeed.
+	if err := w.AddIdentity(identity.Identity{AddedAt: now.Add(time.Second), Fingerprint: "FP3"}); err != nil {
+		t.Errorf("later AddIdentity rejected: %v", err)
+	}
+}
+
+func TestAddIdentity_RejectsForwardDatedBeyondSkew(t *testing.T) {
+	w := newWriterForTest(t)
+	tooFarFuture := time.Now().UTC().Add(MaxClockSkew + time.Minute)
+	err := w.AddIdentity(identity.Identity{AddedAt: tooFarFuture, Fingerprint: "FP1"})
+	if err == nil {
+		t.Fatal("expected forward-dated AddIdentity to be rejected")
+	}
+	if !strings.Contains(err.Error(), "in the future") {
+		t.Errorf("expected forward-dating error, got: %v", err)
+	}
+}
+
+func TestAddIdentity_AcceptsForwardDatedWithinSkew(t *testing.T) {
+	w := newWriterForTest(t)
+	withinSkew := time.Now().UTC().Add(MaxClockSkew - time.Minute)
+	if err := w.AddIdentity(identity.Identity{AddedAt: withinSkew, Fingerprint: "FP1"}); err != nil {
+		t.Errorf("within-skew AddIdentity rejected: %v", err)
+	}
+}
+
+func TestAddSecret_RejectsBackdated(t *testing.T) {
+	w := newWriterForTest(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	if err := w.AddIdentity(identity.Identity{AddedAt: now, Fingerprint: "FP1"}); err != nil {
+		t.Fatalf("AddIdentity failed: %v", err)
+	}
+
+	err := w.AddSecret(Secret{AddedAt: now.Add(-time.Hour), Key: "OLD_SECRET"})
+	if err == nil {
+		t.Fatal("expected backdated AddSecret to be rejected")
+	}
+	if !strings.Contains(err.Error(), "older than the most recent") {
+		t.Errorf("expected backdating error, got: %v", err)
+	}
+}
+
+func TestAddSecretValue_RejectsBackdated(t *testing.T) {
+	w := newWriterForTest(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	if err := w.AddIdentity(identity.Identity{AddedAt: now, Fingerprint: "FP1"}); err != nil {
+		t.Fatalf("AddIdentity failed: %v", err)
+	}
+	if err := w.AddSecret(Secret{AddedAt: now, Key: "MY_SECRET"}); err != nil {
+		t.Fatalf("AddSecret failed: %v", err)
+	}
+
+	err := w.AddSecretValue("MY_SECRET", SecretValue{
+		AddedAt:     now.Add(-time.Hour),
+		AvailableTo: []string{"FP1"},
+		Value:       "dGVzdA==",
+	})
+	if err == nil {
+		t.Fatal("expected backdated AddSecretValue to be rejected")
+	}
+}
+
+func TestAddSecretWithValues_RejectsAnyBackdatedTimestamp(t *testing.T) {
+	w := newWriterForTest(t)
+	now := time.Now().UTC().Truncate(time.Second)
+
+	if err := w.AddIdentity(identity.Identity{AddedAt: now, Fingerprint: "FP1"}); err != nil {
+		t.Fatalf("AddIdentity failed: %v", err)
+	}
+
+	// Secret AddedAt is fine, but one value is backdated — must be rejected.
+	err := w.AddSecretWithValues(Secret{
+		AddedAt: now.Add(time.Second),
+		Key:     "MIXED_TIMES",
+		Values: []SecretValue{
+			{AddedAt: now.Add(-time.Hour), AvailableTo: []string{"FP1"}, Value: "dGVzdA=="},
+		},
+	})
+	if err == nil {
+		t.Fatal("expected AddSecretWithValues to reject a backdated nested value")
+	}
+	if !strings.Contains(err.Error(), "older than the most recent") {
+		t.Errorf("expected backdating error, got: %v", err)
+	}
+}
+
+func TestMaxAddedAt_ReportsLatestAcrossAllEntries(t *testing.T) {
+	w := newWriterForTest(t)
+	t1 := time.Now().UTC().Truncate(time.Second)
+	t2 := t1.Add(time.Second)
+	t3 := t2.Add(time.Second)
+
+	if err := w.AddIdentity(identity.Identity{AddedAt: t1, Fingerprint: "FP1"}); err != nil {
+		t.Fatalf("AddIdentity FP1 failed: %v", err)
+	}
+	if err := w.AddIdentity(identity.Identity{AddedAt: t3, Fingerprint: "FP2"}); err != nil {
+		t.Fatalf("AddIdentity FP2 failed: %v", err)
+	}
+	if err := w.AddSecret(Secret{AddedAt: t2, Key: "MID_TIME"}); err == nil {
+		t.Error("expected AddSecret with t2 to fail because t3 already exists")
+	}
+
+	got := w.maxAddedAt()
+	if !got.Equal(t3) {
+		t.Errorf("maxAddedAt = %v, want %v", got, t3)
+	}
+}

--- a/pkg/dotsecenv/vault/format_test.go
+++ b/pkg/dotsecenv/vault/format_test.go
@@ -802,8 +802,10 @@ func TestDefragmentation(t *testing.T) {
 		t.Fatalf("AddIdentity failed: %v", err)
 	}
 
-	// Add value to first secret (fragmenting secret from its value)
-	sv := SecretValue{AddedAt: now, AvailableTo: []string{"FP1"}, Value: "v1"}
+	// Add value to first secret (fragmenting secret from its value).
+	// Timestamp must respect monotonic write-order; the value lands on a
+	// later line than id2, so it must carry a later or equal added_at.
+	sv := SecretValue{AddedAt: now.Add(2 * time.Second), AvailableTo: []string{"FP1"}, Value: "v1"}
 	if err := w.AddSecretValue("SEC1", sv); err != nil {
 		t.Fatalf("AddSecretValue failed: %v", err)
 	}

--- a/pkg/dotsecenv/vault/writer.go
+++ b/pkg/dotsecenv/vault/writer.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/identity"
 )
@@ -245,6 +246,10 @@ func (w *Writer) AddIdentity(id identity.Identity) error {
 		return fmt.Errorf("skipped, already present: %s", id.Fingerprint)
 	}
 
+	if err := w.checkAppendTimestamps(id.AddedAt); err != nil {
+		return err
+	}
+
 	lineNum := w.nextLineNumber()
 
 	entry, err := CreateIdentityEntry(id)
@@ -271,6 +276,10 @@ func (w *Writer) AddSecret(s Secret) error {
 		if CompareSecretKeys(existingKey, s.Key) {
 			return fmt.Errorf("secret already exists: %s", existingKey)
 		}
+	}
+
+	if err := w.checkAppendTimestamps(s.AddedAt); err != nil {
+		return err
 	}
 
 	lineNum := w.nextLineNumber()
@@ -313,6 +322,10 @@ func (w *Writer) AddSecretValue(secretKey string, sv SecretValue) error {
 		return fmt.Errorf("secret not found: %s", secretKey)
 	}
 
+	if err := w.checkAppendTimestamps(sv.AddedAt); err != nil {
+		return err
+	}
+
 	lineNum := w.nextLineNumber()
 
 	entry, err := CreateValueEntry(secretKey, sv)
@@ -340,6 +353,15 @@ func (w *Writer) AddSecretWithValues(s Secret) error {
 		if CompareSecretKeys(existingKey, s.Key) {
 			return fmt.Errorf("secret already exists: %s", existingKey)
 		}
+	}
+
+	timestamps := make([]time.Time, 0, 1+len(s.Values))
+	timestamps = append(timestamps, s.AddedAt)
+	for _, sv := range s.Values {
+		timestamps = append(timestamps, sv.AddedAt)
+	}
+	if err := w.checkAppendTimestamps(timestamps...); err != nil {
+		return err
 	}
 
 	// Add secret definition


### PR DESCRIPTION
## Summary
- Enforce two write-time invariants on every `Add*` operation in the vault writer:
  - Lower bound: a new entry's `added_at` must not be older than the most recent existing entry's `added_at` — rejects trivial backdating of appends.
  - Upper bound: a new entry's `added_at` must not be more than `MaxClockSkew` (5m) in the future of the local clock — prevents a single forward-dated write from blocking every subsequent legitimate append (vault-wide DoS via one bad timestamp).
- Wired into `AddIdentity`, `AddSecret`, `AddSecretValue`, and `AddSecretWithValues` (the bulk path, variadic — checks every new entry's timestamp).
- `RewriteFromVault` is intentionally unaffected: it rebuilds an existing vault rather than appending new entries (used by defrag and format upgrades).

## Honest scope
This is a write-time speed bump, **not** a cryptographic guarantee. A holder of a signing key can still hand-craft the JSONL with arbitrary timestamps and sign the canonical hash directly. The check raises the operational bar inside dotsecenv itself; it does not change the cryptographic threat model documented at [concepts/threat-model](https://dotsecenv.sh/concepts/threat-model/) (key holders can still backdate by bypassing the CLI). Closing that gap structurally needs entry chaining + an external anchor; tracked separately.

## Behaviour notes
- `>=` comparison: two writes inside the same second are accepted.
- Skew tolerance: `MaxClockSkew = 5 * time.Minute`. Generous enough for most NTP-skewed teams; tight enough that forward-dating attacks need real effort or real bad clocks.
- Empty vault accepts any non-future timestamp (no max to compare against).
- Error messages are explicit about which bound was violated and what to do (\"if your local clock is wrong, fix it and retry\").

## Test plan
- [x] `go test ./pkg/dotsecenv/vault/...` — green (new \`append_check_test.go\` covers empty-vault, equal-time, backdated, forward-dated within/beyond skew, mixed-timestamp bulk add).
- [x] `go test ./...` — green across cmd/, internal/cli/, gpg/, policy/, etc.
- [x] `make lint` — 0 issues.
- [x] Pre-existing `TestDefragmentation` updated: it constructed a fragmented vault by writing entries in non-monotonic order via the public API; the assertion is about line-fragmentation, not time order, so the timestamp is bumped to respect monotonicity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)