### PR TITLE
chore: ignore .claude/settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ website/node_modules
 website/build
 website/.docusaurus
 website/.cache
+
+# Claude
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Add `.claude/settings.local.json` to `.gitignore` so local Claude Code per-user settings stay out of the repo.

## Test plan
- [x] `git status` shows no untracked `.claude/settings.local.json` after this change
- [x] Pre-commit hooks pass