### PR TITLE
ci(release): commit homebrew-tap cask via GraphQL (server-signed)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,6 +347,18 @@ jobs:
           repository: dotsecenv/homebrew-tap
           token: ${{ steps.app-token.outputs.token }}
 
+      # Checkout the monorepo into a subdir so we can call its release
+      # scripts (specifically scripts/release/commit-cask-via-graphql.sh)
+      # from this job. The homebrew-tap stays at workspace root so the
+      # existing sed step keeps using relative `Casks/dotsecenv.rb`.
+      # Order matters: the homebrew-tap checkout above defaults to
+      # clean: true (git clean -ffdx in workspace root), which would
+      # wipe a pre-existing monorepo/ subdir if we ran it second.
+      - name: Checkout dotsecenv monorepo
+        uses: actions/checkout@v6
+        with:
+          path: monorepo
+
       - name: Download updated checksums
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -420,20 +432,57 @@ jobs:
           echo "==> Updated cask file:"
           cat "$CASK_FILE"
 
-      - name: Commit and push
+      # Commit the cask update via GitHub's GraphQL createCommitOnBranch
+      # mutation, which signs the commit server-side with the App's key.
+      # Replaces the previous `git config user.name; git commit; git push`
+      # flow so the homebrew-tap commit gets the same signed-by-bot
+      # provenance as the satellite publishes (see publish-to-satellite.sh).
+      # Provenance trailers (Source-Commit, Source-SHA, Source-Tag,
+      # Published-By) match the satellite convention so tap commits are
+      # parseable by the same `git interpret-trailers --parse` machinery.
+      - name: Commit cask via GraphQL (server-signed)
         id: commit
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ github.ref_name }}
+          SOURCE_SHA: ${{ github.sha }}
+          PUBLISHED_BY: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
-          VERSION="${{ github.ref_name }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Casks/dotsecenv.rb
-          if git commit -m "fix: update Darwin checksums for ${VERSION} (post-notarization)"; then
-            git push
-            echo "cask_commit_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          else
+
+          # Skip if sed didn't change anything (release where Darwin
+          # checksums didn't move). Same idempotency as the old
+          # `git commit` exit-code check.
+          if git diff --quiet HEAD -- Casks/dotsecenv.rb; then
             echo "No cask changes to commit — skipping push (downstream wait will no-op)"
+            exit 0
           fi
+
+          HEADLINE="fix: update Darwin checksums for ${VERSION} (post-notarization)"
+          BODY=$(
+            printf 'Source-Commit: dotsecenv/dotsecenv@%s\n' "${SOURCE_SHA}"
+            printf 'Source-SHA: %s\n' "${SOURCE_SHA}"
+            printf 'Source-Tag: %s\n' "${VERSION}"
+            printf 'Published-By: %s\n' "${PUBLISHED_BY}"
+          )
+
+          OUTPUT=$(
+            TAP_REPO=dotsecenv/homebrew-tap \
+            TAP_BRANCH=main \
+            CASK_PATH=Casks/dotsecenv.rb \
+            CASK_FILE=Casks/dotsecenv.rb \
+            HEADLINE="${HEADLINE}" \
+            BODY="${BODY}" \
+            monorepo/scripts/release/commit-cask-via-graphql.sh
+          )
+          echo "${OUTPUT}"
+
+          NEW_SHA=$(echo "${OUTPUT}" | sed -n 's/^commit_sha=//p')
+          if [ -z "${NEW_SHA}" ]; then
+            echo "::error::commit-cask-via-graphql.sh did not emit a commit SHA"
+            exit 1
+          fi
+          echo "cask_commit_sha=${NEW_SHA}" >> "$GITHUB_OUTPUT"
 
   # Push to homebrew-tap fires that repo's own post-release.yml CI
   # (a `brew tap && brew install` smoke). Until now that run was

