### PR TITLE
docs(agents): require vendoring changes in a separate PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,12 @@ What the script does NOT do — handle manually if needed:
 - **FIPS 140-3:** Release binaries set `GOFIPS140=v1.26.0` and `CGO_ENABLED=0`.
   The build is pure-Go; **don't add CGO dependencies**.
 - **Vendoring:** Dependencies are vendored. `make build` uses `-mod=vendor`.
-  After changing imports, run `go mod tidy && go mod vendor`.
+  After changing imports, run `go mod tidy && go mod vendor`. **Vendor changes
+  go in their own PR, separate from logic.** Adding a dependency can touch
+  hundreds of files (#183 vendored bubbletea/lipgloss across 308), which buries
+  the real diff and makes review impractical. Add or bump the dependency,
+  vendor it, and merge that PR first; then build the feature on the updated
+  `main`.
 - **Commit messages:** Conventional Commits with PR-number suffix, e.g.
   `feat: behavior.* and gpg.program policy fields (last-set-wins) (#116)`.
   Allowed types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`,
@@ -264,6 +269,10 @@ making changes that look like they might violate them.
   some accounts, but the convention is: branch, commit, push the branch,
   open a PR. Direct pushes skip CI gates and review, and force-pushing
   `main` to undo a direct push rewrites public history.
+- **Don't mix vendored dependency changes with logic in one PR.** `go mod
+  vendor` can add hundreds of files; bundled with a feature, the real change
+  is unreviewable (#183 came to 308 files). Vendor the dependency in its own
+  PR first, then open the feature PR against the updated `main`.
 - **Don't modify cryptographic invariants without explicit review.** This
   includes: vault entry signature checks, the SHA-256 hash chain in JSONL
   entries, the append-only writer, multi-recipient PGP encryption, and the


### PR DESCRIPTION
## Why

PR #183 (`init secenv`) came to **308 changed files** because `go mod vendor` pulled in bubbletea/lipgloss and their transitive deps. The 9 files that actually mattered were buried, making review impractical.

## What

Adds the rule to `AGENTS.md` (the canonical agent entrypoint) in two places, matching the file's dual convention/Don't pattern:

- **Conventions → Vendoring:** vendor changes go in their own PR; add/bump the dependency, vendor it, merge that PR first, then build the feature on the updated `main`.
- **Don't do X:** don't mix vendored dependency changes with logic in one PR.

Touches only `AGENTS.md`, so it does not itself violate the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)