### PR TITLE
ci(release): tag dotsecenv/homebrew-tap at release version after brew install verifies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -532,6 +532,69 @@ jobs:
       - name: Smoke a basic command
         run: dotsecenv help > /dev/null
 
+  # Tag dotsecenv/homebrew-tap at the release version once `brew install`
+  # has been proven to work against the just-pushed cask. Lightweight tag
+  # via REST API (mirrors the satellite tagging pattern in
+  # publish-to-satellite.sh: no GPG handling on the runner). When the
+  # cask file didn't change in this release (cask_commit_sha empty),
+  # tag the current HEAD of homebrew-tap/main so every release still
+  # corresponds to a tag.
+  #
+  # This job is an independent leaf — a tagging failure does NOT gate
+  # publish-packages / publish-plugin. If something here breaks, the
+  # release still ships and the tag can be added by hand. Conversely,
+  # the release graph stays red until the tag is created or the failure
+  # is investigated.
+  tag-homebrew-tap:
+    needs: [update-homebrew-tap, verify-homebrew-install]
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Generate App Token
+        uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: homebrew-tap
+
+      - name: Create release tag on homebrew-tap
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ github.ref_name }}
+          CASK_SHA: ${{ needs.update-homebrew-tap.outputs.cask_commit_sha }}
+        run: |
+          set -euo pipefail
+
+          # Determine which SHA to tag: the cask-update commit if there
+          # was one, otherwise the current HEAD of homebrew-tap/main.
+          if [ -n "$CASK_SHA" ]; then
+            SHA="$CASK_SHA"
+            REASON="cask updated by update-homebrew-tap"
+          else
+            SHA=$(gh api repos/dotsecenv/homebrew-tap/branches/main --jq .commit.sha)
+            REASON="cask unchanged; tagging current homebrew-tap main HEAD"
+          fi
+          echo "Tagging homebrew-tap ${VERSION} -> ${SHA} (${REASON})"
+
+          # Lightweight tag via REST. Re-runs are idempotent: a 422
+          # 'Reference already exists' response is treated as success
+          # (the tag is what we wanted to land), anything else fails
+          # the job loudly.
+          if gh api -X POST "repos/dotsecenv/homebrew-tap/git/refs" \
+              -f ref="refs/tags/${VERSION}" \
+              -f sha="${SHA}" > /tmp/tag-response.json 2>&1; then
+            echo "Tagged homebrew-tap ${VERSION} -> ${SHA}"
+          elif grep -q 'Reference already exists' /tmp/tag-response.json; then
+            echo "::warning::Tag ${VERSION} already exists on homebrew-tap; skipping (idempotent re-run)"
+          else
+            echo "::error::Failed to create tag ${VERSION} on homebrew-tap:"
+            cat /tmp/tag-response.json
+            exit 1
+          fi
+
   # Push monorepo packages/ source to the dotsecenv/packages satellite
   # (mirroring publish-plugin). Generates retracted.txt from go.mod via
   # the canonical `go mod edit -json | jq` pipeline before pushing, so


### PR DESCRIPTION
## Summary

Adds a `tag-homebrew-tap` job that runs after `verify-homebrew-install` succeeds, creating a lightweight tag on `dotsecenv/homebrew-tap` at the release version (e.g. `v0.6.13`). Until now the tap had no per-release tags — every release just landed a cask-update commit on `main`, with no ref to mark which commit corresponded to which release.

## Implementation

Mirrors the satellite tagging pattern in `publish-to-satellite.sh`: a single REST API call to `POST repos/dotsecenv/homebrew-tap/git/refs` with a lightweight tag. No GPG handling on the runner — the current `update-homebrew-tap` commits are already unsigned bot pushes, so adding cryptographic signing to the tag without first signing the commit wouldn't change the trust story. Switching the cask-update commit itself to GraphQL `createCommitOnBranch` (server-signed) is a separate follow-up worth considering.

### SHA resolution

| `cask_commit_sha` from `update-homebrew-tap` | Tag points at |
|---|---|
| Set (cask was updated this release) | The fresh cask-update commit |
| Empty (cask unchanged this release) | Current `HEAD` of `homebrew-tap/main` |

Either way every release has a corresponding tag for archaeology.

### Re-run safety

Idempotent: a 422 `Reference already exists` response is treated as success (the desired state is already on the server). Any other failure aborts the job loudly with the API response in the log.

### Failure semantics

`tag-homebrew-tap` is an **independent leaf** — `publish-packages` and `publish-plugin` do NOT depend on it. A tagging failure leaves the release shippable (binaries are out, cask is verified, brew install works) and the tag can be added by hand from the failed run. Conversely, the release graph stays red until the tag is created or the failure is investigated.

## Test plan

- [x] `actionlint .github/workflows/release.yml` clean.
- [x] YAML parse clean.
- [x] Pre-push hook green.
- [ ] **On next release**: confirm a `vX.Y.Z` tag appears on `dotsecenv/homebrew-tap` after the release graph turns green, pointing at the cask-update commit.
- [ ] **Idempotency**: re-run a release workflow (or manually re-trigger the job) — second run should warn `Tag already exists; skipping` and pass.
- [ ] **No-cask-change path**: when a release ships without changing Darwin checksums (cask_commit_sha empty), confirm the tag still gets created, pointing at `homebrew-tap/main` HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)