### PR TITLE
fix(renovate): disable npm lockFileMaintenance (perpetual stability-days)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>dotsecenv/.github"
-  ]
+  ],
+  "lockFileMaintenance": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
## Problem

Renovate **lock-file-maintenance** PRs (e.g. #171, only `website/pnpm-lock.yaml`) never merge. Every real check passes; the blocker is `renovate/stability-days`, stuck pending — *"Updates have not met minimum release age requirement."*

## Root cause

The shared preset `dotsecenv/.github/default.json` sets `minimumReleaseAge: "3 days"` + `internalChecksFilter: "strict"` and only exempts **non-npm** lock maintenance (`matchDatasources: ["!npm"]`). The pnpm lock is npm, so the 3-day age gate stays in force. A lock refresh resolves to the latest in-range versions and reschedules weekly, so `renovate/stability-days` never clears: **the package manager picks versions, so the gate can only block the PR — it can't down-select to an aged version.** Renovate never auto-merges, and the PR sits forever.

(The `main` ruleset only requires the `allow` check, which passes — branch protection isn't the blocker.)

## Why disable rather than drop the gate

`lockFileMaintenance` and `minimumReleaseAge` are fundamentally incompatible — you can't age-gate a lock refresh and still merge it. Dropping the gate (and especially auto-merging) would let freshly-published, possibly-compromised transitive deps land with no buffer and no review. For a secrets tool that's the wrong trade. So this **disables lockFileMaintenance** for the repo instead. **No automerge.**

Security coverage is unaffected:
- Known-CVE fixes still raise PRs via the preset's `vulnerabilityAlerts` + `osvVulnerabilityAlerts`.
- Direct-dependency bumps stay 3-day age-gated and keep updating deps.

lockFileMaintenance was only routine *transitive* hygiene, which can't be age-gated anyway.

## Effect

`"lockFileMaintenance": { "enabled": false }`. Resolves the stuck #171 (Renovate abandons the branch once disabled). Validated with `renovate-config-validator` (✓).

## Companion

The root cause is the shared preset's `["!npm"]` gap. A companion PR disables lockFileMaintenance in `dotsecenv/.github/default.json` org-wide; once that lands, this local override is redundant and can be closed (kept here so #171 unblocks immediately on merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
