### PR TITLE
docs: document the squash-merge commit-message convention

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,9 @@
 ## Description
 
+<!-- This description becomes the squash commit message on merge. Write it with
+Markdown headings and clear prose. GitHub adds the Co-authored-by footer itself,
+so leave attribution out of the description. -->
+
 <!-- Describe your changes in detail -->
 
 ## Related Issue

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,12 +217,19 @@ What the script does NOT do — handle manually if needed:
     so it can't pass CI alone. Keep one PR, but put the vendored tree in one
     commit and the source migration in another (#187), so the code commit
     reviews on its own.
-- **Commit messages:** Conventional Commits with PR-number suffix, e.g.
-  `feat: behavior.* and gpg.program policy fields (last-set-wins) (#116)`.
-  Allowed types: `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`,
-  `style`. Breaking changes use `!`, e.g. `refactor!: drop SUID mode (#110)`.
-  `Co-Authored-By` footers are welcome (e.g. for AI agents that helped
-  produce the change).
+- **Commit messages:** Conventional Commits, e.g. `feat: behavior.* and
+  gpg.program policy fields (last-set-wins)`. Allowed types: `feat`, `fix`,
+  `docs`, `chore`, `refactor`, `test`, `ci`, `style`. Breaking changes use
+  `!`, e.g. `refactor!: drop SUID mode`. Keep a `Co-Authored-By` trailer on a
+  commit when an AI agent helped. GitHub collects those trailers and writes a
+  single deduplicated `Co-authored-by:` footer onto the squash commit.
+- **The PR title and description become the squash commit.** `main` takes
+  squash merges. GitHub uses the PR title as the subject (it appends `(#NNN)`)
+  and the PR description as the body. Title the PR as a Conventional Commit.
+  Write the description the way you want the commit body to read: Markdown
+  headings and prose, not a bulleted list of commits. Leave attribution out of
+  the description; GitHub adds the `Co-authored-by:` footer from the commit
+  trailers.
 - **Branches:** `feat/*`, `fix/*`, `docs/*`, etc. (see `CONTRIBUTING.md`).
 - **PRs only:** All changes land on `main` through pull requests. Don't
   push commits directly to `main`, even when your account holds a bypass

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,15 @@ fix(gpg): handle missing pinentry gracefully
 docs(readme): clarify installation steps
 ```
 
+### Squash Merges
+
+`main` uses squash merges. GitHub builds the commit from the pull request:
+the PR title becomes the subject (with `(#NNN)` appended) and the PR
+description becomes the body. Write the description the way you want it to
+read in `git log`: use Markdown headings and prose, not a list of commits.
+You do not need to add a `Co-authored-by:` line; GitHub collects the trailers
+from your commits and appends one deduplicated footer.
+
 ### Branch Naming
 
 Use descriptive branch names:


### PR DESCRIPTION
## Why

Squash-merge commits on `main` were inconsistent: `*`-prefixed commit titles, no structure, and a `Co-authored-by:` line repeated once per squashed commit (e.g. #190, #187). The cause was the repo's `squash_merge_commit_message` setting, which was `COMMIT_MESSAGES` (concatenate every branch commit's full message).

## Repo setting (already applied)

The squash merge default is now the **"Pull request title and description"** preset:

- `squash_merge_commit_title: PR_TITLE`
- `squash_merge_commit_message: PR_BODY`

GitHub uses the PR title as the subject (and appends `(#NNN)`) and the PR description as the body. Separately, it collects the `Co-Authored-By:` trailers from the squashed commits, deduplicates them, and appends a single `Co-authored-by:` footer after a `---------` separator. That gives clean, structured merge commits with attribution exactly once.

Squash remains the only enabled merge method.

## Docs

This PR records the convention so it is followed going forward:

- `AGENTS.md`: the PR title and description become the squash commit; write the description as the commit body (Markdown headings, no commit list); keep `Co-Authored-By` trailers on commits and leave attribution out of the PR body.
- `CONTRIBUTING.md`: a "Squash Merges" section with the same guidance for human contributors.
- `.github/pull_request_template.md`: a note that the description becomes the commit message.

## Verification

This PR is the first to merge under the new setting, so its own squash commit should demonstrate the format: subject `docs: ... (#NNN)`, this body rendered with headings, then a single `---------` / `Co-authored-by:` footer. Confirm after merge with `git show -s --format=%B <sha>`.