### PR TITLE
ci: SHA-pin every third-party action across all workflows

### DIFF
--- a/.github/workflows/ci-plugin.yml
+++ b/.github/workflows/ci-plugin.yml
@@ -28,10 +28,10 @@ jobs:
       run:
         working-directory: plugin
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version: "1.26"
 

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -37,11 +37,11 @@ jobs:
     name: Snapshot Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "go.sum"

--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -25,15 +25,15 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: website/package.json
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
         with:
           version: 11
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,9 +98,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "go.sum"
@@ -114,9 +114,9 @@ jobs:
     # https://github.com/dotsecenv/dotsecenv/issues/8
     if: ${{ vars.ENABLE_WINDOWS_CI == 'true' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "go.sum"
@@ -131,9 +131,9 @@ jobs:
     name: Build Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "go.sum"
@@ -148,9 +148,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "go.sum"
@@ -162,14 +162,14 @@ jobs:
     needs: [test, build-docs]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "go.sum"
 
-      - uses: hashicorp/setup-terraform@v4
+      - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e  # v4.0.1
 
       - run: terraform version
 
@@ -180,7 +180,7 @@ jobs:
     needs: [test, build-docs]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - uses: ./
         with:
@@ -194,7 +194,7 @@ jobs:
     needs: [test, build-docs]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - uses: ./
         with:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -30,17 +30,17 @@ jobs:
       run:
         working-directory: website
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: website/package.json
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v6
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
         with:
           version: 11
 
@@ -57,10 +57,10 @@ jobs:
           DOTSECENV_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || '' }}
 
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
           path: website/dist
           retention-days: 7
@@ -77,4 +77,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/.github/workflows/e2e-hermetic.yml
+++ b/.github/workflows/e2e-hermetic.yml
@@ -33,9 +33,9 @@ jobs:
     name: Build artifacts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "go.sum"
@@ -44,7 +44,7 @@ jobs:
         run: make build
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: e2e-artifacts
           path: |
@@ -72,7 +72,7 @@ jobs:
           disable-sudo-and-containers: true
 
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: e2e-artifacts
 
@@ -91,9 +91,9 @@ jobs:
     name: Hermetic E2E (strace + namespace)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "go.sum"
@@ -125,7 +125,7 @@ jobs:
           echo "PASSED: Zero external network syscalls verified by strace"
 
       - name: Upload strace log
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: network-syscall-trace

--- a/.github/workflows/e2e-install.yml
+++ b/.github/workflows/e2e-install.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Run install.sh E2E tests
         env:

--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -28,7 +28,7 @@ jobs:
     name: actionlint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Run actionlint
         uses: docker://rhysd/actionlint:1.7.12

--- a/.github/workflows/publish-satellites.yml
+++ b/.github/workflows/publish-satellites.yml
@@ -33,7 +33,7 @@ jobs:
     outputs:
       packages_run_id: ${{ steps.find_packages.outputs.run_id }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Capture pre-push timestamp
         id: timestamp
@@ -41,7 +41,7 @@ jobs:
           echo "push_time=$(date -u -d '5 seconds ago' +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Go (for extract-retracted.sh)
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
           cache: false
@@ -53,7 +53,7 @@ jobs:
           cat packages/retracted.txt || echo "(none)"
 
       - name: Generate App token (packages only)
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
@@ -92,10 +92,10 @@ jobs:
     if: inputs.target == 'packages' || inputs.target == 'both'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Generate App token (packages, actions:read needed)
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
@@ -114,10 +114,10 @@ jobs:
     if: inputs.target == 'plugin' || inputs.target == 'both'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Generate App token (plugin only)
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
@@ -152,7 +152,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Run plugin manager integration tests (remote)
         working-directory: plugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,12 +117,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "go.sum"
@@ -144,14 +144,14 @@ jobs:
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd  # v7.0.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
           trust_level: 5
 
       - name: Generate App Token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
@@ -162,10 +162,10 @@ jobs:
             packages
 
       - name: Install Syft
-        uses: anchore/sbom-action@v0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8  # v7.2.1
         with:
           distribution: goreleaser
           version: "~> v2"
@@ -179,7 +179,7 @@ jobs:
 
       - name: Attest Build Provenance
         if: ${{ !github.event.repository.private }}
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
         with:
           subject-path: "dist/*"
 
@@ -191,11 +191,11 @@ jobs:
         arch: [x86_64, arm64]
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd  # v7.0.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -269,11 +269,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v7
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd  # v7.0.0
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.GPG_PASSPHRASE }}
@@ -321,7 +321,7 @@ jobs:
 
       - name: Attest Darwin Archives
         if: ${{ !github.event.repository.private }}
-        uses: actions/attest-build-provenance@v4
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
         with:
           subject-path: "dotsecenv_*_Darwin_*.tar.gz"
 
@@ -332,7 +332,7 @@ jobs:
       cask_commit_sha: ${{ steps.commit.outputs.cask_commit_sha }}
     steps:
       - name: Generate App Token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
@@ -342,7 +342,7 @@ jobs:
             homebrew-tap
 
       - name: Checkout homebrew-tap
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: dotsecenv/homebrew-tap
           token: ${{ steps.app-token.outputs.token }}
@@ -355,7 +355,7 @@ jobs:
       # clean: true (git clean -ffdx in workspace root), which would
       # wipe a pre-existing monorepo/ subdir if we ran it second.
       - name: Checkout dotsecenv monorepo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           path: monorepo
 
