### PR TITLE
ci(release): link get.dotsecenv.com on publish-packages job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -659,6 +659,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    environment:
+      name: get.dotsecenv.com
+      url: https://get.dotsecenv.com
     # Exposed so wait-publish-packages can watch the just-triggered satellite run.
     outputs:
       packages_run_id: ${{ steps.find_packages.outputs.run_id }}


### PR DESCRIPTION
## Summary

- Add `environment: { name: get.dotsecenv.com, url: https://get.dotsecenv.com }` to the `publish-packages` job in `release.yml`.
- Matches the affordance already on `deploy-website`: the release run's job list shows a clickable "View deployment" link next to the job, pointing at the satellite-published URL.
- Auto-creates a `get.dotsecenv.com` environment in repo settings on first run, with no protection rules. Harmless unless someone later adds gates.

Reference run that motivated this: https://github.com/dotsecenv/dotsecenv/actions/runs/26005208941

## Test plan

- [ ] Next release run shows the deployment link in the UI for `publish-packages`
- [ ] Environment auto-created in Settings → Environments with empty protection rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)