### PR TITLE
fix(website): remove duplicated semver key from pnpm-lock.yaml

### DIFF
--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -2661,11 +2661,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.5:
-    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   seroval-plugins@1.5.4:
     resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
     engines: {node: '>=10'}
@@ -6330,8 +6325,6 @@ snapshots:
       '@bruits/satteri-win32-x64-msvc': 0.9.4
 
   sax@1.6.0: {}
-
-  semver@7.8.5: {}
 
   semver@7.8.5: {}
 

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -40,6 +40,7 @@ _Unreleased_
 - Update Go modules: x/crypto (security), x/term, and bubbletea/lipgloss v2 (#178, #187, #197, #204)
 - Update GitHub Actions and the Go toolchain: checkout, harden-runner, goreleaser-action, Go 1.26.4 (#177, #180, #199)
 - Update the sharp image library (#210)
+- Fix a duplicated `semver` key in the website pnpm lockfile that broke `pnpm install` (#238)
 - Renovate lock file maintenance (#171)
 
 ---


### PR DESCRIPTION
## Problem

CI fails to install website deps:

```
ERR_PNPM_BROKEN_LOCKFILE ... duplicated mapping key (2664:3)
```

`website/pnpm-lock.yaml` lists `semver@7.8.5` **twice** — once too many in both the `packages:` section (line 2664) and the `snapshots:` section (line 6336). YAML forbids duplicate mapping keys, so pnpm refuses to parse the file. The duplication is a merge/dedup artifact from an earlier dependency update (present on `main`, unrelated to any feature work).

## Fix

Remove the duplicate blocks, leaving one entry per key (7 lines deleted, no other change).

## Verification

- Duplicate-key scan of the lockfile is clean.
- `pnpm install --frozen-lockfile` passes, confirming the lockfile is valid YAML and still consistent with `package.json` (no resolution changes).