### PR TITLE
ci(release): RFC-822 trailers in satellite commits, drop .release-sha

### DIFF
--- a/.github/workflows/publish-satellites.yml
+++ b/.github/workflows/publish-satellites.yml
@@ -79,6 +79,7 @@ jobs:
           TAG: ""
           SHA: ${{ github.sha }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PUBLISHED_BY: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: scripts/release/publish-to-satellite.sh
 
       - name: Find satellite publish.yml run
@@ -144,6 +145,7 @@ jobs:
           TAG: ""
           SHA: ${{ github.sha }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PUBLISHED_BY: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: scripts/release/publish-to-satellite.sh
 
   # Mirror release.yml's test-plugin-managers gate. The plugin satellite

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -598,6 +598,7 @@ jobs:
           TAG: ${{ github.ref_name }}
           SHA: ${{ github.sha }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PUBLISHED_BY: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: scripts/release/publish-to-satellite.sh
 
       - name: Find satellite publish.yml run (push-triggered)
@@ -693,6 +694,7 @@ jobs:
           TAG: ${{ github.ref_name }}
           SHA: ${{ github.sha }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PUBLISHED_BY: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: scripts/release/publish-to-satellite.sh
 
   # Gates the release on plugin-manager integration testing. Runs

--- a/.github/workflows/verify-satellites.yml
+++ b/.github/workflows/verify-satellites.yml
@@ -18,9 +18,10 @@ name: Verify Satellite Drift
 #   1. workflow_dispatch input `sha` (explicit operator override)
 #   2. workflow_run.head_sha (the tag commit the upstream Release
 #      just published — newest known publish SHA)
-#   3. The satellite's own .release-sha sidecar (the satellite's
-#      authoritative claim of which monorepo commit it was last
-#      published from)
+#   3. The Source-SHA trailer in the satellite's HEAD commit body
+#      (the satellite's authoritative claim of which monorepo commit
+#      it was last published from), parsed via
+#      `git interpret-trailers --parse`.
 #
 # Crucially, we do NOT default to `github.sha`. That would be the
 # main HEAD when the workflow fires, which can be ahead of the last
@@ -41,7 +42,7 @@ on:
   workflow_dispatch:
     inputs:
       sha:
-        description: "Monorepo SHA to verify satellites against (default: each satellite's own .release-sha)"
+        description: "Monorepo SHA to verify satellites against (default: each satellite's own Source-SHA trailer)"
         required: false
         default: ""
 
@@ -71,8 +72,8 @@ jobs:
             repo: dotsecenv/packages
             source_dir: packages
     steps:
-      # Satellite goes first because we may need to read its
-      # .release-sha to decide which monorepo commit to compare against.
+      # Satellite goes first because we may need to read its Source-SHA
+      # trailer to decide which monorepo commit to compare against.
       - name: Checkout ${{ matrix.repo }} satellite
         uses: actions/checkout@v6
         with:
@@ -92,11 +93,17 @@ jobs:
           elif [ -n "${WR_SHA}" ]; then
             SHA="${WR_SHA}"
             SRC="upstream Release run head_sha"
-          elif [ -f satellite/.release-sha ]; then
-            SHA=$(tr -d '[:space:]' < satellite/.release-sha)
-            SRC="satellite/.release-sha"
+          elif [ -d satellite/.git ]; then
+            SHA=$(git -C satellite log -1 --format=%B \
+              | git interpret-trailers --parse \
+              | awk -F': ' '$1=="Source-SHA"{print $2}')
+            if [ -z "${SHA}" ]; then
+              echo "::error::Satellite HEAD commit has no Source-SHA trailer"
+              exit 1
+            fi
+            SRC="satellite Source-SHA trailer"
           else
-            echo "::error::No SHA source available (no input, no workflow_run, no .release-sha on satellite)"
+            echo "::error::No SHA source available (no input, no workflow_run, no satellite git history)"
             exit 1
           fi
           echo "Reference SHA: ${SHA} (from ${SRC})"

--- a/scripts/release/publish-to-satellite.sh
+++ b/scripts/release/publish-to-satellite.sh
@@ -9,21 +9,36 @@
 # is satisfied without any GPG handling on the runner. The App also lives
 # in the ruleset's bypass list, so the PR-required rule passes too.
 #
+# Provenance is recorded as RFC-822 git trailers in the satellite commit
+# body, parseable via `git interpret-trailers --parse`. The trailer set:
+#
+#   Source-Commit: dotsecenv/dotsecenv@<sha>          (linkable in GitHub UI)
+#   Source-SHA:    <sha>                              (parseable, no splitting)
+#   Source-Path:   <SOURCE_DIR>                       (plugin | packages)
+#   Source-Tag:    <TAG>                              (omitted when TAG is empty)
+#   Published-By:  <PUBLISHED_BY URL>                 (omitted when not set)
+#
 # Required env:
 #   SOURCE_DIR       path to the monorepo subdirectory to publish (e.g. "plugin")
 #   SATELLITE_DIR    path to a checkout of the satellite (e.g. "plugin-satellite")
 #                    used only for listing what's currently on the satellite
 #                    so we can compute deletions
 #   SATELLITE_REPO   "<owner>/<repo>" of the satellite (e.g. "dotsecenv/plugin")
-#   SHA              monorepo commit SHA being published (for .release-sha sidecar)
+#   SHA              monorepo commit SHA being published (recorded in trailers)
 #   GH_TOKEN         App installation token used by gh to call the API
 #
 # Optional env:
 #   TAG              release tag (e.g. "v0.6.7"). When set, a lightweight
-#                    tag is created on the satellite at the new commit.
-#                    When empty, no tag is created — useful for ad-hoc
-#                    workflow_dispatch publishes that aren't tied to a
-#                    release version.
+#                    tag is created on the satellite at the new commit and
+#                    a Source-Tag trailer is emitted. When empty, no tag
+#                    is created — useful for ad-hoc workflow_dispatch
+#                    publishes that aren't tied to a release version.
+#   PUBLISHED_BY     URL of the CI run that produced this publish (typically
+#                    "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}").
+#                    When set, a Published-By trailer is emitted, linkifying
+#                    the originating workflow run in the satellite commit view.
+#                    When unset, the trailer is omitted — keeps the script
+#                    callable from a local shell for one-off testing.
 #
 # Required tools in PATH (caller installs):
 #   gh, jq, find, base64
@@ -36,10 +51,7 @@ set -euo pipefail
 : "${SHA:?SHA is required}"
 : "${GH_TOKEN:?GH_TOKEN is required}"
 TAG="${TAG:-}"
-
-# Write the .release-sha sidecar into the source tree so it shows up as
-# part of the additions array along with everything else.
-echo "${SHA}" > "${SOURCE_DIR}/.release-sha"
+PUBLISHED_BY="${PUBLISHED_BY:-}"
 
 # List every file we want present on the satellite after this publish.
 SOURCE_FILES=$(mktemp)
@@ -92,11 +104,22 @@ else
   HEADLINE="publish: ad-hoc (${SHA:0:7})"
 fi
 
+# Build the RFC-822 trailer block for the commit body. Each trailer is
+# a single Key: value line; the block is the entire commit body, so
+# `git interpret-trailers --parse` will recognize all of them.
+BODY=$(
+  printf 'Source-Commit: dotsecenv/dotsecenv@%s\n' "${SHA}"
+  printf 'Source-SHA: %s\n' "${SHA}"
+  printf 'Source-Path: %s\n' "${SOURCE_DIR}"
+  [ -n "${TAG}" ] && printf 'Source-Tag: %s\n' "${TAG}"
+  [ -n "${PUBLISHED_BY}" ] && printf 'Published-By: %s\n' "${PUBLISHED_BY}"
+)
+
 INPUT_FILE=$(mktemp)
 jq -n \
   --arg repo "${SATELLITE_REPO}" \
   --arg headline "${HEADLINE}" \
-  --arg body "Sourced from dotsecenv/dotsecenv@${SHA}" \
+  --arg body "${BODY}" \
   --arg oid "${EXPECTED_OID}" \
   --slurpfile additions "${ADDITIONS_FILE}" \
   --slurpfile deletions "${DELETIONS_FILE}" \

--- a/scripts/release/verify-satellite.sh
+++ b/scripts/release/verify-satellite.sh
@@ -5,21 +5,20 @@
 #
 # The publish flow (publish-to-satellite.sh) syncs every file under
 # SOURCE_DIR into the satellite via GitHub's GraphQL createCommitOnBranch
-# mutation, plus a .release-sha sidecar pointing at the monorepo commit.
-# So a healthy satellite at commit SHA contains exactly:
-#
-#   (files under SOURCE_DIR at SHA)  +  .release-sha
-#
-# Anything else is drift: a missed file, an out-of-band edit on the
-# satellite, a publish bug, or a stale satellite that didn't receive a
-# later push.
+# mutation. Provenance lives in RFC-822 git trailers in the satellite's
+# HEAD commit body (Source-Commit, Source-SHA, Source-Path, Source-Tag,
+# Published-By), parseable via `git interpret-trailers --parse`. So a
+# healthy satellite at commit SHA contains exactly the files under
+# SOURCE_DIR at SHA. Anything else is drift: a missed file, an out-of-
+# band edit on the satellite, a publish bug, or a stale satellite that
+# didn't receive a later push.
 #
 # This script:
 #   1. Diffs the file LISTS (source-only / satellite-only / common),
 #      with GENERATED_PATHS whitelisted as expected on the satellite.
 #   2. Diffs the file CONTENTS and Unix mode for files present in both.
-#   3. If EXPECTED_SHA is set, validates the satellite's .release-sha
-#      and/or commit-body trailer matches it.
+#   3. If EXPECTED_SHA is set, validates the Source-SHA trailer in
+#      the satellite's HEAD commit body matches it.
 #
 # Exits non-zero on any drift. The diff payload (capped) is printed to
 # stdout and additionally written to $GITHUB_STEP_SUMMARY when running
@@ -31,10 +30,9 @@
 #
 # Optional env:
 #   EXPECTED_SHA      monorepo commit SHA the satellite should be at.
-#                     Validates the .release-sha sidecar AND the
-#                     "Sourced from dotsecenv/dotsecenv@<sha>" trailer
-#                     in the satellite's HEAD commit body. If unset,
-#                     SHA-pinning checks are skipped.
+#                     Validates the Source-SHA trailer in the satellite's
+#                     HEAD commit body matches. If unset, the SHA-pinning
+#                     check is skipped.
 #   GENERATED_PATHS   newline-separated paths the publish workflow
 #                     writes into the satellite but that don't live
 #                     in the monorepo source tree (e.g. "retracted.txt"
@@ -47,8 +45,8 @@
 #
 # Required tools in PATH:
 #   find, diff, cmp, comm, sort, sed, awk, stat
-#   (git is only needed when EXPECTED_SHA is set, to check the commit
-#    body trailer on the satellite)
+#   (git is only needed when EXPECTED_SHA is set, to read the
+#    Source-SHA trailer on the satellite's HEAD commit)
 
 set -euo pipefail
 
@@ -69,43 +67,39 @@ say "  source    : ${SOURCE_DIR}"
 say "  satellite : ${SATELLITE_DIR}"
 [ -n "${EXPECTED_SHA}" ] && say "  expected  : ${EXPECTED_SHA}"
 
-# ---------- .release-sha + commit-body trailer ------------------------------
-# Both should encode the same SHA. The sidecar is a one-line file; the
-# trailer is in the satellite HEAD's commit message body, written by
-# publish-to-satellite.sh.
+# ---------- Source-SHA trailer ----------------------------------------------
+# The publish flow writes a Source-SHA trailer to the satellite commit
+# body. Read it via `git interpret-trailers --parse` and check that it
+# matches what the caller expects.
 if [ -n "${EXPECTED_SHA}" ]; then
-  if [ -f "${SATELLITE_DIR}/.release-sha" ]; then
-    SIDECAR_SHA="$(tr -d '[:space:]' < "${SATELLITE_DIR}/.release-sha")"
-    if [ "${SIDECAR_SHA}" = "${EXPECTED_SHA}" ]; then
-      say "  .release-sha: OK (${SIDECAR_SHA:0:12})"
+  if command -v git >/dev/null 2>&1 && [ -d "${SATELLITE_DIR}/.git" ]; then
+    TRAILER_SHA=$(git -C "${SATELLITE_DIR}" log -1 --format=%B \
+      | git interpret-trailers --parse \
+      | awk -F': ' '$1=="Source-SHA"{print $2}')
+    if [ -z "${TRAILER_SHA}" ]; then
+      say "  Source-SHA trailer: MISSING on satellite HEAD commit"
+      DRIFT=1
+    elif [ "${TRAILER_SHA}" = "${EXPECTED_SHA}" ]; then
+      say "  Source-SHA trailer: OK (${TRAILER_SHA:0:12})"
     else
-      say "  .release-sha: DRIFT — file says ${SIDECAR_SHA:0:12}, expected ${EXPECTED_SHA:0:12}"
+      say "  Source-SHA trailer: DRIFT — trailer says ${TRAILER_SHA:0:12}, expected ${EXPECTED_SHA:0:12}"
       DRIFT=1
     fi
   else
-    say "  .release-sha: MISSING on satellite"
-    DRIFT=1
-  fi
-
-  if command -v git >/dev/null 2>&1 && [ -d "${SATELLITE_DIR}/.git" ]; then
-    TRAILER_SHA=$(git -C "${SATELLITE_DIR}" log -1 --format=%B \
-      | sed -n 's|^Sourced from dotsecenv/dotsecenv@||p' | head -1)
-    if [ -z "${TRAILER_SHA}" ]; then
-      say "  commit body: MISSING 'Sourced from dotsecenv/dotsecenv@<sha>' trailer"
-      DRIFT=1
-    elif [ "${TRAILER_SHA}" = "${EXPECTED_SHA}" ]; then
-      say "  commit body: OK (${TRAILER_SHA:0:12})"
-    else
-      say "  commit body: DRIFT — trailer says ${TRAILER_SHA:0:12}, expected ${EXPECTED_SHA:0:12}"
-      DRIFT=1
-    fi
+    say "  Source-SHA trailer: SKIPPED (no git available or satellite has no .git/)"
   fi
 fi
 
 # ---------- File-list comparison --------------------------------------------
-# Build NL-separated exclude list for satellite-side listing: always
-# .release-sha (sidecar checked above), plus any caller-supplied
-# generated paths (e.g. retracted.txt).
+# Build NL-separated exclude list for satellite-side listing.
+#
+# `.release-sha` was a legacy sidecar from before the trailer convention
+# landed; the publish flow no longer writes it. Existing satellites still
+# carry the file until their next publish, and the GraphQL publish auto-
+# deletes any satellite file not in source — so this entry is purely
+# transitional and can be removed once both satellites have been
+# republished. Until then, we whitelist it here so the file-list check
+# doesn't flag it as an unexpected satellite-only file.
 SAT_EXCLUDES=".release-sha"
 if [ -n "${GENERATED_PATHS}" ]; then
   SAT_EXCLUDES="${SAT_EXCLUDES}


### PR DESCRIPTION
## Summary

Replaces the two existing sources of satellite-commit provenance (the `.release-sha` sidecar file + a prose `Sourced from dotsecenv/dotsecenv@<sha>` line in the commit body) with one paragraph of RFC-822 git trailers, parseable via `git interpret-trailers --parse`.

### Trailer set

```
Source-Commit: dotsecenv/dotsecenv@<sha>
Source-SHA: <sha>
Source-Path: plugin|packages
Source-Tag: vX.Y.Z                                 # omitted for ad-hoc dispatches
Published-By: <full URL to CI run>
```

- **`Source-Commit`** uses `owner/repo@SHA` form → GitHub auto-linkifies the value to the monorepo commit in the satellite commit view.
- **`Source-SHA`** carries the same SHA standalone, so the verifier reads it directly without splitting on `@`. The duplication is deliberate — one trailer is shaped for humans (linkable in GitHub UI), the other for machines (no parsing). Same pattern `git subtree` uses with `git-subtree-dir:` + `git-subtree-split:`.
- **`Published-By`** is a full URL → GitHub auto-linkifies it to the originating workflow run. Investigating a satellite commit months later no longer requires guessing which CI run produced it.
- `Source-Path` and `Source-Tag` stay plain (short, copyable, reachable by clicking through `Source-Commit`).

### `.release-sha` sidecar

Dropped from the publish writer. The GraphQL `createCommitOnBranch` mutation auto-deletes any satellite file not in source, so the next normal publish removes `.release-sha` from both satellites without an explicit cleanup step. `verify-satellite.sh` keeps `.release-sha` in its file-list whitelist transitionally so the verifier doesn't flag the legacy file as "unexpected satellite-only" while both satellites still carry it; that whitelist entry can be removed in a follow-up once both have been republished.

## Files changed

- `scripts/release/publish-to-satellite.sh` — drop `.release-sha` writer; build the trailer block in shell and pass to jq as the body string; document `PUBLISHED_BY` as a new optional env.
- `scripts/release/verify-satellite.sh` — drop the `.release-sha` reader; parse `Source-SHA` via `git interpret-trailers --parse` (no more sed regex on prose); update header docs.
- `.github/workflows/verify-satellites.yml` — replace the `.release-sha` fallback in the SHA-resolve step with trailer parsing.
- `.github/workflows/release.yml` — add `PUBLISHED_BY` env to both satellite publish steps.
- `.github/workflows/publish-satellites.yml` — same `PUBLISHED_BY` addition to both manual-dispatch publish steps.

## Test plan

- [x] **Local smoke**: build a synthetic satellite repo with a commit carrying the new trailers, run `verify-satellite.sh` against it. Healthy pair → `Source-SHA trailer: OK`, exit 0. Mismatched `EXPECTED_SHA` → `Source-SHA trailer: DRIFT`, exit 1. Content+exec-bit comparison still works.
- [x] **Linters**: `actionlint`, `shellcheck -x`, `python3 -m yaml` all clean on touched files.
- [x] **Pre-push hook**: `make clean test build e2e` green.
- [ ] **Post-merge**: `workflow_dispatch` `publish-satellites.yml` with `target: both` → both satellites get new commits with the trailer paragraph; `.release-sha` files disappear from both satellite trees.
- [ ] **Post-merge**: inspect a new satellite commit in the GitHub UI → `Source-Commit` and `Published-By` render as clickable links; the four/five trailers are visible and well-formatted.
- [ ] **Post-merge**: `workflow_dispatch` `verify-satellites.yml` with no input → derives SHA from each satellite's `Source-SHA` trailer, both legs green.
- [ ] **Follow-up**: once both satellites are republished, drop the `.release-sha` entry from the transitional whitelist in `verify-satellite.sh:109-118`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)