### PR TITLE
ci(release): pre-flight check + Why Two Jobs? docs

### DIFF
--- a/.github/workflows/e2e-hermetic.yml
+++ b/.github/workflows/e2e-hermetic.yml
@@ -24,7 +24,11 @@ permissions:
   contents: read
 
 jobs:
-  # Job 1: Build and prepare artifacts (with network)
+  # Job 1: Build the binary once with network available.
+  # The compiled bin/dotsecenv is consumed by `hermetic-harden-runner`,
+  # which cannot fetch the Go toolchain itself (see job 2 comment).
+  # `hermetic-strace-verified` does NOT consume this artifact — it
+  # rebuilds from vendored sources so the compile step is also traced.
   setup:
     name: Build artifacts
     runs-on: ubuntu-latest
@@ -49,7 +53,13 @@ jobs:
             scripts/e2e.sh
           retention-days: 1
 
-  # Job 2: harden-runner enforcement (no network needed)
+  # Job 2: harden-runner enforcement on the e2e phase.
+  # `egress-policy: block` must be the first step for tamper-resistance,
+  # which means no later step can use the network — including
+  # actions/setup-go (vendoring covers `go build`, not toolchain install).
+  # So this job consumes the pre-built artifact from `setup` and only
+  # exercises `make e2e`. Verifies zero egress during the e2e flow via
+  # step-security's runtime egress interceptor.
   hermetic-harden-runner:
     name: Hermetic E2E (harden-runner)
     needs: setup
@@ -69,7 +79,14 @@ jobs:
       - name: Run hermetic e2e
         run: make e2e
 
-  # Job 3: Network namespace + strace verification
+  # Job 3: Network namespace + strace verification on build AND e2e.
+  # Intentionally NOT `needs: setup` — we do checkout + setup-go BEFORE
+  # entering `unshare --net`, then run `make build e2e` inside the
+  # namespace so the compile step is also under syscall inspection.
+  # Vendored modules (`go build -mod=vendor`) make the in-namespace
+  # build possible without any network. Complements job 2: harden-runner
+  # verifies egress at the application layer, strace + netns verify at
+  # the kernel layer and additionally cover the compile step.
   hermetic-strace-verified:
     name: Hermetic E2E (strace + namespace)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,9 @@ jobs:
           if [ "$ASSET_COUNT" -gt 0 ]; then
             RELEASE_URL=$(echo "$RELEASE_JSON" | jq -r '.html_url')
             echo "::error::Release ${TAG} already exists with ${ASSET_COUNT} assets: ${RELEASE_URL}"
-            echo "::error::This usually means the tag was moved or this run is a retry of an already-published release."
-            echo "::error::To proceed: delete the existing release and tag, or bump the version."
+            echo "::error::Tag protection rules prevent moving or deleting release tags, so the only forward path is a new version."
+            echo "::error::To ship a fix: bump the version (next patch) and cut a new tag."
+            echo "::error::To withdraw the existing release: retract it (see scripts/retract-version.sh)."
             exit 1
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,50 @@ permissions:
   attestations: write
 
 jobs:
+  # Fail fast if a release for this tag already exists with assets.
+  # Surfaces tag-moves (same tag re-pushed onto a different commit) in
+  # seconds rather than 4+ minutes into goreleaser's upload phase, which
+  # would 422 with `already_exists` on every asset. All downstream jobs
+  # depend on this (directly or transitively) so we don't burn runner
+  # minutes on a release that cannot publish. Tag protection rules are
+  # the upstream defense; this job is the in-pipeline guard for cases
+  # where the rule was bypassed, disabled, or not yet enforced.
+  preflight:
+    name: Pre-flight release check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Verify no existing release for tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          # gh api exits non-zero on 404; treat that as the happy path.
+          if ! RELEASE_JSON=$(gh api "repos/${REPO}/releases/tags/${TAG}" 2>/dev/null); then
+            echo "::notice::No existing release for ${TAG}; clear to proceed."
+            exit 0
+          fi
+
+          ASSET_COUNT=$(echo "$RELEASE_JSON" | jq '.assets | length')
+          if [ "$ASSET_COUNT" -gt 0 ]; then
+            RELEASE_URL=$(echo "$RELEASE_JSON" | jq -r '.html_url')
+            echo "::error::Release ${TAG} already exists with ${ASSET_COUNT} assets: ${RELEASE_URL}"
+            echo "::error::This usually means the tag was moved or this run is a retry of an already-published release."
+            echo "::error::To proceed: delete the existing release and tag, or bump the version."
+            exit 1
+          fi
+
+          echo "::notice::Release ${TAG} exists with no assets (likely partial prior failure); proceeding."
+
   # Reusable hermetic E2E (harden-runner + strace network-syscall
   # verification). Single source of truth in e2e-hermetic.yml — used by
   # PRs and by the release pipeline so the verification logic doesn't
   # drift between the two.
   e2e-hermetic:
+    needs: preflight
     uses: ./.github/workflows/e2e-hermetic.yml
 
   # Gate the release on each path-scoped CI workflow's pass on this
@@ -38,6 +77,7 @@ jobs:
   # job below) after the release is published.
   wait-ci:
     name: Wait for CI on tagged commit
