### PR TITLE
fix(release): trust cask before brew install in verify step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -558,6 +558,11 @@ jobs:
           # Ensure the latest cask is fetched (no stale cache from a previous run)
           brew untap dotsecenv/tap 2>/dev/null || true
           brew tap dotsecenv/tap
+          # Newer Homebrew (with HOMEBREW_REQUIRE_TAP_TRUST, on by default on
+          # GitHub's hardened runners) refuses to load a third-party tap's cask
+          # until it is trusted. Default end-user Homebrew doesn't require this;
+          # the CI runner does. Trust the cask so the smoke-test can proceed.
+          brew trust --cask dotsecenv/tap/dotsecenv
           # Match the install command users actually run; brew auto-resolves to
           # the cask in dotsecenv/tap.
           brew install dotsecenv


### PR DESCRIPTION
## Problem

The v0.7.0 release published fine (GitHub release, tap cask, plugin satellite), but the post-publish **`verify-homebrew-install`** smoke-test failed, which skipped `tag-homebrew-tap` and **`publish-packages`**.

Root cause is a Homebrew behavior change, not the release content. Newer Homebrew (6.x, on GitHub's hardened runners) sets `HOMEBREW_REQUIRE_TAP_TRUST` and refuses to load a third-party tap's cask until it's trusted:

```
Refusing to load cask dotsecenv/tap/dotsecenv from untrusted tap dotsecenv/tap.
Run `brew trust --cask dotsecenv/tap/dotsecenv` or `brew trust dotsecenv/tap` to trust it.
```

The verify step tapped and installed but never trusted.

## Fix

Add `brew trust --cask dotsecenv/tap/dotsecenv` between `brew tap` and `brew install`. Default end-user Homebrew doesn't require this (the env var is off), so this only affects the hardened CI runner.

## Companion fix (separate repo)

`dotsecenv/homebrew-tap`'s `post-release.yml` (which `wait-homebrew-tap-ci` waits on) hit the identical error and needs the same one-line `brew trust`. Filed/handled separately.

## Note on v0.7.0

The release itself shipped (release + cask + plugin are live). The skipped `publish-packages` (dotsecenv/packages satellite) still needs to run for v0.7.0 — via the `Publish Satellites` workflow (`target: packages`) once these fixes land.