### PR TITLE
ci: flatten DAG — test + build-docs as parallel roots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,18 @@ name: CI
 
 # Pipeline shape (DAG):
 #
-#   test ─► e2e ─► e2e-terraform ─┬─► e2e-action-default-args ─┬─► build-docs
-#                                 └─► e2e-action-init-config
+#   test (matrix) ─┐
+#                  ├─► e2e (matrix)
+#                  ├─► e2e-terraform
+#   build-docs ────┤
+#                  ├─► e2e-action-default-args
+#                  └─► e2e-action-init-config
+#
+# `test` and `build-docs` are the two roots — both fast, both build the
+# binary, and they run in parallel so the slower of the two sets the
+# critical path's first stage. Everything downstream gates on BOTH.
+# Single-os (ubuntu) jobs: e2e-terraform, e2e-action-*, build-docs.
+# Matrix (ubuntu+macos): test, e2e.
 #
 # Scoped to Go-related changes via `paths:` allowlist below — touches to
 # website/, plugin/, docs-only files, etc. don't fire this pipeline.
@@ -119,9 +129,22 @@ jobs:
       - name: Test
         run: go test -v -p 1 ./...
 
+  build-docs:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+          cache-dependency-path: "go.sum"
+
+      - run: make build completions docs man
+
   e2e:
     name: E2E Tests (${{ matrix.os }})
-    needs: test
+    needs: [test, build-docs]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -137,12 +160,9 @@ jobs:
       - run: make build e2e
 
   e2e-terraform:
-    name: E2E Terraform Credentials Helper (${{ matrix.os }})
-    needs: e2e
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    name: E2E Terraform Credentials Helper
+    needs: [test, build-docs]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
@@ -158,12 +178,9 @@ jobs:
       - run: make build e2e-terraform
 
   e2e-action-default-args:
-    name: E2E Action default-args (${{ matrix.os }})
-    needs: e2e-terraform
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    name: E2E Action default-args
+    needs: [test, build-docs]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
@@ -175,12 +192,9 @@ jobs:
       - run: dotsecenv version
 
   e2e-action-init-config:
-    name: E2E Action init-config (${{ matrix.os }})
-    needs: e2e-terraform
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
+    name: E2E Action init-config
+    needs: [test, build-docs]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
@@ -191,20 +205,3 @@ jobs:
           init-config: ""
 
       - run: dotsecenv version
-
-  build-docs:
-    name: Build Docs (${{ matrix.os }})
-    needs: [e2e-action-default-args, e2e-action-init-config]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: "go.mod"
-          cache-dependency-path: "go.sum"
-
-      - run: make build completions docs man


### PR DESCRIPTION
## Summary

Restructures \`ci.yml\`'s job DAG from a 5-stage linear chain to a 2-root parallel fan-out, and drops the OS matrix from jobs where ubuntu-only coverage is enough.

### Before

\`\`\`
test (matrix) → e2e (matrix) → e2e-terraform (matrix) ─┬─► e2e-action-default-args (matrix) ─┐
                                                       └─► e2e-action-init-config (matrix) ──┴─► build-docs (matrix)
\`\`\`

### After

\`\`\`
test (matrix) ─┐
               ├─► e2e (matrix)
               ├─► e2e-terraform
build-docs ────┤
               ├─► e2e-action-default-args
               └─► e2e-action-init-config
\`\`\`

\`test\` and \`build-docs\` are now sibling roots — both fast, both build the binary, both gate everything downstream. The 4 downstream jobs run in parallel as soon as both roots are green.

### Matrix removed where ubuntu coverage is sufficient

- \`e2e-terraform\` — terraform CLI behavior is identical across runners
- \`e2e-action-default-args\` — composite action's source-build path
- \`e2e-action-init-config\` — same
- \`build-docs\` — cobra docs generation is host-OS-independent

### Matrix kept where platform divergence matters

- \`test\` — lint/build/test; real platform bugs surface here
- \`e2e\` — full integration; keeps Darwin coverage of the binary path

## Branch-protection follow-up

Display names dropped the \`(\${{ matrix.os }})\` suffix on the de-matrixed jobs:
- \`E2E Terraform Credentials Helper (ubuntu-latest)\` → \`E2E Terraform Credentials Helper\`
- \`E2E Action default-args (ubuntu-latest)\` → \`E2E Action default-args\`
- \`E2E Action init-config (ubuntu-latest)\` → \`E2E Action init-config\`
- \`Build Docs (ubuntu-latest)\` → \`Build Docs\`

Required status checks listing the old parenthesized names need to be re-added under the new names before this PR can be required-status-gated.

## Test plan

- [ ] CI passes on this PR (this PR itself is the validation)
- [ ] Wall-clock to all-green drops vs. main (the whole point — should be roughly \`max(test, build-docs) + max(e2e, e2e-terraform, e2e-action-*)\` instead of the previous 5-stage sum)
- [ ] Branch protection updated to reference new check names

🤖 Generated with [Claude Code](https://claude.com/claude-code)