@@ -495,7 +495,7 @@ jobs:
     permissions: {}
     steps:
       - name: Generate App token (homebrew-tap actions:read)
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
@@ -601,7 +601,7 @@ jobs:
     permissions: {}
     steps:
       - name: Generate App Token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
@@ -664,7 +664,7 @@ jobs:
       packages_run_id: ${{ steps.find_packages.outputs.run_id }}
       packages_run_url: ${{ steps.find_packages.outputs.run_url }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Capture pre-push timestamp
         id: timestamp
@@ -674,7 +674,7 @@ jobs:
           echo "push_time=$(date -u -d '5 seconds ago' +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Go (for extract-retracted.sh)
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: go.mod
           cache: false
@@ -686,7 +686,7 @@ jobs:
           cat packages/retracted.txt || echo "(none)"
 
       - name: Generate App token (packages only)
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
@@ -729,10 +729,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Generate App token (packages only, actions:read needed)
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
@@ -776,10 +776,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Generate App token (plugin only)
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3.2.0
         id: app-token
         with:
           client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
@@ -815,7 +815,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Run plugin manager integration tests (remote)
         working-directory: plugin

--- a/.github/workflows/verify-satellites.yml
+++ b/.github/workflows/verify-satellites.yml
@@ -75,7 +75,7 @@ jobs:
       # Satellite goes first because we may need to read its Source-SHA
       # trailer to decide which monorepo commit to compare against.
       - name: Checkout ${{ matrix.repo }} satellite
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           repository: ${{ matrix.repo }}
           path: satellite
@@ -110,7 +110,7 @@ jobs:
           echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout monorepo @ ${{ steps.sha.outputs.sha }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ steps.sha.outputs.sha }}
           path: monorepo
@@ -124,7 +124,7 @@ jobs:
       # whitelisting it.
       - name: Set up Go (for extract-retracted.sh)
         if: matrix.satellite == 'packages'
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: monorepo/go.mod
           cache: false


### PR DESCRIPTION
## Summary

Replaces 15 floating tag references (`actions/checkout@v6`, `actions/setup-go@v6`, `anchore/sbom-action@v0`, etc.) with their commit SHAs plus a human-readable version comment. Matches the existing pattern used for `step-security/harden-runner` and the new `releasetools/actions/signed-push` pin from #163.

**Net diff**: 11 workflow files changed, +71 / −71 (pure 1-for-1 substitution).

## Why every third-party action

A floating tag like `@v6` can be moved by the upstream maintainer at any time. In practice this is benign — a patch release lands and `@v6` follows it. The worst case is a supply-chain compromise where the tag is moved to a malicious commit. SHA pinning forces every upstream change to surface as a diff in this repo before it runs in CI. A reviewer sees exactly what bytes are about to execute with the release-pipeline tokens.

GitHub's own [security hardening guidance](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) recommends this pattern for third-party actions.

## What got pinned

| Action | SHA | Version |
|---|---|---|
| `actions/attest-build-provenance` | `a2bbfa25` | v4.1.0 |
| `actions/checkout` | `de0fac2e` | v6.0.2 |
| `actions/configure-pages` | `45bfe019` | v6.0.0 |
| `actions/create-github-app-token` | `bcd2ba49` | v3.2.0 |
| `actions/deploy-pages` | `cd2ce8fc` | v5.0.0 |
| `actions/download-artifact` | `3e5f45b2` | v8.0.1 |
| `actions/setup-go` | `4a360112` | v6.4.0 |
| `actions/setup-node` | `48b55a01` | v6.4.0 |
| `actions/upload-artifact` | `043fb46d` | v7.0.1 |
| `actions/upload-pages-artifact` | `fc324d35` | v5.0.0 |
| `anchore/sbom-action` | `e22c3899` | v0.24.0 |
| `crazy-max/ghaction-import-gpg` | `2dc316de` | v7.0.0 |
| `goreleaser/goreleaser-action` | `1a80836c` | v7.2.1 |
| `hashicorp/setup-terraform` | `dfe3c3f8` | v4.0.1 |
| `pnpm/action-setup` | `0e279bb9` | v6.0.8 |

Each SHA was resolved via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>` (with annotated-tag dereferencing). The version comment is the most specific semver tag pointing at that same SHA, found via `gh api repos/<owner>/<repo>/tags`.

## What stays unpinned, on purpose

- **`docker://rhysd/actionlint:1.7.12`** — Docker image tags carry their own immutable digest convention; the explicit version pin here is the equivalent.
- **`./` and `./.github/workflows/*`** — local refs to same-repo content, covered by branch protection and code review.
- **`dotsecenv/dotsecenv@v0`** — self-reference to this repo's own action (`action.yml` at repo root). Not third-party; same security profile as the rest of `main`.

## Maintenance

Dependabot's `package-ecosystem: github-actions` understands the SHA-with-comment pattern and opens PRs that bump both the SHA and the comment in lockstep. If you haven't already, add this to `.github/dependabot.yml`:

```yaml
- package-ecosystem: github-actions
  directory: /
  schedule:
    interval: weekly
```

## Test plan

- [x] `actionlint` clean across all 11 touched workflow files.
- [x] `git diff --stat` shows pure 1-for-1 substitution (+71 / −71).
- [x] Pre-push hook clean (no `scripts/**` touched).
- [ ] **Post-merge**: confirm the next release runs goreleaser, GPG import, setup-go, etc. via the pinned SHAs without behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)