### PR TITLE
fix(plugin): stay silent in non-interactive shells

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,16 @@
 - When asked to release, use `rt git::release --major --sign --push vX.Y.Z` where X.Y.Z is the version to release
 - Then push the tag to the origin
 
+## Satellite repositories (plugin, packages)
+
+`plugin/` and `packages/` in this monorepo are the **source of truth**. CI mirrors them to their standalone satellite repos (`dotsecenv/plugin`, `dotsecenv/packages`). Never edit the satellites directly and never accept PRs there; edits made on a satellite are overwritten by the next publish.
+
+- **On release**, `.github/workflows/release.yml` (`publish-plugin` / `publish-packages`) pushes the source dir to the satellite's `main` and tags it with the release version.
+- **Ad-hoc** (Renovate updates, doc fixes that don't warrant a release), run the `Publish Satellites` workflow (`.github/workflows/publish-satellites.yml`, `workflow_dispatch`); it pushes without tagging.
+- Both use `releasetools/actions/signed-push` and stamp `Source-Commit`, `Source-SHA`, `Source-Path` (and `Source-Tag` on release) into the satellite commit body.
+
+A bug reported on a satellite (e.g. `dotsecenv/plugin#29` about `conf.d/dotsecenv.fish`) is fixed here under `plugin/` with a matching `plugin/tests/` change, and reaches the satellite on the next publish. `plugin/AGENTS.md` states this in the satellite for anyone landing there. Reference satellite issues/PRs as `plugin#N` / `packages#N`. The plugin test suite is `make -C plugin test-plugins` (bash/zsh/fish).
+
 ## Policy directory conventions
 
 - Policy fragments live at `/etc/dotsecenv/policy.d/*.yaml`, owned `root:root`, mode `0644` or stricter

--- a/plugin/AGENTS.md
+++ b/plugin/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+**This repository is a generated mirror. Do not edit it or open pull requests here.**
+
+The source of truth for the dotsecenv shell plugins lives in the
+[`dotsecenv/dotsecenv`](https://github.com/dotsecenv/dotsecenv) monorepo under
+[`plugin/`](https://github.com/dotsecenv/dotsecenv/tree/main/plugin). CI publishes
+that directory to this repo on each dotsecenv release, and ad-hoc for dependency
+and doc updates, via a signed push. Anything committed directly here is
+overwritten on the next publish.
+
+## Working on an issue filed here
+
+- Reproduce and fix in `dotsecenv/dotsecenv` under `plugin/`. The files map 1:1:
+  `conf.d/dotsecenv.fish` (fish), `dotsecenv.plugin.bash`, `dotsecenv.plugin.zsh`,
+  and the shared `_dotsecenv_core.sh`.
+- Add or update coverage in `plugin/tests/`, then run `make -C plugin test-plugins`
+  (bash, zsh, and fish).
+- Open the pull request against `dotsecenv/dotsecenv:main`, not this repo.
+
+## Behavior notes for triage
+
+- The plugins auto-load `.secenv` only in **interactive** shells. In a
+  non-interactive shell (`fish -c`, a script, an editor capturing output) they
+  stay silent and do not spawn the CLI. If a diagnostic line leaks into captured
+  command output, that is a bug in the interactivity guards; see the fish
+  `conf.d/dotsecenv.fish` load-time / PWD-hook entry points and the bash/zsh
+  load-time / `chpwd` equivalents.
+
+Each mirrored commit records its origin in the commit body: `Source-Commit`,
+`Source-SHA`, `Source-Path`, and `Source-Tag` (on release). See
+[CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide.

--- a/plugin/conf.d/dotsecenv.fish
+++ b/plugin/conf.d/dotsecenv.fish
@@ -732,6 +732,12 @@ end
 
 # Hook function called on directory change
 function _dotsecenv_cd_hook --on-variable PWD
+    # Only act in interactive sessions. conf.d snippets are sourced by *every*
+    # fish session, including `fish -c …` used by editors/scripts/CI. Emitting
+    # our diagnostics (or spawning `dotsecenv secret get`) there pollutes any
+    # captured stdout+stderr. See dotsecenv/plugin#29.
+    status is-interactive; or return
+
     set -l old_dir "$_DOTSECENV_PREV_PWD"
     set -l new_dir "$PWD"
 
@@ -840,6 +846,11 @@ function dse
     end
 end
 
-# Process current directory on plugin load
+# Process current directory on plugin load.
+# Guarded on interactivity: conf.d is sourced by non-interactive `fish -c …`
+# too, and auto-loading there both pollutes captured output and needlessly
+# spawns the dotsecenv CLI. Interactive sessions still load on startup.
 set -g _DOTSECENV_PREV_PWD ""
-_dotsecenv_on_cd "" "$PWD"
+if status is-interactive
+    _dotsecenv_on_cd "" "$PWD"
+end

--- a/plugin/dotsecenv.plugin.bash
+++ b/plugin/dotsecenv.plugin.bash
@@ -52,5 +52,11 @@ elif [[ "$PROMPT_COMMAND" != *"_dotsecenv_prompt_hook"* ]]; then
     PROMPT_COMMAND="_dotsecenv_prompt_hook;$PROMPT_COMMAND"
 fi
 
-# Process current directory on plugin load (initial shell startup)
-_dotsecenv_chpwd_hook
+# Process current directory on plugin load, interactive shells only. Sourcing
+# this file in a non-interactive shell (a script, or `bash -c`) must not emit
+# diagnostics or spawn the dotsecenv CLI, which would corrupt captured output.
+# See dotsecenv/plugin#29. (The PROMPT_COMMAND hook above is already
+# interactive-only, since PROMPT_COMMAND runs only before an interactive prompt.)
+case $- in
+*i*) _dotsecenv_chpwd_hook ;;
+esac

--- a/plugin/dotsecenv.plugin.zsh
+++ b/plugin/dotsecenv.plugin.zsh
@@ -28,6 +28,10 @@ typeset -g _DOTSECENV_PREV_PWD=""
 
 # Hook function for directory changes
 _dotsecenv_chpwd_hook() {
+    # Stay silent in non-interactive shells. zsh fires chpwd on `cd` even under
+    # `zsh -c`, and auto-loading there pollutes captured output and needlessly
+    # spawns the dotsecenv CLI. See dotsecenv/plugin#29.
+    [[ -o interactive ]] || return
     local old_dir="$_DOTSECENV_PREV_PWD"
     _DOTSECENV_PREV_PWD="$PWD"
     _dotsecenv_on_cd "$old_dir" "$PWD"
@@ -42,5 +46,6 @@ reloadsecenv() {
 autoload -Uz add-zsh-hook
 add-zsh-hook chpwd _dotsecenv_chpwd_hook
 
-# Process current directory on plugin load (initial shell startup)
+# Process current directory on plugin load (interactive shells only; the hook
+# self-guards via [[ -o interactive ]]). See dotsecenv/plugin#29.
 _dotsecenv_chpwd_hook

--- a/plugin/tests/test_plugins.fish
+++ b/plugin/tests/test_plugins.fish
@@ -97,6 +97,38 @@ fi' >"$mock_dir/dotsecenv"
     echo $mock_dir
 end
 
+# Regression: a NON-interactive fish (`fish -c`, as used by editors like Emacs
+# and by scripts/CI) must emit nothing when conf.d loads and a directory with an
+# untrusted .secenv is entered. See dotsecenv/plugin#29. Note this test does NOT
+# pass -i: it exercises the real non-interactive path that the bug reported.
+function test_noninteractive_silent
+    log "[fish] Testing non-interactive shell stays silent (plugin#29)..."
+    set TESTS_RUN (math $TESTS_RUN + 1)
+
+    set test_dir "$TEMP_DIR/test_noninteractive"
+    mkdir -p "$test_dir"
+    echo 'FOO=bar' >"$test_dir/.secenv"
+    chmod 644 "$test_dir/.secenv"
+
+    set mock_path (create_mock_dotsecenv)
+
+    # No trusted_dirs -> untrusted. Interactively this prints "skipping ... no
+    # TTY for trust prompt"; non-interactively it must stay silent.
+    set result (fish --no-config -c "
+        set -gx PATH '$mock_path' \$PATH
+        set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config-noninteractive'
+        source '$SHELL_DIR/conf.d/dotsecenv.fish'
+        cd '$test_dir'
+        echo MARKER
+    " 2>&1)
+
+    if test "$result" = MARKER
+        pass "[fish] Non-interactive shell emits no dotsecenv output"
+    else
+        fail "[fish] Non-interactive shell leaked output, got: $result"
+    end
+end
+
 # ============================================================================
 # Test Functions
 # ============================================================================
@@ -116,7 +148,7 @@ APP_NAME="My Application"' >"$test_dir/.secenv"
     set mock_path (create_mock_dotsecenv)
 
     # Run fish with the plugin loaded
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -146,7 +178,7 @@ function test_parse_secret_same_name
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -176,7 +208,7 @@ function test_parse_secret_named
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -206,7 +238,7 @@ function test_missing_secret_warning
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -236,7 +268,7 @@ function test_security_check_world_writable
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -267,7 +299,7 @@ SECRET_VAR={dotsecenv/API_KEY}' >"$test_dir/.secenv"
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -305,7 +337,7 @@ SVC_KEY={dotsecenv/API_KEY}' >"$test_dir/.secenv"
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -342,7 +374,7 @@ function test_empty_secenv_no_message
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -370,7 +402,7 @@ function test_alias_dse
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         source '$SHELL_DIR/conf.d/dotsecenv.fish'
         type dse
@@ -389,7 +421,7 @@ function test_alias_dse_get
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         source '$SHELL_DIR/conf.d/dotsecenv.fish'
         dse get API_KEY
@@ -419,7 +451,7 @@ DATABASE_PORT=5432
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -451,7 +483,7 @@ UNQUOTED=helloworld' >"$test_dir/.secenv"
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -491,7 +523,7 @@ function test_tree_scope_persist_in_subdir
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -527,7 +559,7 @@ function test_tree_scope_unload_on_leave
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -567,7 +599,7 @@ function test_tree_scope_nested_secenv
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -603,7 +635,7 @@ function test_tree_scope_sibling_navigation
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -639,7 +671,7 @@ function test_tree_scope_no_reload_from_subdir
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -677,7 +709,7 @@ function test_multiline_warning
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -713,7 +745,7 @@ function test_dse_up_basic
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -750,7 +782,7 @@ function test_dse_up_multiple_ancestors
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -783,7 +815,7 @@ function test_dse_up_skips_already_loaded
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -813,7 +845,7 @@ function test_dse_up_no_ancestors
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -837,7 +869,7 @@ function test_parse_trailing_whitespace_secret
     log "[fish] Testing {dotsecenv*} with trailing whitespace resolves as secret..."
     set TESTS_RUN (math $TESTS_RUN + 1)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         source '$SHELL_DIR/conf.d/dotsecenv.fish'
         _dotsecenv_parse_line 'DB_PASSWORD={dotsecenv} '
         echo \"same|\$_DOTSECENV_PARSE_TYPE|\$_DOTSECENV_PARSE_VALUE\"
@@ -873,7 +905,7 @@ function test_load_crlf_empty_name_resolves
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -912,7 +944,7 @@ function test_sync_new_key_always_trusted
 
     # Fish only fires its hook on a real PWD change, so use dse reload / direct
     # sync to ingest the newly-appended key.
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -947,7 +979,7 @@ function test_sync_no_new_keys_noop
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -983,7 +1015,7 @@ function test_sync_new_key_unload_integrity
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -1018,7 +1050,7 @@ function test_reload_ingests_new_key
 
     set mock_path (create_mock_dotsecenv)
 
-    set result (fish --no-config -c "
+    set result (fish --no-config -i -c "
         set -gx PATH '$mock_path' \$PATH
         set -gx DOTSECENV_CONFIG_DIR '$config_dir'
         set -gx DOTSECENV_TRUSTED_DIRS_FILE '$config_dir/trusted_dirs'
@@ -1095,6 +1127,9 @@ function main
     test_sync_no_new_keys_noop
     test_sync_new_key_unload_integrity
     test_reload_ingests_new_key
+
+    # Regression: non-interactive shells stay silent (plugin#29)
+    test_noninteractive_silent
 
     cleanup
 

--- a/plugin/tests/test_plugins.sh
+++ b/plugin/tests/test_plugins.sh
@@ -168,7 +168,7 @@ run_with_plugin_zsh() {
     local cmd="$*"
 
     # Run zsh with the plugin sourced, preserving existing PATH
-    zsh -c "
+    zsh -i -f -c "
         export PATH='$mock_path:$PATH'
         export DOTSECENV_CONFIG_DIR='$TEMP_DIR/config'
         mkdir -p '$TEMP_DIR/config'
@@ -216,7 +216,7 @@ EOF
             echo \"\$DATABASE_HOST|\$DATABASE_PORT|\$APP_NAME\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir'
@@ -263,7 +263,7 @@ EOF
             echo \"\$DB_PASSWORD\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir'
@@ -310,7 +310,7 @@ EOF
             echo \"\$MY_API_KEY\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir'
@@ -357,7 +357,7 @@ EOF
             echo \"VAR=\$MISSING_SECRET\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir'
@@ -404,7 +404,7 @@ EOF
             echo \"VAR=\${UNSAFE_VAR:-unset}\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir'
@@ -453,7 +453,7 @@ EOF
             echo \"\$PLAIN_VAR|\$SECRET_VAR\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir'
@@ -505,7 +505,7 @@ EOF
             _dotsecenv_chpwd_hook
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir'
@@ -551,7 +551,7 @@ test_empty_secenv_no_message() {
             echo MARKER
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir'
@@ -582,7 +582,7 @@ test_alias_dse() {
             type dse
         " 2>&1)
     else
-        result=$(zsh -c "
+        result=$(zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             type dse
@@ -612,7 +612,7 @@ test_alias_dse_get() {
             dse get API_KEY
         " 2>&1)
     else
-        result=$(zsh -c "
+        result=$(zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             dse get API_KEY
@@ -663,7 +663,7 @@ EOF
             echo \"\$DATABASE_HOST|\$DATABASE_PORT\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir'
@@ -712,7 +712,7 @@ EOF
             echo \"\$DOUBLE_QUOTED|\$SINGLE_QUOTED|\$UNQUOTED\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir'
@@ -766,7 +766,7 @@ EOF
             echo \"\$DB_PASSWORD\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir/parent'
@@ -818,7 +818,7 @@ EOF
             echo \"VAR=\${DB_PASSWORD:-unset}\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir/project'
@@ -878,7 +878,7 @@ EOF
             echo \"\$DB_PASSWORD|\$API_KEY\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir/parent'
@@ -932,7 +932,7 @@ EOF
             echo \"\$DB_PASSWORD\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir/parent'
@@ -986,7 +986,7 @@ EOF
             echo \"\$DB_PASSWORD\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir/project'
@@ -1037,7 +1037,7 @@ EOF
             _dotsecenv_chpwd_hook
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir'
@@ -1087,7 +1087,7 @@ EOF
             echo \"\$DB_PASSWORD\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir/project/terraform/modules'
@@ -1141,7 +1141,7 @@ EOF
             echo \"\$APP_ENV|\$DB_PASSWORD\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir/root/project/src'
@@ -1191,7 +1191,7 @@ EOF
             echo \"\$DB_PASSWORD\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir/project'
@@ -1233,7 +1233,7 @@ test_dse_up_no_ancestors() {
             dse up '$test_dir'
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir/project/src'
@@ -1311,7 +1311,7 @@ MOCK_EOF
             echo \"before_secret=\$before_secret|after_secret=\$DB_PASSWORD|before_plain=\$before_plain|after_plain=\$APP_NAME\"
         " 2>/dev/null)
     else
-        result=$(zsh -c "
+        result=$(zsh -i -f -c "
             export PATH='$mock_dir:$PATH'
             export DOTSECENV_CONFIG_DIR='$TEMP_DIR/config_reload'
             mkdir -p '$TEMP_DIR/config_reload'
@@ -1382,7 +1382,7 @@ EOF
             echo \"before_env=\$before_env|after_env=\$APP_ENV|before_pw=\$before_pw|after_pw=\$DB_PASSWORD|stack=\${_DOTSECENV_SOURCE_STACK[*]}\"
         " 2>/dev/null)
     else
-        result=$(zsh -c "
+        result=$(zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             export DOTSECENV_CONFIG_DIR='$TEMP_DIR/config_reload_stack'
             mkdir -p '$TEMP_DIR/config_reload_stack'
@@ -1420,7 +1420,7 @@ _parse_one() {
             echo \"\$_DOTSECENV_PARSE_TYPE|\$_DOTSECENV_PARSE_VALUE\"
         " _ "$line" 2>&1
     else
-        zsh -c "
+        zsh -i -f -c "
             source '$SHELL_DIR/_dotsecenv_core.sh'
             _dotsecenv_parse_line \"\$1\"
             echo \"\$_DOTSECENV_PARSE_TYPE|\$_DOTSECENV_PARSE_VALUE\"
@@ -1488,7 +1488,7 @@ test_load_crlf_empty_name_resolves() {
             echo \"\$API_KEY\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir'
@@ -1545,7 +1545,7 @@ EOF
             echo \"DB=\${DB_PASSWORD:-unset}|API=\${API_KEY:-unset}\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir'
@@ -1599,7 +1599,7 @@ EOF
             echo MARKER
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir'
@@ -1654,7 +1654,7 @@ EOF
             echo \"DB=\${DB_PASSWORD:-unset}|API=\${API_KEY:-unset}\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir/project'
@@ -1706,7 +1706,7 @@ EOF
             echo \"DB=\${DB_PASSWORD:-unset}|API=\${API_KEY:-unset}\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             cd '$test_dir/project'
@@ -1761,7 +1761,7 @@ EOF
             echo \"DB=\${DB_PASSWORD:-unset}|API=\${API_KEY:-unset}\"
         " 2>&1)
     else
-        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -c "
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -i -f -c "
             export PATH='$mock_path:$PATH'
             source '$SHELL_DIR/dotsecenv.plugin.zsh'
             _dotsecenv_trust_session '$test_dir'
@@ -1823,6 +1823,55 @@ EOF
     fi
 }
 
+# Regression: a NON-interactive shell (editor/script that captures output) must
+# emit nothing when the plugin is sourced and a directory with an untrusted
+# .secenv is entered. See dotsecenv/plugin#29. Note this test deliberately does
+# NOT pass -i (zsh) or call the hook explicitly (bash): it exercises the real
+# non-interactive path.
+test_noninteractive_silent() {
+    local shell="$1"
+    log "[$shell] Testing non-interactive shell stays silent (plugin#29)..."
+    ((TESTS_RUN++)) || true
+
+    local test_dir="$TEMP_DIR/test_noninteractive_$shell"
+    mkdir -p "$test_dir"
+    echo 'FOO=bar' >"$test_dir/.secenv"
+    chmod 644 "$test_dir/.secenv"
+
+    # Fresh config dir with no trusted_dirs -> the dir is untrusted. In an
+    # interactive shell this path prints "skipping ... no TTY for trust prompt";
+    # a non-interactive shell must stay silent so captured output isn't corrupted.
+    local config_dir="$TEMP_DIR/config_noninteractive_$shell"
+    mkdir -p "$config_dir"
+
+    local mock_path
+    mock_path=$(create_mock_dotsecenv)
+
+    local result
+    if [[ "$shell" == "bash" ]]; then
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" "$BASH_BIN" -c "
+            export PATH='$mock_path:$PATH'
+            source '$SHELL_DIR/_dotsecenv_core.sh'
+            source '$SHELL_DIR/dotsecenv.plugin.bash'
+            cd '$test_dir'
+            echo MARKER
+        " 2>&1)
+    else
+        result=$(DOTSECENV_CONFIG_DIR="$config_dir" DOTSECENV_TRUSTED_DIRS_FILE="$config_dir/trusted_dirs" zsh -f -c "
+            export PATH='$mock_path:$PATH'
+            source '$SHELL_DIR/dotsecenv.plugin.zsh'
+            cd '$test_dir'
+            echo MARKER
+        " 2>&1)
+    fi
+
+    if [[ "$result" == "MARKER" ]]; then
+        pass "[$shell] Non-interactive shell emits no dotsecenv output"
+    else
+        fail "[$shell] Non-interactive shell leaked output, got: $result"
+    fi
+}
+
 # ============================================================================
 # Main
 # ============================================================================
@@ -1880,6 +1929,7 @@ main() {
         test_sync_new_key_unload_integrity "bash"
         test_reload_ingests_new_key "bash"
         test_sync_new_key_not_always_trusted_no_autoload "bash"
+        test_noninteractive_silent "bash"
         test_bash_cd_dot_asymmetry "bash"
     fi
 
@@ -1921,6 +1971,7 @@ main() {
             test_sync_new_key_unload_integrity "zsh"
             test_reload_ingests_new_key "zsh"
             test_sync_new_key_not_always_trusted_no_autoload "zsh"
+            test_noninteractive_silent "zsh"
         else
             warn "Zsh not found, skipping zsh tests"
         fi

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -19,6 +19,7 @@ _Unreleased_
 
 ### Bug Fixes
 
+- Shell plugins (fish, bash, zsh): stay silent in non-interactive shells, so `fish -c` and scripts no longer leak `dotsecenv:` diagnostics into captured command output (fixes Emacs/Magit "invalid object name" errors) (plugin#29, #237)
 - `vault doctor -v N` now targets the Nth configured vault instead of erroring for any index above 1 (#223)
 - Shell plugin: reload secrets on directory re-entry, fix the `{dotsecenv/}` literal regression, and fail fast when the store is unavailable (#190)
 - Shell plugin reports plain env vars and secrets on separate lines (#192)


### PR DESCRIPTION
Fixes dotsecenv/plugin#29.

## Problem

`conf.d/dotsecenv.fish` is sourced by **every** fish session, including `fish -c …` used by editors, scripts, and CI. On load — and on the `--on-variable PWD` hook — it wrote `dotsecenv:` diagnostics to stderr (and could spawn `dotsecenv secret get`), corrupting any captured stdout+stderr. In Emacs, `shell-command-to-string "git merge-base HEAD main"` came back with the diagnostic prefixed, so Magit/magit-todos passed `dotsecenv:` to `git diff` → `fatal: invalid object name 'dotsecenv'`.

The output is from the **plugin**, not the binary: the binary's stderr is already redirected to a temp file in the load path (`dotsecenv secret get … 2>$secret_stderr_file`).

## Fix

Guard the two fish entry points on `status is-interactive`:
- the `--on-variable PWD` hook (`_dotsecenv_cd_hook`)
- the load-time `_dotsecenv_on_cd "" "$PWD"` call

Apply equivalent guards so all three shells behave identically (silent + no CLI spawn when non-interactive):
- **bash** — guard the load-time `_dotsecenv_chpwd_hook` call (`case $- in *i*)`); `PROMPT_COMMAND` is already interactive-only.
- **zsh** — guard the `chpwd` hook body (`[[ -o interactive ]] || return`) and the load-time call.

## Tests

- Run the fish/zsh harnesses interactively (`fish --no-config -i -c`, `zsh -i -f -c`) so the auto-hook fires as it does for real users; bash already calls the hook explicitly.
- Add a per-shell regression test: a **non-interactive** shell entering an untrusted `.secenv` dir must emit nothing (asserts the exact reported symptom).
- `make -C plugin fmt-check lint test-plugins` all pass — fish 29, bash 33, zsh 32.

## On the reported double-print

On fish 4.8 the load-time call fires **exactly once**; I couldn't reproduce a double via `-c` / `-i -c` / `-l -c` / unset-or-stale `PWD` / double-source (the `_DOTSECENV_FISH_LOADED` guard prevents re-processing). The report's doubling is environment-specific (older fish interactive-init, a plugin-manager double-load, or the editor invoking twice); the guard drives the non-interactive count to zero regardless.

## Residual edge

`status is-interactive` is true for `fish -i -c` without a TTY (an unusual editor config). The reported path (`shell-command-to-string` → `fish -c`) is non-interactive, so it's fully fixed; a TTY-based guard could cover the `-i`-no-tty case if it ever comes up.

## Docs

- CLAUDE.md: document that `plugin/` here is the source of truth published to `dotsecenv/plugin` by CI (release + ad-hoc `Publish Satellites`).
- Add `plugin/AGENTS.md` so anyone landing in the satellite repo knows where the source lives.