+    needs: preflight
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/website/src/content/docs/concepts/security-model.mdx
+++ b/website/src/content/docs/concepts/security-model.mdx
@@ -200,10 +200,10 @@ dotsecenv validate
 A secrets management tool that "phones home" or makes unexpected network connections is a severe risk. dotsecenv's CI pipeline includes hermetic e2e testing with two independent verifications:
 
 1. Vendored dependencies. Go modules are vendored, so the build needs no network.
-2. Dual verification. Two parallel jobs check that zero network connections happen:
+2. Dual verification. Two jobs check that zero network connections happen:
    - [step-security/harden-runner](https://github.com/step-security/harden-runner) blocks egress at the kernel level
    - A network namespace plus `strace` traces every network syscall in isolation
-3. Defense in depth. If one method has a bug, the other still catches violations.
+3. Complementary coverage. The two jobs aren't identical reruns; they check different parts of the pipeline (see [Why Two Jobs?](#why-two-jobs)).
 4. Auditable artifacts. Job summaries and downloadable syscall traces.
 5. Release gate. Releases are blocked if hermetic tests fail.
 
@@ -229,6 +229,23 @@ A secrets management tool that "phones home" or makes unexpected network connect
 │  ✓ Both jobs must pass = zero network connections verified twice       │
 └───────────────────────────────────────────────────────────────────────┘
 ```
+
+### Why Two Jobs?
+
+The two jobs cover different parts of the pipeline, not just the same part twice. The split exists because of an ordering constraint in `harden-runner`.
+
+| Surface under inspection | `harden-runner` job | `strace + netns` job |
+| --- | --- | --- |
+| `go build` (compile step) | uses pre-built binary | rebuilds inside namespace |
+| `make e2e` (runtime) | yes | yes |
+| Enforcement layer | userspace egress interceptor | kernel network namespace + syscall trace |
+| Catches a bug in the other? | yes (different mechanism) | yes (different mechanism) |
+
+Why does only the strace job cover the build? `harden-runner` should be the first step of the job so a compromised later step cannot disable it. Once `egress-policy: block` is set, no later step has network access, including `actions/setup-go`, which has to fetch the Go toolchain. Vendoring removes the network requirement from `go build` itself but not from installing the compiler. So the `harden-runner` job consumes a pre-built `bin/dotsecenv` from the `setup` job and only exercises `make e2e`.
+
+The strace job has no such constraint. It runs `actions/setup-go` before entering `unshare --net`, then builds and runs e2e inside the namespace. The kernel namespace is the isolation boundary, so the compile step is covered too. `go build -mod=vendor` is what makes the in-namespace build possible.
+
+So every CI step has at least one job watching it, and the e2e phase has both.
 
 ### Trusted By
 

--- a/website/src/content/docs/concepts/security-model.mdx
+++ b/website/src/content/docs/concepts/security-model.mdx
@@ -203,7 +203,7 @@ A secrets management tool that "phones home" or makes unexpected network connect
 2. Dual verification. Two jobs check that zero network connections happen:
    - [step-security/harden-runner](https://github.com/step-security/harden-runner) blocks egress at the kernel level
    - A network namespace plus `strace` traces every network syscall in isolation
-3. Complementary coverage. The two jobs aren't identical reruns; they check different parts of the pipeline (see [Why Two Jobs?](#why-two-jobs)).
+3. Build and runtime are both hermetic. The two jobs cover different surfaces of the pipeline (see [Hermetic guarantees across build and runtime](#hermetic-guarantees-across-build-and-runtime)).
 4. Auditable artifacts. Job summaries and downloadable syscall traces.
 5. Release gate. Releases are blocked if hermetic tests fail.
 
@@ -230,7 +230,7 @@ A secrets management tool that "phones home" or makes unexpected network connect
 └───────────────────────────────────────────────────────────────────────┘
 ```
 
-### Why Two Jobs?
+### Hermetic guarantees across build and runtime
 
 The two jobs cover different parts of the pipeline, not just the same part twice. The split exists because of an ordering constraint in `harden-runner`.
 


### PR DESCRIPTION
## Summary

- Adds a `preflight` job to `release.yml` that fails fast (in seconds) if a release with assets already exists for the tag being published, instead of burning ~4 minutes on a goreleaser run that 422s on every asset upload. Catches tag-moves and replays of already-published releases.
- Surfaces the rationale for the hermetic E2E job layout in two places that cannot drift: inline comments on each job in `e2e-hermetic.yml`, and a new \"Why Two Jobs?\" section on the security-model docs page with a coverage matrix and the ordering-constraint explanation.

Both came out of investigating the v0.6.11 duplicate-upload failure: the runtime defense (preflight) and the docs that explain why the existing split exists.

Pairs with the tag protection rule on \`refs/tags/v*\` (already configured in repo settings) — tag protection prevents the root cause (tag moves); preflight is the in-pipeline guard for when that rule is bypassed, disabled, or not yet enforced.

## Test plan

- [ ] CI passes on this branch (lint-workflows / actionlint covers the YAML change)
- [ ] Confirm the preflight job appears as a needs:-target on \`e2e-hermetic\` and \`wait-ci\` in the workflow graph
- [ ] Visually inspect /concepts/security-model on the deployed docs site after merge