### PR TITLE
feat: add changelog skill that builds release notes continuously

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,12 @@ What the script does NOT do — handle manually if needed:
   the description; GitHub adds the `Co-authored-by:` footer from the commit
   trailers. End the description with a `---` line so that footer is set off by
   a separator.
+- **Changelog:** every PR adds one line to the `## Upcoming` section of
+  `website/src/content/docs/changelog.mdx` (use the `changelog` skill,
+  `skills/changelog/SKILL.md`), in the subsection for its type (`feat` ->
+  Features, `fix` -> Bug Fixes, else Other), ending with the PR number. Release
+  notes build up per PR; the release PR stamps "Upcoming" to the tag.
+  `bash skills/changelog/assess.sh` reports any merged PRs missing from it.
 - **Branches:** `feat/*`, `fix/*`, `docs/*`, etc. (see `CONTRIBUTING.md`).
 - **PRs only:** All changes land on `main` through pull requests. Don't
   push commits directly to `main`, even when your account holds a bypass

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,7 @@
 ## Release new version
 
 - **Pre-release gate:** run the CLI reference drift check and resolve any drift before tagging — `bash skills/cli-reference-drift/check.sh` (see [skills/cli-reference-drift/SKILL.md](skills/cli-reference-drift/SKILL.md)). The website CLI reference (`website/src/content/docs/reference.mdx`) is hand-curated and must stay in sync with the binary.
+- **Changelog:** in the release PR, run `bash skills/changelog/assess.sh` to confirm every merged PR since the last tag is recorded, then stamp the `## Upcoming` section of `website/src/content/docs/changelog.mdx` to `vX.Y.Z` + date (see [skills/changelog/SKILL.md](skills/changelog/SKILL.md)).
 - When asked to release, use `rt git::release --major --sign --push vX.Y.Z` where X.Y.Z is the version to release
 - Then push the tag to the origin
 

