### PR TITLE
docs: end PR descriptions with --- to set off the squash footer

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,3 +40,8 @@ so leave attribution out of the description. -->
 ## Screenshots
 
 <!-- If applicable, add screenshots to help explain your changes -->
+
+<!-- Keep the line below as the last line: it separates the Co-authored-by
+footer that GitHub appends to the squash commit. -->
+
+---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -229,7 +229,8 @@ What the script does NOT do — handle manually if needed:
   Write the description the way you want the commit body to read: Markdown
   headings and prose, not a bulleted list of commits. Leave attribution out of
   the description; GitHub adds the `Co-authored-by:` footer from the commit
-  trailers.
+  trailers. End the description with a `---` line so that footer is set off by
+  a separator.
 - **Branches:** `feat/*`, `fix/*`, `docs/*`, etc. (see `CONTRIBUTING.md`).
 - **PRs only:** All changes land on `main` through pull requests. Don't
   push commits directly to `main`, even when your account holds a bypass

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,8 @@ the PR title becomes the subject (with `(#NNN)` appended) and the PR
 description becomes the body. Write the description the way you want it to
 read in `git log`: use Markdown headings and prose, not a list of commits.
 You do not need to add a `Co-authored-by:` line; GitHub collects the trailers
-from your commits and appends one deduplicated footer.
+from your commits and appends one deduplicated footer. End the description with
+a `---` line so that footer sits below a separator.
 
 ### Branch Naming
 


### PR DESCRIPTION
## Why

Under the new squash setting (`PR_BODY`), GitHub appends its deduplicated `Co-authored-by:` footer after the PR description. On a single-commit PR that lands as a bare blank line before the trailer (see #194), with no visible separator.

## Change

Document a one-line convention: end every PR description with a `---` horizontal rule. GitHub then appends the footer below it, so every squash commit ends with a clear separator and a single trailer.

- `AGENTS.md` and `CONTRIBUTING.md`: add the "end with `---`" instruction.
- `.github/pull_request_template.md`: ends with a `---` line so web-UI PRs get it by default.

## Verification

This PR's own description ends with `---`. After merge, check that the squash commit body shows `---` immediately before the `Co-authored-by:` line:

```
git show -s --format=%B <merge-sha>
```

---