### PR TITLE
fix: keep maintainer-only skills out of the published plugin

### DIFF
--- a/.claude/skills/changelog/SKILL.md
+++ b/.claude/skills/changelog/SKILL.md
@@ -54,7 +54,7 @@ List merged PRs since the last release tag that are not yet under "Next
 release":
 
 ```bash
-bash skills/changelog/assess.sh
+bash .claude/skills/changelog/assess.sh
 ```
 
 It exits non-zero when commits since the last tag are missing. Add the missing
@@ -65,7 +65,7 @@ GitHub adds to squash-merge subjects.)
 
 In the PR that cuts `vX.Y.Z`:
 
-1. Run `bash skills/changelog/assess.sh` and add any missing entries.
+1. Run `bash .claude/skills/changelog/assess.sh` and add any missing entries.
 2. Rename the header `## Upcoming` -> `## vX.Y.Z`, and replace
    `_Unreleased_` with `_<Month Day, Year>_` (today's date).
 3. Remove any subsection that ended up with no entries.

--- a/.claude/skills/changelog/assess.sh
+++ b/.claude/skills/changelog/assess.sh
@@ -13,7 +13,7 @@
 
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../.. && pwd)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.. && pwd)"
 CL="$ROOT/website/src/content/docs/changelog.mdx"
 
 command -v git >/dev/null 2>&1 || { echo "error: git not found on PATH" >&2; exit 2; }
@@ -44,7 +44,7 @@ done < <(git -C "$ROOT" log "${LAST}..HEAD" --pretty='%s')
 echo
 if [ "$missing" -ne 0 ]; then
   echo "RESULT: ${missing} commit(s) since ${LAST} are not in 'Upcoming'." >&2
-  echo "Add an entry for each (see skills/changelog/SKILL.md) before releasing." >&2
+  echo "Add an entry for each (see .claude/skills/changelog/SKILL.md) before releasing." >&2
   exit 1
 fi
 echo "RESULT: 'Upcoming' covers every commit since ${LAST}."

--- a/.claude/skills/cli-reference-drift/SKILL.md
+++ b/.claude/skills/cli-reference-drift/SKILL.md
@@ -21,7 +21,7 @@ from the page.
 ## Run it
 
 ```bash
-bash skills/cli-reference-drift/check.sh
+bash .claude/skills/cli-reference-drift/check.sh
 ```
 
 The script runs the repo's `make docs` target to generate the live command and

--- a/.claude/skills/cli-reference-drift/check.sh
+++ b/.claude/skills/cli-reference-drift/check.sh
@@ -12,7 +12,7 @@
 
 set -euo pipefail
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../.. && pwd)"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../.. && pwd)"
 REF="$ROOT/website/src/content/docs/reference.mdx"
 
 command -v go >/dev/null 2>&1 || { echo "error: go toolchain not found on PATH" >&2; exit 2; }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,8 @@ end-to-end test harness verified by network-namespace + strace in CI.
 | `pkg/dotsecenv/`    | Public packages: `config/`, `crypto/`, `gpg/`, `identity/`, `output/`, `policy/`, `vault/`. |
 | `contrib/`          | `terraform-credentials-dotsecenv` Bash credentials helper for Terraform/OpenTofu. |
 | `demos/`            | `demo.sh` for asciinema recording (driven by `make demo`).                     |
-| `skills/`           | Claude Code skills (`secenv/SKILL.md`, `secrets/SKILL.md`).                    |
+| `skills/`           | Claude Code skills shipped in the plugin (`secenv/SKILL.md`, `secrets/SKILL.md`). |
+| `.claude/skills/`   | Maintainer-only skills, NOT shipped to plugin installers (`changelog/`, `cli-reference-drift/`). |
 | `.claude-plugin/`   | Claude Code plugin manifest (`plugin.json`, `marketplace.json`).               |
 | `scripts/`          | `install.sh`, `e2e.sh`, `e2e-install.sh`, `e2e-terraform.sh`, `sandbox.sh`, `notarize-macos.sh`, `generate_release_key.sh`. |
 | `.github/workflows/` | CI + release: `ci.yml` (Go DAG), `ci-plugin.yml`, `ci-website.yml`, `ci-release.yml` (goreleaser snapshot), `e2e-hermetic.yml`, `e2e-install.yml`, `e2e-action-post-release.yml` (reusable, post-release action smoke), `lint-workflows.yml` (actionlint), `release.yml`, `deploy-website.yml`. |
@@ -233,10 +234,10 @@ What the script does NOT do — handle manually if needed:
   a separator.
 - **Changelog:** every PR adds one line to the `## Upcoming` section of
   `website/src/content/docs/changelog.mdx` (use the `changelog` skill,
-  `skills/changelog/SKILL.md`), in the subsection for its type (`feat` ->
+  `.claude/skills/changelog/SKILL.md`), in the subsection for its type (`feat` ->
   Features, `fix` -> Bug Fixes, else Other), ending with the PR number. Release
   notes build up per PR; the release PR stamps "Upcoming" to the tag.
-  `bash skills/changelog/assess.sh` reports any merged PRs missing from it.
+  `bash .claude/skills/changelog/assess.sh` reports any merged PRs missing from it.
 - **Branches:** `feat/*`, `fix/*`, `docs/*`, etc. (see `CONTRIBUTING.md`).
 - **PRs only:** All changes land on `main` through pull requests. Don't
   push commits directly to `main`, even when your account holds a bypass
@@ -249,8 +250,8 @@ What the script does NOT do — handle manually if needed:
 - **Linters:** `golangci-lint` v2.11.4 — pinned because v2.12.x had a
   checksum mismatch on release. Don't bump back to `latest` without verifying.
 - **Releases:** Triggered by pushing a signed semver tag. Before tagging, run
