### PR TITLE
fix(release): drop unused actions:read from e2e-hermetic.yml (unblocks v0.6.10)

### DIFF
--- a/.github/workflows/e2e-hermetic.yml
+++ b/.github/workflows/e2e-hermetic.yml
@@ -22,7 +22,6 @@ on:
 
 permissions:
   contents: read
-  actions: read
 
 jobs:
   # Job 1: Build and prepare artifacts (with network)


### PR DESCRIPTION
## Summary

v0.6.10 release run failed with \`startup_failure\`: https://github.com/dotsecenv/dotsecenv/actions/runs/25913051045

### Root cause

\`release.yml\`'s explicit workflow-level \`permissions:\` block grants only:

\`\`\`yaml
permissions:
  contents: write
  id-token: write
  attestations: write
\`\`\`

GitHub treats an explicit \`permissions:\` block as exhaustive — every permission not listed becomes implicitly \`none\`. When \`release.yml\` calls \`e2e-hermetic.yml\` via \`workflow_call\`, the reusable workflow's declared \`actions: read\` exceeds what the caller granted. GitHub rejects the run at evaluation time, before any job starts, with \`startup_failure\`.

### Fix

\`actions: read\` was set defensively on \`e2e-hermetic.yml\` but is never used — its jobs only do \`checkout\` / \`setup-go\` / \`upload-artifact\` / \`download-artifact\` / \`step-security/harden-runner\` / \`strace + make\`, none of which call the GitHub Actions API. Dropping it keeps the permission set honest and unblocks the \`workflow_call\` from release.yml.

## Tag fix-up after merge

The \`v0.6.10\` tag still points at the broken \`release.yml\`. Two options:

1. **Re-push v0.6.10**:
   \`\`\`bash
   git tag -d v0.6.10
   git push origin :v0.6.10
   git tag -s v0.6.10 <main-sha-after-this-PR>
   git push origin v0.6.10
   \`\`\`
   Release pipeline re-fires against the fixed workflow file.

2. **Cut v0.6.11**:
   \`\`\`bash
   rt git::release --sign --push v0.6.11
   \`\`\`

## Test plan

- [x] \`actionlint\` clean (verified locally — exit 0)
- [ ] Re-pushed tag (or v0.6.11) triggers a release run that progresses past \`e2e-hermetic\`
- [ ] No silent permission downgrades downstream (e2e-action-post-release.yml doesn't declare workflow-level permissions, so isn't affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)