--- a/scripts/release/commit-cask-via-graphql.sh
+++ b/scripts/release/commit-cask-via-graphql.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Commit a single file (the homebrew cask) to a target branch via
+# GitHub's GraphQL `createCommitOnBranch` mutation, producing a
+# server-signed commit. Mirrors publish-to-satellite.sh for the
+# single-file case so we avoid GPG handling on the runner — the App
+# installation token used by gh signs the commit server-side.
+#
+# Required env:
+#   TAP_REPO     "<owner>/<repo>" of the homebrew tap (e.g.
+#                "dotsecenv/homebrew-tap")
+#   TAP_BRANCH   target branch on the tap (typically "main")
+#   CASK_PATH    path of the cask file within the tap repo (e.g.
+#                "Casks/dotsecenv.rb")
+#   CASK_FILE    local file path containing the new cask contents
+#                (typically equal to CASK_PATH, when the tap is the
+#                workspace cwd)
+#   HEADLINE     commit message headline
+#   BODY         commit message body (RFC-822 trailer paragraph,
+#                parseable via `git interpret-trailers --parse`)
+#   GH_TOKEN     App installation token used by gh to call the API
+#
+# Output:
+#   prints "commit_sha=<sha>" on stdout for the caller to capture
+#   (e.g. into $GITHUB_OUTPUT)
+#
+# Required tools in PATH: gh, jq, base64
+
+set -euo pipefail
+
+: "${TAP_REPO:?TAP_REPO is required}"
+: "${TAP_BRANCH:?TAP_BRANCH is required}"
+: "${CASK_PATH:?CASK_PATH is required}"
+: "${CASK_FILE:?CASK_FILE is required}"
+: "${HEADLINE:?HEADLINE is required}"
+: "${BODY:?BODY is required}"
+: "${GH_TOKEN:?GH_TOKEN is required}"
+
+# Current head OID — required by the mutation as expectedHeadOid to
+# detect races. If something else pushes between this fetch and the
+# mutation, the mutation fails loudly rather than silently overwriting.
+EXPECTED_OID=$(gh api "repos/${TAP_REPO}/branches/${TAP_BRANCH}" --jq .commit.sha)
+echo "Current ${TAP_REPO}/${TAP_BRANCH} HEAD: ${EXPECTED_OID}"
+
+# Build the CreateCommitOnBranchInput payload. createCommitOnBranch
+# expects file contents base64-encoded. We materialize the JSON to a
+# file because the same `gh api graphql -F` quirk that bites
+# publish-to-satellite.sh applies here: -F reads the value as a STRING,
+# not JSON, so building the request body ourselves and sending via
+# --input is the only reliable path.
+CONTENTS=$(base64 < "${CASK_FILE}" | tr -d '\n')
+
+INPUT_FILE=$(mktemp)
+REQUEST_FILE=$(mktemp)
+trap 'rm -f "${INPUT_FILE}" "${REQUEST_FILE}"' EXIT
+
+jq -n \
+  --arg repo "${TAP_REPO}" \
+  --arg branch "${TAP_BRANCH}" \
+  --arg headline "${HEADLINE}" \
+  --arg body "${BODY}" \
+  --arg oid "${EXPECTED_OID}" \
+  --arg path "${CASK_PATH}" \
+  --arg contents "${CONTENTS}" \
+  '{
+    branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+    message: { headline: $headline, body: $body },
+    expectedHeadOid: $oid,
+    fileChanges: {
+      additions: [ { path: $path, contents: $contents } ]
+    }
+  }' > "${INPUT_FILE}"
+
+jq -n \
+  --arg query 'mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid url } } }' \
+  --slurpfile input "${INPUT_FILE}" \
+  '{query: $query, variables: {input: $input[0]}}' > "${REQUEST_FILE}"
+
+RESPONSE=$(gh api graphql --input "${REQUEST_FILE}")
+NEW_OID=$(jq -r '.data.createCommitOnBranch.commit.oid // empty' <<<"${RESPONSE}")
+
+if [ -z "${NEW_OID}" ]; then
+  echo "::error::createCommitOnBranch returned no commit oid"
+  echo "Full response from GitHub:" >&2
+  jq . <<<"${RESPONSE}" >&2 || echo "${RESPONSE}" >&2
+  exit 1
+fi
+
+echo "Signed commit ${NEW_OID} created on ${TAP_REPO}/${TAP_BRANCH}"
+echo "commit_sha=${NEW_OID}"


### PR DESCRIPTION
## Summary

Follow-up to #160. The homebrew-tap commit produced by `update-homebrew-tap` is now created via GitHub's GraphQL `createCommitOnBranch` mutation, mirroring the satellite publish pattern in `publish-to-satellite.sh`. Server-signed by GitHub using the App installation token — no GPG handling on the runner, no bot-identity push that shows up as unverified in the GitHub UI.

Closes the asymmetry flagged at the end of #160: the tap commit was the last leg of the release pipeline still using runner-side `git config user.name; git commit; git push`. After this PR, all three production-affecting writes (plugin satellite, packages satellite, homebrew-tap cask) use the same server-signed createCommitOnBranch primitive.

### Trailer convention

The cask commit body now carries the same RFC-822 trailers as satellite commits:

```
Source-Commit: dotsecenv/dotsecenv@<sha>      (linkable to release commit)
Source-SHA: <sha>                              (parseable standalone)
Source-Tag: vX.Y.Z                             (release version)
Published-By: <CI run URL>                     (linkable to workflow run)
```

`Source-Path` is omitted — the cask isn't a synced subdir, just a single file updated in place. All four trailers parse via `git interpret-trailers --parse`.

## Files changed

- **`scripts/release/commit-cask-via-graphql.sh`** (new) — focused single-file variant of `publish-to-satellite.sh`'s GraphQL machinery. Same `expectedHeadOid` race protection, same `gh api graphql --input` workaround for the `-F`-treats-JSON-as-string quirk. ~90 lines.
- **`.github/workflows/release.yml`** (`update-homebrew-tap` job):
  - Add a monorepo checkout into `monorepo/` so the script is reachable. Order matters: the homebrew-tap checkout takes the workspace root first (its `clean: true` default would wipe a pre-existing `monorepo/` subdir if we ran it second).
  - Replace "Commit and push" with "Commit cask via GraphQL (server-signed)" — preserves the no-op-on-no-change behavior via `git diff --quiet HEAD -- Casks/dotsecenv.rb` (was previously the `git commit` exit code).

## Test plan

- [x] `actionlint`, `shellcheck -x`, YAML parse all clean.
- [x] Pre-push hook green.
- [x] Local plumbing smoke: confirmed env validation works, gh api failures propagate through `set -e` (command-substitution errexit verified separately).
- [ ] **On next release**: confirm the cask-update commit on `dotsecenv/homebrew-tap` shows as "Verified" in the GitHub UI (signed by the App), and the commit body carries the four trailers.
- [ ] **No-op path**: confirm a release where Darwin checksums didn't change still skips cleanly (no commit, no `cask_commit_sha` output, downstream jobs no-op).

## Out of scope

The existing `publish-to-satellite.sh` and the new `commit-cask-via-graphql.sh` share ~30 lines of GraphQL machinery (jq input construction, request body, mutation call, OID extraction). Extracting a shared `_graphql-commit.sh` helper would dedupe but isn't urgent — neither caller is changing often and the duplication is small enough to read each in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)