### PR TITLE
ci(packages): keep last patch of last N minors, not last N patches

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -23,3 +23,13 @@ paths:
     ignore:
       - 'input "client-id" is not defined in action "actions/create-github-app-token@v3"'
       - 'missing input "app-id" which is required by action "actions/create-github-app-token@v3"'
+  packages/.github/workflows/publish.yml:
+    # Same actionlint stale-cache issue as release.yml above. This file
+    # lives under packages/ because it gets published to the satellite
+    # repo (dotsecenv/packages); actionlint only scans .github/workflows
+    # by default and won't reach here in normal CI, but the entry keeps
+    # `actionlint packages/.github/workflows/publish.yml` clean for
+    # anyone linting it directly.
+    ignore:
+      - 'input "client-id" is not defined in action "actions/create-github-app-token@v3"'
+      - 'missing input "app-id" which is required by action "actions/create-github-app-token@v3"'

--- a/packages/.github/workflows/publish.yml
+++ b/packages/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch:
     inputs:
       keep_versions:
-        description: "Number of releases to include (default: 5)"
+        description: "Number of minor versions to include — last patch of each (default: 5)"
         required: false
         default: "5"
 
@@ -88,13 +88,35 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           RETRACTED_CSV: ${{ steps.retracted.outputs.csv }}
         run: |
-          # Get last N release tags. Filter out:
+          # Pick the latest patch of each of the last KEEP_VERSIONS
+          # MINOR versions. Rationale: a refactor cycle can produce
+          # many patches against the same minor (e.g. 0.6.4..0.6.13
+          # were nearly-identical builds during the release-pipeline
+          # rewrite). Indexing the package repos by every patch
+          # wastes storage and obscures the meaningful version axis;
+          # users typically want to pin to a minor and ride the
+          # latest patch. With this selector, dropping "0.6" into a
+          # `brew install` / apt pinning configuration always
+          # resolves to the freshest known-good patch of that minor.
+          #
+          # Pre-filtering (in jq, same as before):
           #  - drafts (stale orphans / rc tags pushed for CI testing)
           #  - prereleases
           #  - versions listed in dotsecenv's go.mod retract block
-          # Retracted releases may still appear in the API even after
-          # their assets are deleted; excluding by tag_name catches both
-          # asset-deleted and not-yet-asset-deleted cases.
+          #    (retracted releases may still appear in the API even
+          #    after their assets are deleted; excluding by tag_name
+          #    catches both asset-deleted and not-yet-asset-deleted
+          #    cases).
+          #
+          # Post-filtering (shell pipeline):
+          #  - grep keeps only strict semver tags (v\d+\.\d+\.\d+),
+          #    so a one-off `funky-tag` or `v0.6.0-rc1` doesn't
+          #    crash the version parse.
+          #  - `sort -V -r` puts everything newest-first so awk's
+          #    "first occurrence per minor" picks the highest patch.
+          #  - awk dedups by major.minor, keeping the first-seen
+          #    (= highest patch for that minor).
+          #  - head -n KEEP_VERSIONS takes the last N minor lineages.
           RETRACTED_FILTER=""
           if [ -n "${RETRACTED_CSV}" ]; then
             # Build a jq array literal from the CSV.
@@ -109,9 +131,11 @@ jobs:
           fi
           JQ_EXPR="${JQ_EXPR} | .tag_name"
 
-          VERSIONS=$(gh api repos/dotsecenv/dotsecenv/releases \
-            --jq "${JQ_EXPR}" \
-            | head -n ${{ env.KEEP_VERSIONS }})
+          VERSIONS=$(gh api repos/dotsecenv/dotsecenv/releases --jq "${JQ_EXPR}" \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V -r \
+            | awk -F. '!seen[$1"."$2]++' \
+            | head -n "${KEEP_VERSIONS}")
 
           echo "versions<<EOF" >> $GITHUB_OUTPUT
           echo "$VERSIONS" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Changes the package-repo version selector in `packages/.github/workflows/publish.yml` from "last N release tags" to "last patch of each of the last N minor versions."

## Motivation

The recent release-pipeline rewrite produced `v0.6.4..v0.6.13` — ten near-identical patch builds of the same minor. With the old selector and `KEEP_VERSIONS=5`, the apt/yum/arch repos surface `v0.6.9..v0.6.13` — five patches of the same minor, with `v0.5.x` and earlier minors invisible to users.

This obscures the meaningful version axis. Users typically want to pin to a minor (apt-pin `0.6`, a `homebrew_install --version 0.6` etc.) and ride the latest patch as it lands. With this selector, pinning to a minor always resolves to the freshest known-good patch of that minor, and the last N **minors** are what's exposed — not the last N patches of whichever minor happened to churn most recently.

## Implementation

Same pre-filter as before (jq drops drafts, prereleases, retracted tags). Then a tight post-filter shell pipeline:

```bash
grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$'   # strict semver only (drops 'v0.6.0-rc1', 'funky-tag')
| sort -V -r                           # newest first
| awk -F. '!seen[$1"."$2]++'           # first per major.minor wins (= highest patch)
| head -n "${KEEP_VERSIONS}"           # take last N minor lineages
```

`KEEP_VERSIONS` keeps its name and default (5) but its **semantics shift** from "N patch tags" to "N minor lineages." Updated the input description and surrounding comment.

## Test plan

- [x] Local smoke with synthetic tag set including `v0.6.4..v0.6.13`, `v0.5.x`, `v0.4.0`, `v1.0.0`, plus a prerelease and a non-semver tag. With `KEEP_VERSIONS=3`: outputs `v1.0.0, v0.6.13, v0.5.3` (correct).
- [x] `actionlint` clean for this step (other warnings in the file are pre-existing, not introduced here).
- [x] YAML parse clean.
- [ ] **Post-merge**: trigger `publish.yml` on the packages satellite via `workflow_dispatch` with default `keep_versions=5`. Confirm the resulting `get.dotsecenv.com` index exposes the latest patch of the last 5 minors (currently `v0.6.13` plus four older minors), not five patches of `v0.6.x`.
- [ ] **Spot-check `LATEST`**: `LATEST=$(echo "$VERSIONS" | head -n 1)` still resolves to the highest patch of the newest minor (currently `v0.6.13`). The Arch repo "latest only" build depends on this — should be unaffected.

## What this doesn't change

- The retraction filter still operates pre-grouping, so a retracted patch is still excluded; if the **highest** patch of a minor is retracted, the selector falls back to the next-highest of that minor (which may still get cut by `KEEP_VERSIONS` if its minor moves down the list).
- `KEEP_VERSIONS` default stays at 5. Operators wanting more minor history can dispatch with a higher value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)