### PR TITLE
ci: set least-privilege GITHUB_TOKEN permissions on ci + post-release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,8 @@ on:
       - "!.github/workflows/ci-website.yml"
       - "!.github/workflows/deploy-website.yml"
 
+permissions: {}
+
 jobs:
   test:
     name: Lint, Build, Test (${{ matrix.os }})

--- a/.github/workflows/e2e-action-post-release.yml
+++ b/.github/workflows/e2e-action-post-release.yml
@@ -30,6 +30,8 @@ on:
         required: false
         default: ""
 
+permissions: {}
+
 jobs:
   test-released-action:
     name: Test Released Action (${{ matrix.os }})


### PR DESCRIPTION
## Summary

- Add `permissions: {}` at the workflow root of `ci.yml` and `e2e-action-post-release.yml`.
- Resolves CodeQL `actions/missing-workflow-permissions` alerts [#1–#12](https://github.com/dotsecenv/dotsecenv/security/code-scanning?query=is%3Aopen+rule%3Aactions%2Fmissing-workflow-permissions) in one shot.
- Matches the pattern already used in `ci-plugin.yml` and `ci-website.yml`. Both affected workflows only do public `actions/checkout` + build/test/e2e — no token writes required.

## Test plan

- [ ] CI green on this branch (the workflow changes self-test on push)
- [ ] After merge, confirm the 12 missing-workflow-permissions alerts close automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)