--- a/skills/changelog/SKILL.md
+++ b/skills/changelog/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: changelog
+description: >
+  Keep the website changelog (website/src/content/docs/changelog.mdx) building
+  up continuously, one entry per PR. Use when opening a PR (add a one-line
+  entry under "Upcoming"), when preparing a release (stamp "Upcoming" to
+  the version tag), or to assess which merged PRs are missing from the
+  changelog. Triggers on: changelog, release notes, upcoming,
+  changelog entry, add changelog, before release, release PR.
+---
+
+# Changelog / Release Notes
+
+Release notes are built up continuously. Every PR adds one line under a standing
+**`## Upcoming`** section in `website/src/content/docs/changelog.mdx`, and
+the release PR stamps that section to the version tag. This keeps the changelog
+from falling behind the actual releases.
+
+Categories follow the Conventional Commit type: `feat` -> **Features**,
+`fix` -> **Bug Fixes**, everything else (`docs`, `chore`, `refactor`, `test`,
+`ci`, dependency bumps) -> **Other**. Entries end with the PR number.
+
+```mdx
+## Upcoming
+
+_Unreleased_
+
+### Features
+- Short, user-facing description (#PR)
+
+### Bug Fixes
+- ... (#PR)
+
+### Other
+- ... (#PR)
+```
+
+## Add an entry (do this on every PR)
+
+When you open a PR, add ONE line under `## Upcoming`, in the matching
+subsection, as part of the PR's own diff:
+
+- Write it for someone reading release notes, not as a commit message.
+- Put it in the subsection for the PR's type (`feat`/`fix`/other). Create the
+  subsection if it does not exist yet, keeping the order
+  Features -> Bug Fixes -> Other.
+- End with the PR number once the PR exists: `- <description> (#<PR>)`.
+
+This per-PR edit is the whole point: the release notes accumulate as work lands.
+
+## Assess (release PR, or any spot check)
+
+List merged PRs since the last release tag that are not yet under "Next
+release":
+
+```bash
+bash skills/changelog/assess.sh
+```
+
+It exits non-zero when commits since the last tag are missing. Add the missing
+entries before releasing. (Maps commits to PRs via the `(#NN)` suffix that
+GitHub adds to squash-merge subjects.)
+
+## Stamp the release (release PR)
+
+In the PR that cuts `vX.Y.Z`:
+
+1. Run `bash skills/changelog/assess.sh` and add any missing entries.
+2. Rename the header `## Upcoming` -> `## vX.Y.Z`, and replace
+   `_Unreleased_` with `_<Month Day, Year>_` (today's date).
+3. Remove any subsection that ended up with no entries.
+4. Add a fresh, empty `## Upcoming` section (with `_Unreleased_`) at the top
+   of the version list, ready for the next cycle.
+
+Then proceed with the tag per [CLAUDE.md](../../CLAUDE.md) "Release new version".
+The optional Twitter/X announcement guidance lives in
+[website/CLAUDE.md](../../website/CLAUDE.md) "Changelog Generation".
+
+## Prerequisites
+
+Git with tags available (`git fetch --tags`). No build step is required.

--- a/skills/changelog/assess.sh
+++ b/skills/changelog/assess.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Assess changelog completeness.
+#
+# Lists PRs merged since the last release tag that are NOT yet recorded under
+# the "## Upcoming" section of the website changelog. Run it in the release
+# PR (and any time you want to verify the changelog is keeping up). Release
+# notes are meant to build up one entry per PR, so this should normally be
+# empty.
+#
+# Exit codes: 0 = changelog covers everything since the last tag,
+#             1 = some commits are missing, 2 = setup error.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../.. && pwd)"
+CL="$ROOT/website/src/content/docs/changelog.mdx"
+
+command -v git >/dev/null 2>&1 || { echo "error: git not found on PATH" >&2; exit 2; }
+[ -f "$CL" ] || { echo "error: changelog not found: $CL" >&2; exit 2; }
+
+git -C "$ROOT" fetch --tags --quiet origin 2>/dev/null || true
+LAST="$(git -C "$ROOT" describe --tags --abbrev=0 2>/dev/null || true)"
+[ -n "$LAST" ] || { echo "error: no release tags found (git describe --tags)" >&2; exit 2; }
+echo "==> last release tag: $LAST"
+
+# PR numbers already recorded under "## Upcoming" (until the next "## ").
+recorded="$(awk '/^## Upcoming$/ {f=1; next} /^## / {f=0} f' "$CL" \
+  | grep -oE '#[0-9]+' | tr -d '#' | sort -u || true)"
+
+echo
+echo "==> commits since ${LAST} not yet under '## Upcoming':"
+missing=0
+while IFS= read -r subject; do
+  [ -n "$subject" ] || continue
+  pr="$(printf '%s' "$subject" | grep -oE '\(#[0-9]+\)$' | grep -oE '[0-9]+' || true)"
+  if [ -n "$pr" ] && printf '%s\n' "$recorded" | grep -qx "$pr"; then
+    continue
+  fi
+  printf '  %-10s %s\n' "${pr:+#$pr}" "$subject"
+  missing=$((missing + 1))
+done < <(git -C "$ROOT" log "${LAST}..HEAD" --pretty='%s')
+
+echo
+if [ "$missing" -ne 0 ]; then
+  echo "RESULT: ${missing} commit(s) since ${LAST} are not in 'Upcoming'." >&2
+  echo "Add an entry for each (see skills/changelog/SKILL.md) before releasing." >&2
+  exit 1
+fi
+echo "RESULT: 'Upcoming' covers every commit since ${LAST}."

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -12,62 +12,36 @@ When documenting CI/CD, use the canonical secret names and always state whether 
 
 ## Changelog Generation
 
-When asked to update the changelog for a new release:
+The changelog (`src/content/docs/changelog.mdx`) builds up continuously: every PR adds a one-line entry under the standing `## Upcoming` section, and the release PR stamps that section to the version tag. The `changelog` skill (`../skills/changelog/SKILL.md`) drives this; this section is the reference for format and the release stamp.
 
-1. **Get version tags** from the dotsecenv repo:
-   ```bash
-   cd ../dotsecenv
-   git fetch --tags
-   LATEST=$(git describe --tags --abbrev=0)
-   PREV=$(git tag -l "v*" --sort=-version:refname | sed -n '2p')
-   ```
+**Per PR:** add one line under `## Upcoming`, in the subsection for the PR's type (see the table below), ending with the PR number.
 
-2. **Get commit logs** between tags from both repos:
-   ```bash
-   # dotsecenv commits
-   cd ../dotsecenv
-   git log $PREV..$LATEST --oneline
+**At release (in the release PR):**
 
-   # plugin commits (skip if tags don't exist in plugin for older releases)
-   cd ../plugin
-   git fetch --tags
-   if git rev-parse "$PREV" >/dev/null 2>&1 && git rev-parse "$LATEST" >/dev/null 2>&1; then
-     git log $PREV..$LATEST --oneline
-   fi
-   ```
+1. From the repo root, run `bash skills/changelog/assess.sh` to list any merged PRs since the last tag that are missing from "Upcoming", and add an entry for each. This is the "assess all commits since the last release" step.
+2. Rename `## Upcoming` to `## vX.Y.Z` and replace `_Unreleased_` with `_Month Day, Year_` (today's date). Drop any subsection left empty.
+3. Open a fresh, empty `## Upcoming` section at the top for the next cycle.
 
-3. **Get release date**:
-   ```bash
-   cd ../dotsecenv
-   git log -1 --format='%B %d, %Y' $LATEST
-   ```
-
-4. **Group commits** by type:
-   - `feat:` → **Features**
-   - `fix:` → **Bug Fixes**
-   - Everything else → **Other**
-   - Commits from **dotsecenv** use `#N` for issue/PR references
-   - Commits from **plugin** use `plugin#N` for issue/PR references
-
-5. **Update changelog**: Add new version section at the top of `src/content/docs/changelog.mdx` (after the intro paragraph, before the first version entry)
+Plugin changes live in the separate `plugin` repo; reference them as `plugin#N` when they belong in a dotsecenv release note.
 
 ### Changelog Entry Format
 
 ```mdx
----
+## Upcoming
 
-## vX.Y.Z
-*Month Day, Year*
+_Unreleased_
 
 ### Features
-- Feature description here
+- Feature description here (#PR)
 
 ### Bug Fixes
-- Fix description here
+- Fix description here (#PR)
 
 ### Other
-- Other changes here
+- Other changes here (#PR)
 ```
+
+At release, `## Upcoming` / `_Unreleased_` becomes `## vX.Y.Z` / `_Month Day, Year_`, and a fresh empty `## Upcoming` is opened above it.
 
 ### Commit Message Convention
 

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -7,6 +7,16 @@ All notable changes to dotsecenv are documented here. Each version includes chan
 
 ---
 
+## Upcoming
+
+_Unreleased_
+
+### Other
+
+- Release notes now build up continuously under "Upcoming": a new `changelog` skill adds a one-line entry per PR and stamps the section at release time (#212)
+
+---
+
 ## v0.6.1
 
 _May 7, 2026_


### PR DESCRIPTION
## Summary

Make release notes build up **continuously** instead of being generated in one pass at release time (which had let the changelog drift to v0.6.1 while tags reached v0.6.16). Every PR adds a one-line entry under a standing `## Upcoming` section; the release PR stamps that section to the version tag.

## What's included

- **New `changelog` skill** (`skills/changelog/`):
  - `assess.sh` — lists merged PRs since the last release tag that are not yet recorded under "Upcoming" (maps commits to PRs via the `(#NN)` squash suffix). Exits non-zero when entries are missing. This is the "assess all commits since the last release" capability.
  - `SKILL.md` — documents the three operations: **add** a one-liner per PR, **assess** before a release, **stamp** "Upcoming" to `vX.Y.Z` + date in the release PR.
- **Standing `## Upcoming` section** added to `website/src/content/docs/changelog.mdx` (seeded with this PR's own entry — dogfooding the per-PR rule).
- **Agent instructions**:
  - `AGENTS.md` — every PR adds a changelog entry under "Upcoming" (categorised by Conventional Commit type), via the skill.
  - `CLAUDE.md` ("Release new version") — the release PR runs `assess.sh` and stamps the section.
  - `website/CLAUDE.md` ("Changelog Generation") — reworked from "generate the whole section at release" to the continuous build-up + assess + stamp workflow (format, commit-type table, and Twitter/X guidance retained).

## Why a check + continuous entries (not auto-generation)

Auto-generating the whole changelog at release is what let it fall behind. Building it up per-PR keeps it current with no release-time scramble, and `assess.sh` is the backstop that catches anything missed.

## Validation

- `shellcheck skills/changelog/assess.sh` → clean.
- `bash skills/changelog/assess.sh` → correctly lists the current backlog and exits non-zero.
- `make lint` + `pnpm build` in `website/` → clean (53 pages; changelog renders the new section).

## Heads-up: existing changelog backlog

`assess.sh` surfaces a real, pre-existing gap: the changelog stops at **v0.6.1**, but the latest tag is **v0.6.16** with **35 commits** since. This PR sets up the going-forward mechanism but does **not** backfill that history (that's a separate content task). The new tooling makes the catch-up straightforward — happy to do it in a follow-up if you want.

---
