### PR TITLE
fix(plugin): report plain env vars and secrets on separate lines

### DIFF
--- a/plugin/_dotsecenv_core.sh
+++ b/plugin/_dotsecenv_core.sh
@@ -14,6 +14,9 @@ declare -g -a _DOTSECENV_SESSION_DENIED_DIRS=()
 # Track secrets loaded from .secenv (reset per directory change)
 declare -g -a _DOTSECENV_SECRETS_LOADED=()
 
+# Track plain env vars loaded from .secenv (reset per directory change)
+declare -g -a _DOTSECENV_ENVVARS_LOADED=()
+
 # Stack of directories with loaded .secenv (ordered ancestor → descendant)
 # Used for tree-scoped secret loading
 declare -g -a _DOTSECENV_SOURCE_STACK=()
@@ -279,6 +282,17 @@ _dotsecenv_array_append() {
     eval "${array_name}+=(\"\$value\")"
 }
 
+# Join arguments into a single ", "-separated string (portable across bash and
+# zsh; "${arr[*]}" with IFS=', ' would use only the first IFS char).
+_dotsecenv_join_comma() {
+    local result="" sep="" item
+    for item in "$@"; do
+        result="${result}${sep}${item}"
+        sep=", "
+    done
+    printf '%s' "$result"
+}
+
 # Load a single .secenv file
 # Arguments: file_path, phase (1=plain vars only, 2=secrets only), dir
 _dotsecenv_load_file() {
@@ -304,6 +318,7 @@ _dotsecenv_load_file() {
                 # Phase 1: load plain variables
                 export "$key=$value"
                 _dotsecenv_array_append "$vars_var" "$key"
+                _DOTSECENV_ENVVARS_LOADED+=("$key")
 
             elif [[ "$phase" == "2" && ("$ptype" == "secret_same" || "$ptype" == "secret_named") ]]; then
                 # Phase 2: load secrets via dotsecenv CLI
@@ -341,15 +356,25 @@ _dotsecenv_unload_dir() {
     dir_hash=$(_dotsecenv_dir_hash "$dir")
     local vars_var="_DOTSECENV_LOADED_${dir_hash}"
     local secrets_var="_DOTSECENV_SECRETS_${dir_hash}"
+    local envvars_var="_DOTSECENV_ENVVARS_${dir_hash}"
 
     # Reset the unloaded keys tracking
     _DOTSECENV_UNLOADED_KEYS=()
 
-    # Report secrets being unloaded before clearing them
+    # Report plain env vars and secrets on separate lines before clearing them;
+    # skip a line when its category is empty.
+    if eval "[[ \${#${envvars_var}[@]} -gt 0 ]]" 2>/dev/null; then
+        local envvars_list="" envvar_count=0
+        eval "envvar_count=\${#${envvars_var}[@]}"
+        eval "envvars_list=\$(_dotsecenv_join_comma \"\${${envvars_var}[@]}\")"
+        echo "dotsecenv: unloaded $envvar_count env var(s): $envvars_list" >&2
+        unset "$envvars_var"
+    fi
+
     if eval "[[ \${#${secrets_var}[@]} -gt 0 ]]" 2>/dev/null; then
         local secrets_list="" secret_count=0
         eval "secret_count=\${#${secrets_var}[@]}"
-        eval "secrets_list=\$(IFS=', '; echo \"\${${secrets_var}[*]}\")"
+        eval "secrets_list=\$(_dotsecenv_join_comma \"\${${secrets_var}[@]}\")"
         echo "dotsecenv: unloaded $secret_count secret(s): $secrets_list" >&2
         unset "$secrets_var"
     fi
@@ -430,6 +455,7 @@ _dotsecenv_load_key() {
     dir_hash=$(_dotsecenv_dir_hash "$dir")
     local vars_var="_DOTSECENV_LOADED_${dir_hash}"
     local secrets_var="_DOTSECENV_SECRETS_${dir_hash}"
+    local envvars_var="_DOTSECENV_ENVVARS_${dir_hash}"
 
     [[ -f "$file" ]] || return 1
 
@@ -445,6 +471,7 @@ _dotsecenv_load_key() {
             if [[ "$ptype" == "plain" ]]; then
                 export "$key=$value"
                 _dotsecenv_array_append "$vars_var" "$key"
+                _dotsecenv_array_append "$envvars_var" "$key"
                 return 0
             elif [[ "$ptype" == "secret_same" || "$ptype" == "secret_named" ]]; then
                 local secret_name="$value"
@@ -660,11 +687,27 @@ _dotsecenv_on_cd() {
     fi
 
     # Phase 1: Load plain variables from .secenv
+    _DOTSECENV_ENVVARS_LOADED=()
     _dotsecenv_load_file "$new_dir/.secenv" 1 "$new_dir"
 
     # Phase 2: Load secrets from .secenv
     _DOTSECENV_SECRETS_LOADED=()
     _dotsecenv_load_file "$new_dir/.secenv" 2 "$new_dir"
+
+    # Report plain env vars and secrets on separate lines; skip a line when its
+    # category is empty (an empty .secenv produces no output at all).
+    if [[ ${#_DOTSECENV_ENVVARS_LOADED[@]} -gt 0 ]]; then
+        # Track env vars per directory for unload reporting
+        local envvars_var="_DOTSECENV_ENVVARS_${dir_hash}"
+        eval "${envvars_var}=()"
+        local env_key
+        for env_key in "${_DOTSECENV_ENVVARS_LOADED[@]}"; do
+            _dotsecenv_array_append "$envvars_var" "$env_key"
+        done
+        local envvars_list
+        envvars_list=$(_dotsecenv_join_comma "${_DOTSECENV_ENVVARS_LOADED[@]}")
+        echo "dotsecenv: loaded ${#_DOTSECENV_ENVVARS_LOADED[@]} env var(s) from .secenv: $envvars_list" >&2
+    fi
 
     if [[ ${#_DOTSECENV_SECRETS_LOADED[@]} -gt 0 ]]; then
         # Track secrets per directory for unload reporting
@@ -675,10 +718,7 @@ _dotsecenv_on_cd() {
             _dotsecenv_array_append "$secrets_var" "$secret_key"
         done
         local keys_list
-        keys_list=$(
-            IFS=', '
-            echo "${_DOTSECENV_SECRETS_LOADED[*]}"
-        )
+        keys_list=$(_dotsecenv_join_comma "${_DOTSECENV_SECRETS_LOADED[@]}")
         echo "dotsecenv: loaded ${#_DOTSECENV_SECRETS_LOADED[@]} secret(s) from .secenv: $keys_list" >&2
     fi
 

--- a/plugin/conf.d/dotsecenv.fish
+++ b/plugin/conf.d/dotsecenv.fish
@@ -30,6 +30,8 @@ set -g _DOTSECENV_PREV_PWD ""
 # Format: _DOTSECENV_LOADED_<hash> = "VAR1 VAR2 VAR3"
 # Track secrets loaded from .secenv (reset per directory change)
 set -g _DOTSECENV_SECRETS_LOADED
+# Track plain env vars loaded from .secenv (reset per directory change)
+set -g _DOTSECENV_ENVVARS_LOADED
 # Stack of directories with loaded .secenv (ordered ancestor → descendant)
 set -g _DOTSECENV_SOURCE_STACK
 # Track unloaded keys for re-fetch logic
@@ -283,6 +285,7 @@ function _dotsecenv_load_file
                 # Phase 1: load plain variables
                 set -gx $key "$value"
                 set -g -a _DOTSECENV_LOADED_$dir_hash "$key"
+                set -g -a _DOTSECENV_ENVVARS_LOADED "$key"
 
             else if test "$phase" = 2; and begin
                     test "$ptype" = secret_same; or test "$ptype" = secret_named
@@ -320,11 +323,22 @@ function _dotsecenv_unload_dir
     set -l dir_hash (_dotsecenv_dir_hash "$dir")
     set -l vars_var "_DOTSECENV_LOADED_$dir_hash"
     set -l secrets_var "_DOTSECENV_SECRETS_$dir_hash"
+    set -l envvars_var "_DOTSECENV_ENVVARS_$dir_hash"
 
     # Reset the unloaded keys tracking
     set -g _DOTSECENV_UNLOADED_KEYS
 
-    # Report secrets being unloaded before clearing them
+    # Report plain env vars and secrets on separate lines before clearing them;
+    # skip a line when its category is empty.
+    if set -q $envvars_var
+        set -l envvar_count (count $$envvars_var)
+        if test $envvar_count -gt 0
+            set -l envvars_list (string join ', ' $$envvars_var)
+            echo "dotsecenv: unloaded $envvar_count env var(s): $envvars_list" >&2
+        end
+        set -e $envvars_var
+    end
+
     if set -q $secrets_var
         set -l secret_count (count $$secrets_var)
         if test $secret_count -gt 0
@@ -423,6 +437,7 @@ function _dotsecenv_load_key
             if test "$ptype" = plain
                 set -gx $key "$value"
                 set -g -a _DOTSECENV_LOADED_$dir_hash "$key"
+                set -g -a _DOTSECENV_ENVVARS_$dir_hash "$key"
                 return 0
             else if test "$ptype" = secret_same; or test "$ptype" = secret_named
                 set -l secret_name "$value"
@@ -622,11 +637,21 @@ function _dotsecenv_on_cd
     end
 
     # Phase 1: Load plain variables from .secenv
+    set -g _DOTSECENV_ENVVARS_LOADED
     _dotsecenv_load_file "$new_dir/.secenv" 1 "$new_dir"
 
     # Phase 2: Load secrets from .secenv
     set -g _DOTSECENV_SECRETS_LOADED
     _dotsecenv_load_file "$new_dir/.secenv" 2 "$new_dir"
+
+    # Report plain env vars and secrets on separate lines; skip a line when its
+    # category is empty (an empty .secenv produces no output at all).
+    if test (count $_DOTSECENV_ENVVARS_LOADED) -gt 0
+        # Track env vars per directory for unload reporting
+        set -g _DOTSECENV_ENVVARS_$dir_hash $_DOTSECENV_ENVVARS_LOADED
+        set -l envvars_list (string join ', ' $_DOTSECENV_ENVVARS_LOADED)
+        echo "dotsecenv: loaded "(count $_DOTSECENV_ENVVARS_LOADED)" env var(s) from .secenv: $envvars_list" >&2
+    end
 
     if test (count $_DOTSECENV_SECRETS_LOADED) -gt 0
         # Track secrets per directory for unload reporting

--- a/plugin/tests/test_plugins.fish
+++ b/plugin/tests/test_plugins.fish
@@ -113,7 +113,7 @@ APP_NAME="My Application"' >"$test_dir/.env"
     set mock_path (create_mock_dotsecenv)
 
     # Run fish with the plugin loaded
-    set result (fish -c "
+    set result (fish --no-config -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -142,7 +142,7 @@ function test_parse_secret_same_name
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish -c "
+    set result (fish --no-config -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -171,7 +171,7 @@ function test_parse_secret_named
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish -c "
+    set result (fish --no-config -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -200,7 +200,7 @@ function test_missing_secret_warning
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish -c "
+    set result (fish --no-config -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -229,7 +229,7 @@ function test_security_check_world_writable
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish -c "
+    set result (fish --no-config -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -259,7 +259,7 @@ SECRET_VAR={dotsecenv/API_KEY}' >"$test_dir/.env"
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish -c "
+    set result (fish --no-config -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -276,13 +276,92 @@ SECRET_VAR={dotsecenv/API_KEY}' >"$test_dir/.env"
     end
 end
 
+function test_load_unload_message_split
+    log "[fish] Testing env var(s)/secret(s) messages split on load and unload..."
+    set TESTS_RUN (math $TESTS_RUN + 1)
+
+    set test_dir "$TEMP_DIR/test_msg_split/project"
+    mkdir -p "$test_dir"
+    mkdir -p "$TEMP_DIR/test_msg_split/other"
+
+    echo 'APP_ENV=production
+NODE_ENV=staging
+DB_URL={dotsecenv/DB_PASSWORD}
+SVC_KEY={dotsecenv/API_KEY}' >"$test_dir/.secenv"
+    chmod 644 "$test_dir/.secenv"
+
+    set config_dir "$TEMP_DIR/config_msg_split"
+    mkdir -p "$config_dir"
+    echo "$test_dir" >"$config_dir/trusted_dirs"
+
+    set mock_path (create_mock_dotsecenv)
+
+    set result (fish --no-config -c "
+        set -gx PATH '$mock_path' \$PATH
+        set -gx DOTSECENV_CONFIG_DIR '$config_dir'
+        set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
+        source '$SHELL_DIR/conf.d/dotsecenv.fish'
+        cd '$test_dir'
+        cd '$TEMP_DIR/test_msg_split/other'
+    " 2>&1)
+
+    set -l ok 1
+    string match -q "*loaded 2 env var(s) from .secenv: APP_ENV, NODE_ENV*" "$result"; or set ok 0
+    string match -q "*loaded 2 secret(s) from .secenv: DB_URL, SVC_KEY*" "$result"; or set ok 0
+    string match -q "*unloaded 2 env var(s): APP_ENV, NODE_ENV*" "$result"; or set ok 0
+    string match -q "*unloaded 2 secret(s): DB_URL, SVC_KEY*" "$result"; or set ok 0
+
+    if test $ok -eq 1
+        pass "[fish] Plain vars and secrets reported on separate lines"
+    else
+        fail "[fish] Message split incorrect, got: $result"
+    end
+end
+
+function test_empty_secenv_no_message
+    log "[fish] Testing an empty .secenv produces no load message..."
+    set TESTS_RUN (math $TESTS_RUN + 1)
+
+    set test_dir "$TEMP_DIR/test_empty_secenv"
+    mkdir -p "$test_dir"
+    printf '' >"$test_dir/.secenv"
+    chmod 644 "$test_dir/.secenv"
+
+    set config_dir "$TEMP_DIR/config_empty_secenv"
+    mkdir -p "$config_dir"
+    echo "$test_dir" >"$config_dir/trusted_dirs"
+
+    set mock_path (create_mock_dotsecenv)
+
+    set result (fish --no-config -c "
+        set -gx PATH '$mock_path' \$PATH
+        set -gx DOTSECENV_CONFIG_DIR '$config_dir'
+        set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
+        source '$SHELL_DIR/conf.d/dotsecenv.fish'
+        cd '$test_dir'
+        echo MARKER
+    " 2>&1)
+
+    set -l ok 1
+    string match -q "*MARKER*" "$result"; or set ok 0
+    string match -q "*loaded*" "$result"; and set ok 0
+    string match -q "*env var(s)*" "$result"; and set ok 0
+    string match -q "*secret(s)*" "$result"; and set ok 0
+
+    if test $ok -eq 1
+        pass "[fish] Empty .secenv produces no load message"
+    else
+        fail "[fish] Empty .secenv produced unexpected output, got: $result"
+    end
+end
+
 function test_alias_dse
     log "[fish] Testing 'dse' function..."
     set TESTS_RUN (math $TESTS_RUN + 1)
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish -c "
+    set result (fish --no-config -c "
         set -gx PATH '$mock_path' \$PATH
         source '$SHELL_DIR/conf.d/dotsecenv.fish'
         type dse
@@ -301,7 +380,7 @@ function test_alias_dse_get
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish -c "
+    set result (fish --no-config -c "
         set -gx PATH '$mock_path' \$PATH
         source '$SHELL_DIR/conf.d/dotsecenv.fish'
         dse get API_KEY
@@ -331,7 +410,7 @@ DATABASE_PORT=5432
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish -c "
+    set result (fish --no-config -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -362,7 +441,7 @@ UNQUOTED=helloworld' >"$test_dir/.env"
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish -c "
+    set result (fish --no-config -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -401,7 +480,7 @@ function test_tree_scope_persist_in_subdir
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish -c "
+    set result (fish --no-config -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -437,7 +516,7 @@ function test_tree_scope_unload_on_leave
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish -c "
+    set result (fish --no-config -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -477,7 +556,7 @@ function test_tree_scope_nested_secenv
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish -c "
+    set result (fish --no-config -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -513,7 +592,7 @@ function test_tree_scope_sibling_navigation
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish -c "
+    set result (fish --no-config -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -549,7 +628,7 @@ function test_tree_scope_no_reload_from_subdir
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish -c "
+    set result (fish --no-config -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -587,7 +666,7 @@ function test_multiline_warning
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish -c "
+    set result (fish --no-config -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -975,6 +1054,8 @@ function main
     test_missing_secret_warning
     test_security_check_world_writable
     test_two_phase_loading
+    test_load_unload_message_split
+    test_empty_secenv_no_message
     test_alias_dse
     test_alias_dse_get
     test_comments_and_empty_lines

--- a/plugin/tests/test_plugins.sh
+++ b/plugin/tests/test_plugins.sh
@@ -468,6 +468,104 @@ EOF
     fi
 }
 
+test_load_unload_message_split() {
+    local shell="$1"
+    log "[$shell] Testing env var(s)/secret(s) messages split on load and unload..."
+    ((TESTS_RUN++)) || true
+
+    local test_dir="$TEMP_DIR/test_msg_split/project"
+    mkdir -p "$test_dir"
+    mkdir -p "$TEMP_DIR/test_msg_split/other"
+
+    # 2 plain vars + 2 secret references
+    cat >"$test_dir/.secenv" <<'EOF'
+APP_ENV=production
+NODE_ENV=staging
+DB_URL={dotsecenv/DB_PASSWORD}
+SVC_KEY={dotsecenv/API_KEY}
+EOF
+    chmod 644 "$test_dir/.secenv"
+
+    local config_dir="$TEMP_DIR/config_msg_split"
+    mkdir -p "$config_dir"
+    echo "$test_dir" >"$config_dir/trusted_dirs"
+
+    local mock_path
+    mock_path=$(create_mock_dotsecenv)
+
+    local result
+    if [[ "$shell" == "bash" ]]; then
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" "$BASH_BIN" -c "
+            export PATH='$mock_path:$PATH'
+            source '$SHELL_DIR/_dotsecenv_core.sh'
+            source '$SHELL_DIR/dotsecenv.plugin.bash'
+            cd '$test_dir'
+            _dotsecenv_chpwd_hook
+            cd '$TEMP_DIR/test_msg_split/other'
+            _dotsecenv_chpwd_hook
+        " 2>&1)
+    else
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+            export PATH='$mock_path:$PATH'
+            source '$SHELL_DIR/dotsecenv.plugin.zsh'
+            cd '$test_dir'
+            cd '$TEMP_DIR/test_msg_split/other'
+        " 2>&1)
+    fi
+
+    if [[ "$result" == *"loaded 2 env var(s) from .secenv: APP_ENV, NODE_ENV"* &&
+        "$result" == *"loaded 2 secret(s) from .secenv: DB_URL, SVC_KEY"* &&
+        "$result" == *"unloaded 2 env var(s): APP_ENV, NODE_ENV"* &&
+        "$result" == *"unloaded 2 secret(s): DB_URL, SVC_KEY"* ]]; then
+        pass "[$shell] Plain vars and secrets reported on separate lines"
+    else
+        fail "[$shell] Message split incorrect, got: $result"
+    fi
+}
+
+test_empty_secenv_no_message() {
+    local shell="$1"
+    log "[$shell] Testing an empty .secenv produces no load message..."
+    ((TESTS_RUN++)) || true
+
+    local test_dir="$TEMP_DIR/test_empty_secenv"
+    mkdir -p "$test_dir"
+    : >"$test_dir/.secenv"
+    chmod 644 "$test_dir/.secenv"
+
+    local config_dir="$TEMP_DIR/config_empty_secenv"
+    mkdir -p "$config_dir"
+    echo "$test_dir" >"$config_dir/trusted_dirs"
+
+    local mock_path
+    mock_path=$(create_mock_dotsecenv)
+
+    local result
+    if [[ "$shell" == "bash" ]]; then
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" "$BASH_BIN" -c "
+            export PATH='$mock_path:$PATH'
+            source '$SHELL_DIR/_dotsecenv_core.sh'
+            source '$SHELL_DIR/dotsecenv.plugin.bash'
+            cd '$test_dir'
+            _dotsecenv_chpwd_hook
+            echo MARKER
+        " 2>&1)
+    else
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+            export PATH='$mock_path:$PATH'
+            source '$SHELL_DIR/dotsecenv.plugin.zsh'
+            cd '$test_dir'
+            echo MARKER
+        " 2>&1)
+    fi
+
+    if [[ "$result" == *"MARKER"* && "$result" != *"loaded"* && "$result" != *"env var(s)"* && "$result" != *"secret(s)"* ]]; then
+        pass "[$shell] Empty .secenv produces no load message"
+    else
+        fail "[$shell] Empty .secenv produced unexpected output, got: $result"
+    fi
+}
+
 test_alias_dse() {
     local shell="$1"
     log "[$shell] Testing 'dse' alias..."
@@ -1757,6 +1855,8 @@ main() {
         test_missing_secret_warning "bash"
         test_security_check_world_writable "bash"
         test_two_phase_loading "bash"
+        test_load_unload_message_split "bash"
+        test_empty_secenv_no_message "bash"
         test_alias_dse "bash"
         test_alias_dse_get "bash"
         test_comments_and_empty_lines "bash"
@@ -1796,6 +1896,8 @@ main() {
             test_missing_secret_warning "zsh"
             test_security_check_world_writable "zsh"
             test_two_phase_loading "zsh"
+            test_load_unload_message_split "zsh"
+            test_empty_secenv_no_message "zsh"
             test_alias_dse "zsh"
             test_alias_dse_get "zsh"
             test_comments_and_empty_lines "zsh"

--- a/website/src/content/docs/guides/shell-plugins.mdx
+++ b/website/src/content/docs/guides/shell-plugins.mdx
@@ -104,7 +104,7 @@ Now `cd` into the project:
 ~ $ cd myapp/
 dotsecenv: found .secenv in /home/user/myapp
 Load secrets? [y]es / [n]o / [a]lways: y
-dotsecenv: loaded 2 secret(s) from .secenv: APP_ENV, NODE_ENV
+dotsecenv: loaded 2 env var(s) from .secenv: APP_ENV, NODE_ENV
 ```
 
 Your answer decides what happens:
@@ -156,7 +156,8 @@ Reload the directory to pick up the new line:
 
 ```text
 ~/myapp $ cd .                # or: dse reload
-dotsecenv: loaded 3 secret(s) from .secenv: APP_ENV, NODE_ENV, DATABASE_URL
+dotsecenv: loaded 2 env var(s) from .secenv: APP_ENV, NODE_ENV
+dotsecenv: loaded 1 secret(s) from .secenv: DATABASE_URL
 
 ~/myapp $ echo $DATABASE_URL
 postgres://...
@@ -185,7 +186,8 @@ PROD_DB_PASSWORD={dotsecenv/prod::DATABASE_URL}
 
 ```text
 ~/myapp $ dse reload
-dotsecenv: loaded 4 secret(s) from .secenv: APP_ENV, NODE_ENV, DATABASE_URL, PROD_DB_PASSWORD
+dotsecenv: loaded 2 env var(s) from .secenv: APP_ENV, NODE_ENV
+dotsecenv: loaded 2 secret(s) from .secenv: DATABASE_URL, PROD_DB_PASSWORD
 ```
 
 ## Tree-scoped loading
@@ -205,14 +207,16 @@ Navigate down into the project and the secrets follow you. Step out of the tree 
 
 ```text
 ~ $ cd myapp/
-dotsecenv: loaded 4 secret(s) from .secenv: APP_ENV, NODE_ENV, DATABASE_URL, PROD_DB_PASSWORD
+dotsecenv: loaded 2 env var(s) from .secenv: APP_ENV, NODE_ENV
+dotsecenv: loaded 2 secret(s) from .secenv: DATABASE_URL, PROD_DB_PASSWORD
 
 ~/myapp $ cd src/components/
 ~/myapp/src/components $ echo $DATABASE_URL
 postgres://...                 # still loaded; same tree
 
 ~/myapp/src/components $ cd ~/other-project/
-dotsecenv: unloaded 4 secret(s): APP_ENV, NODE_ENV, DATABASE_URL, PROD_DB_PASSWORD
+dotsecenv: unloaded 2 env var(s): APP_ENV, NODE_ENV
+dotsecenv: unloaded 2 secret(s): DATABASE_URL, PROD_DB_PASSWORD
 ```
 
 Auto-loading happens when you `cd` through the directory that holds the `.secenv`. If your shell starts straight inside a subdirectory, for example a tmux pane or an editor terminal, the parent file was never crossed, so nothing loaded. Run `dse up` to walk up the tree and load ancestor files:
@@ -223,7 +227,8 @@ Auto-loading happens when you `cd` through the directory that holds the `.secenv
                                # empty
 
 ~/myapp/src/components $ dse up
-dotsecenv: loaded 4 secret(s) from .secenv: APP_ENV, NODE_ENV, DATABASE_URL, PROD_DB_PASSWORD
+dotsecenv: loaded 2 env var(s) from .secenv: APP_ENV, NODE_ENV
+dotsecenv: loaded 2 secret(s) from .secenv: DATABASE_URL, PROD_DB_PASSWORD
 
 ~/myapp/src/components $ echo $DATABASE_URL
 postgres://...
@@ -295,6 +300,7 @@ dotsecenv init secenv --all    # add every vault reference
   DATABASE_URL={dotsecenv}
   PROD_DB_PASSWORD={dotsecenv/prod::DATABASE_URL}
   ```
+
 </Aside>
 
 ## The dse command
@@ -341,7 +347,8 @@ Clipboard backends: `pbcopy` on macOS, `wl-copy` on Wayland, `xclip` or `xsel` o
 
 ```text
 ~/myapp $ dse reload
-dotsecenv: loaded 4 secret(s) from .secenv: APP_ENV, NODE_ENV, DATABASE_URL, PROD_DB_PASSWORD
+dotsecenv: loaded 2 env var(s) from .secenv: APP_ENV, NODE_ENV
+dotsecenv: loaded 2 secret(s) from .secenv: DATABASE_URL, PROD_DB_PASSWORD
 ```
 
 <Aside type="note" title="dse reload semantics (v0.5.1+)">


### PR DESCRIPTION
## Problem

The shell plugin reported **every** loaded `.secenv` key as `secret(s)`, including plain values. For a file like:

```bash title="~/myapp/.secenv"
APP_ENV=production
NODE_ENV=production
DATABASE_URL={dotsecenv}
PROD_DB_PASSWORD={dotsecenv/prod::DATABASE_URL}
```

`APP_ENV` and `NODE_ENV` are plain env vars, not secrets — but they were counted and labeled as secrets.

## Change

Split load and unload output so plain values and vault-backed references are reported on separate lines:

```
dotsecenv: loaded 2 env var(s) from .secenv: APP_ENV, NODE_ENV
dotsecenv: loaded 2 secret(s) from .secenv: DATABASE_URL, PROD_DB_PASSWORD
```

- A category prints **only when non-empty** — an empty `.secenv` produces no output at all.
- Unload mirrors the split (`unloaded N env var(s):` / `unloaded N secret(s):`).
- Applies to **bash, zsh, and fish**.

### Secondary fix: list separator

The bash/zsh join used `"${arr[*]}"` with `IFS=', '`, which applies only the **first** IFS char — so the list printed `A,B` while fish (`string join ', '`) and every doc show `A, B`. A portable `_dotsecenv_join_comma` helper now produces `, ` consistently across all three shells.

## Tests

Added to both the bash/zsh (`test_plugins.sh`) and fish (`test_plugins.fish`) suites:
- mixed file → both lines, correct counts and `, ` separator, on load and unload
- empty `.secenv` → no output

The fish suite's inner shells now run with `fish --no-config` so they exercise the **repo** plugin instead of a copy installed in the developer's `~/.config/fish/conf.d/`.

## Verification

- bash + zsh: **63/63 pass** (incl. new cases); `make fmt-check` and `make lint` clean.
- fish: verified in isolation (`fish --no-config`) — both lines on load and unload, silent on empty file.
- website: `pnpm lint:md` clean (also fixes a pre-existing MD031 from the #190 rewrite); `pnpm build` completes.

## Docs

Updated the example outputs in `guides/shell-plugins.mdx` to the two-line form. Other guides (`getting-started`, `reload-secrets`, `migrate-from-dotenv`, `team-onboarding`) use all-secret `.secenv` files and were already correct.

## Follow-up (separate PR)

Pre-existing fish test-infra issues found while testing, to be addressed separately: `make test-fish` doesn't actually run `test_plugins.fish` (unknown `--fish-only` flag falls through to bash+zsh), CI installs fish 3.x while ~9 tests fail under fish 4.x, and CI fish-version selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)