### PR TITLE
feat: add CLI reference drift-check skill, gated before release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,7 +242,9 @@ What the script does NOT do — handle manually if needed:
   through existing tests are the only exception.
 - **Linters:** `golangci-lint` v2.11.4 — pinned because v2.12.x had a
   checksum mismatch on release. Don't bump back to `latest` without verifying.
-- **Releases:** Triggered by pushing a signed semver tag. Use
+- **Releases:** Triggered by pushing a signed semver tag. Before tagging, run
+  the CLI reference drift check (`bash skills/cli-reference-drift/check.sh`; see
+  `skills/cli-reference-drift/SKILL.md`) and resolve any drift. Use
   [`releasetools-cli`](https://github.com/releasetools/cli):
 
   ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,7 @@
 
 ## Release new version
 
+- **Pre-release gate:** run the CLI reference drift check and resolve any drift before tagging — `bash skills/cli-reference-drift/check.sh` (see [skills/cli-reference-drift/SKILL.md](skills/cli-reference-drift/SKILL.md)). The website CLI reference (`website/src/content/docs/reference.mdx`) is hand-curated and must stay in sync with the binary.
 - When asked to release, use `rt git::release --major --sign --push vX.Y.Z` where X.Y.Z is the version to release
 - Then push the tag to the origin
 

--- a/skills/cli-reference-drift/SKILL.md
+++ b/skills/cli-reference-drift/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: cli-reference-drift
+description: >
+  Check the website CLI reference (website/src/content/docs/reference.mdx) for
+  drift against the actual dotsecenv CLI, and run it before cutting a release.
+  Use when preparing a release, when asked to verify the CLI docs are in sync or
+  check reference drift, or after adding or changing a command or flag.
+  Triggers on: release, cli reference drift, reference out of date,
+  docs in sync, before release, new command, new flag.
+---
+
+# CLI Reference Drift Check
+
+The website CLI reference at `website/src/content/docs/reference.mdx` is
+hand-curated (it carries examples, JSON output schemas, sample outputs, exit
+codes, and a config-file reference that cobra cannot generate). Because it is
+hand-written, it can drift from the actual CLI. Run this check before every
+release to catch commands or flags that exist in the binary but are missing
+from the page.
+
+## Run it
+
+```bash
+bash skills/cli-reference-drift/check.sh
+```
+
+The script runs the repo's `make docs` target to generate the live command and
+flag inventory from source (into `build/cli`), then compares it against
+`reference.mdx`. It exits non-zero when it finds drift. No network is needed
+(dependencies are vendored); a Go toolchain and `make` on `PATH` are required.
+
+## What it reports
+
+- **MISSING command** — a CLI command with no matching `##`/`###` heading in
+  `reference.mdx`.
+- **MISSING flag** — a command-specific (long) flag not mentioned anywhere in
+  `reference.mdx`.
+- **DUPLICATE heading** — the same `##`/`###` heading text appears more than
+  once (a copy-paste or stale-section bug).
+
+## Act on the report
+
+For each genuine finding, edit `reference.mdx`:
+
+- Missing command or flag: add it in the page's existing style — a heading, a
+  one-line description, an **Options** table, and at least one **Examples**
+  block. Place it under the right parent section (e.g. a new `secret`
+  subcommand goes under `## secret`).
+- Duplicate or stale heading: remove the redundant section.
+
+Re-run the check until it reports `no drift`.
+
+Known false positives to ignore:
+
+- `completion bash` / `zsh` / `fish` are documented under `## completion` as
+  `### Bash` / `### Zsh` / `### Fish`, not as `### completion <shell>`.
+
+## Release gate
+
+This is a pre-release step. Before running `rt git::release` (see
+[CLAUDE.md](../../CLAUDE.md) "Release new version"), run this check and resolve
+any drift. Do not release with an out-of-sync CLI reference. The page is the
+canonical CLI reference at <https://dotsecenv.com/reference/>; keeping it honest
+is the point of this check.

--- a/skills/cli-reference-drift/check.sh
+++ b/skills/cli-reference-drift/check.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# CLI reference drift check.
+#
+# The website CLI reference (website/src/content/docs/reference.mdx) is
+# hand-curated and NOT generated, so it can drift from the real CLI. This
+# script generates the command + flag inventory from source and verifies every
+# command and command-specific flag is documented in reference.mdx. Run it
+# before every release.
+#
+# Exit codes: 0 = no drift, 1 = drift detected, 2 = setup error.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../.. && pwd)"
+REF="$ROOT/website/src/content/docs/reference.mdx"
+
+command -v go >/dev/null 2>&1 || { echo "error: go toolchain not found on PATH" >&2; exit 2; }
+command -v make >/dev/null 2>&1 || { echo "error: make not found on PATH" >&2; exit 2; }
+[ -f "$REF" ] || { echo "error: reference page not found: $REF" >&2; exit 2; }
+
+# Generate the CLI inventory via the canonical Makefile target so the
+# generation command stays a single source of truth. `make docs` writes the
+# per-command markdown to build/cli; remove any stale output first so a deleted
+# command does not leave a lingering file.
+CLI="$ROOT/build/cli"
+echo "==> generating CLI inventory from source (make docs)"
+rm -rf "$CLI"
+( cd "$ROOT" && make docs >/dev/null )
+
+drift=0
+
+echo
+echo "==> commands missing a heading in reference.mdx"
+for f in "$CLI"/*.md; do
+  base="$(basename "$f" .md)"            # e.g. dotsecenv_secret_get
+  cmd="${base//_/ }"                     # e.g. dotsecenv secret get
+  doc="${cmd#dotsecenv}"; doc="${doc# }" # e.g. secret get   (root -> "")
+  needle="${doc:-dotsecenv}"             # root command -> the "## dotsecenv" heading
+  if ! grep -qE "^#{1,6} ${needle}\$" "$REF"; then
+    echo "  MISSING command: '${cmd}' (expected a heading '${needle}')"
+    drift=1
+  fi
+done
+
+echo
+echo "==> command-specific flags missing from reference.mdx"
+for f in "$CLI"/*.md; do
+  base="$(basename "$f" .md)"
+  cmd="${base//_/ }"
+  # Long flags from the command's OWN "### Options" block (not inherited ones).
+  flags="$(awk '
+    /^### Options$/ { inopt = 1; next }
+    /^### /         { inopt = 0 }
+    inopt           { print }
+  ' "$f" | grep -oE -- '--[a-zA-Z][a-zA-Z0-9-]*' | sort -u | grep -vx -- '--help' || true)"
+  for fl in $flags; do
+    if ! grep -qF -- "$fl" "$REF"; then
+      echo "  MISSING flag: '${fl}' (command '${cmd}')"
+      drift=1
+    fi
+  done
+done
+
+echo
+echo "==> duplicate headings in reference.mdx"
+dupes="$(grep -E '^#{2,3} ' "$REF" | sed -E 's/^#{2,3} //' | sort | uniq -d || true)"
+if [ -n "$dupes" ]; then
+  while IFS= read -r d; do echo "  DUPLICATE heading: '${d}'"; done <<<"$dupes"
+  drift=1
+fi
+
+echo
+if [ "$drift" -ne 0 ]; then
+  cat >&2 <<'EOF'
+RESULT: drift detected.
+
+Update website/src/content/docs/reference.mdx to add the missing command(s) or
+flag(s) (match the page's style: description, options table, examples) and
+remove any duplicate/stale section, then re-run this check until it passes.
+
+Known false positives: `completion bash|zsh|fish` are documented under
+`## completion` as `### Bash|Zsh|Fish`, not as `### completion <shell>`.
+EOF
+  exit 1
+fi
+echo "RESULT: no drift — every command and flag is documented, no duplicate headings."

--- a/website/src/content/docs/reference.mdx
+++ b/website/src/content/docs/reference.mdx
@@ -600,6 +600,12 @@ This adds a deletion marker to the secret. The secret will no longer be returned
 The deletion is a soft delete. The secret's history is preserved in the vault file. Use `vault doctor` (which offers defragmentation) to permanently remove deleted secrets.
 </Aside>
 
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--ignore-not-found` | Exit successfully if the secret is not found or already deleted (handy for idempotent scripts and CI) |
+
 **Examples:**
 
 ```bash
@@ -611,6 +617,9 @@ dotsecenv secret forget -v 2 prod::API_KEY
 
 # Delete using vault path
 dotsecenv secret forget -v ./project/vault SECRET_NAME
+
+# Idempotent delete: succeed even if the secret is absent or already deleted
+dotsecenv secret forget --ignore-not-found DATABASE_PASSWORD
 ```
 
 **Behavior after deletion:**
@@ -755,29 +764,6 @@ Health checks:
 Status: warning
 
 Upgrade vault .dotsecenv/vault from v1 to v2? [y/N]:
-```
-
-### vault upgrade
-
-Upgrade vault file format to the latest version.
-
-```bash
-dotsecenv vault upgrade [flags]
-```
-
-When `behavior.require_explicit_vault_upgrade` is set to `true` in your config, automatic vault upgrades are disabled. Use this command to explicitly upgrade vault formats.
-
-**Examples:**
-
-```bash
-# Upgrade vault (prompts if multiple vaults configured)
-dotsecenv vault upgrade
-
-# Upgrade specific vault
-dotsecenv vault upgrade -v 1
-
-# Upgrade vault at path
-dotsecenv vault upgrade -v ./project/vault
 ```
 
 ### vault upgrade


### PR DESCRIPTION
## Summary

The website CLI reference (`website/src/content/docs/reference.mdx`) is hand-curated — it carries per-command examples, JSON output schemas, sample outputs, exit codes, environment variables, and a full config-file reference that cobra cannot generate. It is deliberately **not** auto-generated, which keeps its quality but means it can drift from the actual CLI.

This adds a **drift-check skill** that keeps it honest without sacrificing the curation, and gates it before releases.

## What's included

- **New skill `skills/cli-reference-drift/`** (`SKILL.md` + `check.sh`). The script generates the live command + flag inventory from source (`go run -tags gendocs ./cmd/dotsecenv markdown`) and verifies that:
  - every CLI command has a heading in `reference.mdx` (**MISSING command**),
  - every command-specific long flag is documented (**MISSING flag**),
  - no `##`/`###` heading is duplicated (**DUPLICATE heading**).

  It exits non-zero on drift. No network needed (deps are vendored); requires a Go toolchain.
- **Release gate**: `CLAUDE.md` ("Release new version") and `AGENTS.md` ("Releases") now instruct running the check and resolving drift before tagging.
- **Two real drifts the check found, now fixed** in `reference.mdx`:
  - `secret forget --ignore-not-found` was undocumented (added an Options row + example).
  - the `vault upgrade` section was duplicated (removed the copy).

## Why a check instead of generating the page

A straight cobra-generated reference would drop the examples, JSON schemas, sample outputs, version-availability notes, and the Env Vars / Exit Codes / Config-file sections that make the current page useful. The check preserves all of that while preventing the page from silently falling out of sync with the binary.

## Validation

- `bash skills/cli-reference-drift/check.sh` → reports the two drifts on the original page, then `RESULT: no drift` after the fixes.
- `shellcheck skills/cli-reference-drift/check.sh` → clean.
- `make lint` in `website/` (markdownlint + eslint) → clean.

---
