### PR TITLE
fix(website): unify Expressive Code frame corners and border color

### DIFF
--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -113,10 +113,27 @@ h1, h2, h3, h4, h5, h6 {
   margin-top: 2rem;
 }
 
-/* Terminal-like code blocks */
-pre {
-  border: 1px solid var(--sl-color-hairline);
-  border-radius: 6px;
+/*
+ * Code blocks render through Expressive Code, which owns each block's border
+ * and corner radius. A blanket `pre { border; border-radius }` rule used to
+ * live here, but being unlayered it overrode EC's own per-corner rules: it
+ * re-rounded the body's top corners (which EC zeroes so the title tab can sit
+ * flush on top), leaving a 6px-rounded body behind a square, left-aligned tab.
+ * It also leaked a border onto the asciinema player's internal <pre>. Drive EC
+ * through its own variables instead, so the frame, title tab, and code body
+ * round together as one unit.
+ */
+.expressive-code {
+  --ec-brdRad: 6px; /* frame + code-body corners */
+  --ec-frm-edTabBrdRad: 6px; /* title tab top corners, matched to the frame */
+  /*
+   * One border color for the whole frame. EC draws the body outline from
+   * --ec-brdCol and the title-tab outline from --ec-frm-edTabBarBrdCol; left
+   * unmatched, the tab's blue-gray border met the body's neutral hairline in a
+   * two-tone seam down the left edge.
+   */
+  --ec-brdCol: var(--sl-color-hairline);
+  --ec-frm-edTabBarBrdCol: var(--sl-color-hairline);
 }
 
 /* Inline code styling */


### PR DESCRIPTION
## Problem

Titled code blocks (e.g. ```` ```bash title="~/myapp/.secenv" ````) on the docs site rendered with a square, left-aligned title tab sitting on a 6px-rounded body, plus a two-tone border seam down the left edge where the tab's border met the body's border.

## Root cause

A blanket rule in `website/src/styles/custom.css`:

```css
pre { border: 1px solid var(--sl-color-hairline); border-radius: 6px; }
```

Code blocks render through Expressive Code, which owns each block's border and corners — for titled frames it deliberately zeroes the body's top corners so the tab sits flush on top. Because Starlight's custom CSS is **unlayered** and EC's rules live in `@layer starlight.components`, this blanket rule beat EC's per-corner rules regardless of specificity, re-rounding the body's top corners behind the square tab. It also leaked a border onto the asciinema player's internal `<pre>`.

The later border seam came from EC drawing the body outline from `--ec-brdCol` and the title-tab outline from a separate variable (`--ec-frm-edTabBarBrdCol`, an untouched blue-gray default).

## Fix

Replace the blanket `pre` rule with Expressive Code's own variables so the frame, title tab, and body round together as one unit and share a single hairline border color:

```css
.expressive-code {
  --ec-brdRad: 6px;
  --ec-frm-edTabBrdRad: 6px;
  --ec-brdCol: var(--sl-color-hairline);
  --ec-frm-edTabBarBrdCol: var(--sl-color-hairline);
}
```

## Verification

Inspected the live render (dark + light) with Playwright:

- Tab top corners 7px (match the frame); body top corners 0 (flush under the tab); body bottom 7px.
- `--ec-brdCol` and `--ec-frm-edTabBarBrdCol` both resolve to `#262626` — no seam.
- Border color preserved at the prior `--sl-color-hairline` value; only corners and tab-border color changed.
- Applies consistently to titled, untitled, and terminal frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)