### PR TITLE
ci(verify-satellite): drop transitional .release-sha whitelist + fix comm locale

### DIFF
--- a/scripts/release/verify-satellite.sh
+++ b/scripts/release/verify-satellite.sh
@@ -91,20 +91,10 @@ if [ -n "${EXPECTED_SHA}" ]; then
 fi
 
 # ---------- File-list comparison --------------------------------------------
-# Build NL-separated exclude list for satellite-side listing.
-#
-# `.release-sha` was a legacy sidecar from before the trailer convention
-# landed; the publish flow no longer writes it. Existing satellites still
-# carry the file until their next publish, and the GraphQL publish auto-
-# deletes any satellite file not in source — so this entry is purely
-# transitional and can be removed once both satellites have been
-# republished. Until then, we whitelist it here so the file-list check
-# doesn't flag it as an unexpected satellite-only file.
-SAT_EXCLUDES=".release-sha"
-if [ -n "${GENERATED_PATHS}" ]; then
-  SAT_EXCLUDES="${SAT_EXCLUDES}
-${GENERATED_PATHS}"
-fi
+# Build NL-separated exclude list for satellite-side listing: just
+# caller-supplied generated paths (e.g. "retracted.txt" for the packages
+# satellite, generated from go.mod by extract-retracted.sh).
+SAT_EXCLUDES="${GENERATED_PATHS}"
 
 SRC_LIST=$(mktemp); SAT_LIST=$(mktemp)
 trap 'rm -f "${REPORT}" "${SRC_LIST}" "${SAT_LIST}"' EXIT
@@ -112,13 +102,25 @@ trap 'rm -f "${REPORT}" "${SRC_LIST}" "${SAT_LIST}"' EXIT
 ( cd "${SOURCE_DIR}" && find . -type f -not -path './.git/*' | sed 's|^\./||' ) \
   | LC_ALL=C sort -u > "${SRC_LIST}"
 
-( cd "${SATELLITE_DIR}" && find . -type f -not -path './.git/*' | sed 's|^\./||' ) \
-  | grep -vxF "${SAT_EXCLUDES}" \
-  | LC_ALL=C sort -u > "${SAT_LIST}"
+# When SAT_EXCLUDES is empty, skip the grep — `grep -vxF ""` would match
+# empty lines (harmless here, since find never emits them, but odd to read).
+if [ -n "${SAT_EXCLUDES}" ]; then
+  ( cd "${SATELLITE_DIR}" && find . -type f -not -path './.git/*' | sed 's|^\./||' ) \
+    | grep -vxF "${SAT_EXCLUDES}" \
+    | LC_ALL=C sort -u > "${SAT_LIST}"
+else
+  ( cd "${SATELLITE_DIR}" && find . -type f -not -path './.git/*' | sed 's|^\./||' ) \
+    | LC_ALL=C sort -u > "${SAT_LIST}"
+fi
 
-SRC_ONLY=$(comm -23 "${SRC_LIST}" "${SAT_LIST}")
-SAT_ONLY=$(comm -13 "${SRC_LIST}" "${SAT_LIST}")
-COMMON=$(comm -12 "${SRC_LIST}" "${SAT_LIST}")
+# Match the LC_ALL=C used for sort above. Without it, GNU comm uses the
+# system locale's collation, which can disagree with LC_ALL=C sort about
+# how dotfiles order vs alphanumerics — leading to spurious "not in
+# sorted order" errors, a non-zero comm exit, and (under set -e) the
+# script bailing before printing which files actually drifted.
+SRC_ONLY=$(LC_ALL=C comm -23 "${SRC_LIST}" "${SAT_LIST}")
+SAT_ONLY=$(LC_ALL=C comm -13 "${SRC_LIST}" "${SAT_LIST}")
+COMMON=$(LC_ALL=C comm -12 "${SRC_LIST}" "${SAT_LIST}")
 
 if [ -n "${SRC_ONLY}" ]; then
   say ""


### PR DESCRIPTION
## Summary

Cleanup follow-up to #158. Both satellites have been republished off the new trailer-aware publish flow, so the legacy `.release-sha` sidecar is gone from each satellite tree (verified via `gh api repos/dotsecenv/{plugin,packages}/contents/.release-sha` — 404 on both). The transitional whitelist in `verify-satellite.sh` can come out.

## Latent bug surfaced

Removing the whitelist exposed a pre-existing bug: the script's three `comm` invocations had no `LC_ALL=C` prefix, so they used the system locale's collation instead of the C-locale ordering that the input lists were sorted under. Some locales order dotfiles after alphanumerics, others before — when they disagree with `sort`'s output, GNU `comm` prints `not in sorted order` warnings AND exits non-zero. Under `set -e` that makes the verifier bail before printing the drift listing, so the operator gets `exit 1` with no indication of *which* file drifted.

The old `.release-sha` whitelist masked this because `.release-sha` was the only dotfile that ever reached `comm` — once filtered out, the remaining file list was alphanumeric-only and collation differences didn't bite.

**Fix**: prefix all three `comm` calls with `LC_ALL=C` to match the `sort` ordering. Future dotfiles on a satellite (whether legitimate drift or new whitelist candidates) now get listed correctly instead of vanishing into a cryptic sort-order error.

## Test plan

- [x] Local smoke against three synthetic satellites:
  1. **Clean satellite** (no `.release-sha`, no extra files) → verify passes, no warnings, exit 0.
  2. **Satellite with stale `.release-sha`** → `.release-sha` correctly listed in the "Files on satellite but missing from monorepo" section, exit 1.
  3. **`GENERATED_PATHS=retracted.txt`** → whitelist still respected, verify passes, exit 0.
- [x] `shellcheck -x scripts/release/verify-satellite.sh` clean.
- [x] Pre-push hook (`make clean test build e2e`) green.
- [ ] **Post-merge**: `workflow_dispatch` `verify-satellites.yml` with no input → both legs green against the existing satellite trees (no `.release-sha` on either, so no drift reported).

🤖 Generated with [Claude Code](https://claude.com/claude-code)