### PR TITLE
fix(packages): import key.asc before verifying historical release assets

### DIFF
--- a/packages/.github/workflows/publish.yml
+++ b/packages/.github/workflows/publish.yml
@@ -220,10 +220,9 @@ jobs:
 
       - name: Verify All Assets
         run: |
-          # key.asc bundles current + retired public keys. The ghaction-import-gpg
-          # step above only loaded the current signing key, so older releases
-          # signed under a retired key fail `gpg --verify` with "No public key".
-          # Import the bundle so historical versions verify too.
+          # key.asc bundles current + retired public keys. ghaction-import-gpg
+          # above imports only the current signing key; importing the bundle
+          # here adds retired keys so older releases also verify.
           gpg --import key.asc
 
           for dir in incoming/*/; do

--- a/packages/.github/workflows/publish.yml
+++ b/packages/.github/workflows/publish.yml
@@ -220,6 +220,12 @@ jobs:
 
       - name: Verify All Assets
         run: |
+          # key.asc bundles current + retired public keys. The ghaction-import-gpg
+          # step above only loaded the current signing key, so older releases
+          # signed under a retired key fail `gpg --verify` with "No public key".
+          # Import the bundle so historical versions verify too.
+          gpg --import key.asc
+
           for dir in incoming/*/; do
             [ -d "$dir" ] || continue
             echo "Verifying $dir..."


### PR DESCRIPTION
## Summary
- Satellite publish workflow's **Verify All Assets** step failed on v0.6.14 republish because the runner's keyring held only the current signing key (loaded by `ghaction-import-gpg`). v0.0.11, signed under retired key `E60A1740...F0921C59`, hit `gpg: Can't check signature: No public key` and aborted the job.
- `packages/key.asc` already concatenates current + retired public keys for exactly this scenario. Import it before the verify loop so historical releases verify too.
- Surfaced now because the new "last patch per minor" selector (#162) pulled `v0.0.11` back into the rebuild set.

Failing run: https://github.com/dotsecenv/packages/actions/runs/25997768967

## Test plan
- [ ] Merge to `main`
- [ ] Run **Publish Satellites** workflow (workflow_dispatch, target=`packages`) to ship the updated `packages/` source
- [ ] Confirm the resulting satellite `publish.yml` run passes the **Verify All Assets** step for all five included versions, including `v0.0.11`

🤖 Generated with [Claude Code](https://claude.com/claude-code)