-  the CLI reference drift check (`bash skills/cli-reference-drift/check.sh`; see
-  `skills/cli-reference-drift/SKILL.md`) and resolve any drift. Use
+  the CLI reference drift check (`bash .claude/skills/cli-reference-drift/check.sh`; see
+  `.claude/skills/cli-reference-drift/SKILL.md`) and resolve any drift. Use
   [`releasetools-cli`](https://github.com/releasetools/cli):
 
   ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,8 +2,8 @@
 
 ## Release new version
 
-- **Pre-release gate:** run the CLI reference drift check and resolve any drift before tagging — `bash skills/cli-reference-drift/check.sh` (see [skills/cli-reference-drift/SKILL.md](skills/cli-reference-drift/SKILL.md)). The website CLI reference (`website/src/content/docs/reference.mdx`) is hand-curated and must stay in sync with the binary.
-- **Changelog:** in the release PR, run `bash skills/changelog/assess.sh` to confirm every merged PR since the last tag is recorded, then stamp the `## Upcoming` section of `website/src/content/docs/changelog.mdx` to `vX.Y.Z` + date (see [skills/changelog/SKILL.md](skills/changelog/SKILL.md)).
+- **Pre-release gate:** run the CLI reference drift check and resolve any drift before tagging — `bash .claude/skills/cli-reference-drift/check.sh` (see [.claude/skills/cli-reference-drift/SKILL.md](.claude/skills/cli-reference-drift/SKILL.md)). The website CLI reference (`website/src/content/docs/reference.mdx`) is hand-curated and must stay in sync with the binary.
+- **Changelog:** in the release PR, run `bash .claude/skills/changelog/assess.sh` to confirm every merged PR since the last tag is recorded, then stamp the `## Upcoming` section of `website/src/content/docs/changelog.mdx` to `vX.Y.Z` + date (see [.claude/skills/changelog/SKILL.md](.claude/skills/changelog/SKILL.md)).
 - When asked to release, use `rt git::release --major --sign --push vX.Y.Z` where X.Y.Z is the version to release
 - Then push the tag to the origin
 

--- a/website/CLAUDE.md
+++ b/website/CLAUDE.md
@@ -12,13 +12,13 @@ When documenting CI/CD, use the canonical secret names and always state whether 
 
 ## Changelog Generation
 
-The changelog (`src/content/docs/changelog.mdx`) builds up continuously: every PR adds a one-line entry under the standing `## Upcoming` section, and the release PR stamps that section to the version tag. The `changelog` skill (`../skills/changelog/SKILL.md`) drives this; this section is the reference for format and the release stamp.
+The changelog (`src/content/docs/changelog.mdx`) builds up continuously: every PR adds a one-line entry under the standing `## Upcoming` section, and the release PR stamps that section to the version tag. The `changelog` skill (`../.claude/skills/changelog/SKILL.md`) drives this; this section is the reference for format and the release stamp.
 
 **Per PR:** add one line under `## Upcoming`, in the subsection for the PR's type (see the table below), ending with the PR number.
 
 **At release (in the release PR):**
 
-1. From the repo root, run `bash skills/changelog/assess.sh` to list any merged PRs since the last tag that are missing from "Upcoming", and add an entry for each. This is the "assess all commits since the last release" step.
+1. From the repo root, run `bash .claude/skills/changelog/assess.sh` to list any merged PRs since the last tag that are missing from "Upcoming", and add an entry for each. This is the "assess all commits since the last release" step.
 2. Rename `## Upcoming` to `## vX.Y.Z` and replace `_Unreleased_` with `_Month Day, Year_` (today's date). Drop any subsection left empty.
 3. Open a fresh, empty `## Upcoming` section at the top for the next cycle.
 

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -14,6 +14,7 @@ _Unreleased_
 ### Other
 
 - Release notes now build up continuously under "Upcoming": a new `changelog` skill adds a one-line entry per PR and stamps the section at release time (#212)
+- The `changelog` and `cli-reference-drift` maintainer skills moved to `.claude/skills/`, so the published plugin now ships only the `secenv` and `secrets` skills to installers (#213)
 
 ---
 


### PR DESCRIPTION
## Problem

The plugin `source` in `.claude-plugin/marketplace.json` is the repo root, and Claude Code auto-discovers every skill under the plugin's `skills/` directory. As a result, **all four** skills shipped to anyone installing the dotsecenv plugin — including two that are release-time maintainer tooling, not user-facing:

- `changelog` — maintains `website/.../changelog.mdx` per-PR and stamps releases (added in #212)
- `cli-reference-drift` — checks the website CLI reference against the binary before a release (added in #211)

Plugin installers should only get the secret-management skills, `secenv` and `secrets`.

## Change

- Move both internal skills from `skills/` to `.claude/skills/` (via `git mv`, history preserved). `.claude/skills/` is available to maintainers working in the repo but is **not** bundled into the published plugin.
- Fix `ROOT` resolution in `assess.sh` and `check.sh` — both compute the repo root relative to the script, which moved one level deeper (`../..` → `../../..`). Verified both resolve to the repo root.
- Update every path reference: `CLAUDE.md`, `AGENTS.md` (plus a new directory-table row making the shipped-vs-maintainer split explicit), `website/CLAUDE.md`, and the self-references inside the moved `SKILL.md`/`assess.sh` files.

## Result

- `skills/` (shipped in plugin): `secenv`, `secrets`
- `.claude/skills/` (maintainer-only): `changelog`, `cli-reference-drift`

No CI workflow, Makefile, goreleaser config, or plugin test references these skills, so nothing else needs updating.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)