### PR TITLE
ci(release): sync the tap's post-release CI from the monorepo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,6 +359,47 @@ jobs:
         with:
           path: monorepo
 
+      # Sync the tap's own CI (post-release.yml) from the monorepo source of
+      # truth BEFORE pushing the cask, so the cask commit's post-release run uses
+      # the just-synced workflow. Same server-signed GraphQL push as the cask
+      # (commit-cask-via-graphql.sh takes a generic repo path + local file).
+      #
+      # Pushing a file under .github/workflows/ requires the RELEASE App to have
+      # `workflows: write` on homebrew-tap (the cask push only needs contents).
+      # Until that's granted the push is rejected, so this step warns and
+      # continues rather than breaking the release; make it strict once the
+      # permission is in place.
+      - name: Sync tap CI from monorepo
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SOURCE_SHA: ${{ github.sha }}
+          PUBLISHED_BY: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          SRC="monorepo/homebrew-tap/.github/workflows/post-release.yml"
+          DEST=".github/workflows/post-release.yml"
+          if [ ! -f "$SRC" ]; then
+            echo "::error::tap CI source not found: $SRC"; exit 1
+          fi
+          if diff -q "$SRC" "$DEST" >/dev/null 2>&1; then
+            echo "Tap CI already in sync; nothing to push."
+            exit 0
+          fi
+          cp "$SRC" "$DEST"
+          BODY="$(printf 'Source-Commit: dotsecenv/dotsecenv@%s\nSource-SHA: %s\nSource-Path: homebrew-tap/.github/workflows/post-release.yml\nPublished-By: %s\n' \
+            "$SOURCE_SHA" "$SOURCE_SHA" "$PUBLISHED_BY")"
+          if TAP_REPO=dotsecenv/homebrew-tap \
+             TAP_BRANCH=main \
+             CASK_PATH=.github/workflows/post-release.yml \
+             CASK_FILE="$DEST" \
+             HEADLINE="ci: sync post-release.yml from monorepo (${{ github.ref_name }})" \
+             BODY="$BODY" \
+             monorepo/scripts/release/commit-cask-via-graphql.sh; then
+            echo "Tap CI synced to homebrew-tap main."
+          else
+            echo "::warning::Could not push tap CI to homebrew-tap — the RELEASE App likely lacks 'workflows: write' there. Release continues; the tap's existing CI runs. Grant the permission to enable CI sync."
+          fi
+
       - name: Download updated checksums
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -340,6 +340,11 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: |
             homebrew-tap
+          # Least-privilege: this job checks out the tap (contents:read),
+          # commits the cask (contents:write), and pushes the tap's CI workflow
+          # (workflows:write). Nothing else, so scope the token to just these.
+          permission-contents: write
+          permission-workflows: write
 
       - name: Checkout homebrew-tap
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -363,12 +368,10 @@ jobs:
       # truth BEFORE pushing the cask, so the cask commit's post-release run uses
       # the just-synced workflow. Same server-signed GraphQL push as the cask
       # (commit-cask-via-graphql.sh takes a generic repo path + local file).
-      #
-      # Pushing a file under .github/workflows/ requires the RELEASE App to have
-      # `workflows: write` on homebrew-tap (the cask push only needs contents).
-      # Until that's granted the push is rejected, so this step warns and
-      # continues rather than breaking the release; make it strict once the
-      # permission is in place.
+      # Requires the RELEASE App to have `workflows: write` on homebrew-tap
+      # (scoped on the token above). No-op when the tap is already in sync;
+      # otherwise a push failure hard-fails the release so a broken/rejected sync
+      # is never shipped silently.
       - name: Sync tap CI from monorepo
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -388,17 +391,14 @@ jobs:
           cp "$SRC" "$DEST"
           BODY="$(printf 'Source-Commit: dotsecenv/dotsecenv@%s\nSource-SHA: %s\nSource-Path: homebrew-tap/.github/workflows/post-release.yml\nPublished-By: %s\n' \
             "$SOURCE_SHA" "$SOURCE_SHA" "$PUBLISHED_BY")"
-          if TAP_REPO=dotsecenv/homebrew-tap \
-             TAP_BRANCH=main \
-             CASK_PATH=.github/workflows/post-release.yml \
-             CASK_FILE="$DEST" \
-             HEADLINE="ci: sync post-release.yml from monorepo (${{ github.ref_name }})" \
-             BODY="$BODY" \
-             monorepo/scripts/release/commit-cask-via-graphql.sh; then
-            echo "Tap CI synced to homebrew-tap main."
-          else
-            echo "::warning::Could not push tap CI to homebrew-tap — the RELEASE App likely lacks 'workflows: write' there. Release continues; the tap's existing CI runs. Grant the permission to enable CI sync."
-          fi
+          TAP_REPO=dotsecenv/homebrew-tap \
+          TAP_BRANCH=main \
+          CASK_PATH=.github/workflows/post-release.yml \
+          CASK_FILE="$DEST" \
+          HEADLINE="ci: sync post-release.yml from monorepo (${{ github.ref_name }})" \
+          BODY="$BODY" \
+          monorepo/scripts/release/commit-cask-via-graphql.sh
+          echo "Tap CI synced to homebrew-tap main."
 
       - name: Download updated checksums
         env:

--- a/homebrew-tap/.github/workflows/post-release.yml
+++ b/homebrew-tap/.github/workflows/post-release.yml
@@ -1,0 +1,31 @@
+# Source of truth: dotsecenv/dotsecenv at
+# homebrew-tap/.github/workflows/post-release.yml. The release pipeline
+# (update-homebrew-tap in dotsecenv/dotsecenv's release.yml) pushes this file to
+# dotsecenv/homebrew-tap on each release. Edit it in the monorepo, not in the tap
+# repo — direct edits there are overwritten on the next release.
+name: Homebrew install
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test-install:
+    name: Test Homebrew Installation
+    runs-on: macos-latest
+    steps:
+      - name: Tap dotsecenv/homebrew-tap
+        run: brew tap dotsecenv/tap
+
+      # Newer Homebrew (HOMEBREW_REQUIRE_TAP_TRUST, on by default on GitHub's
+      # hardened runners) refuses to load a third-party tap's cask until it is
+      # trusted. Default end-user Homebrew doesn't require this; the runner does.
+      - name: Trust the dotsecenv/tap cask
+        run: brew trust --cask dotsecenv/tap/dotsecenv
+
+      - name: Install dotsecenv
+        run: brew install dotsecenv
+
+      - name: Verify installation
+        run: dotsecenv version

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -11,6 +11,10 @@ All notable changes to dotsecenv are documented here. Each version includes chan
 
 _Unreleased_
 
+### Other
+
+- The homebrew tap's post-release CI is now sourced from the monorepo and pushed to the tap on release, so all release automation lives in one place (#241)
+
 ---
 
 ## v0.7.0


### PR DESCRIPTION
## What

Makes the monorepo the source of truth for the homebrew-tap's CI workflow (`post-release.yml`, the brew-install smoke-test), which until now was maintained only in `dotsecenv/homebrew-tap`.

- Adds `homebrew-tap/.github/workflows/post-release.yml` to the monorepo (seeded from the fixed tap version, with a "source of truth" header).
- Adds a **Sync tap CI from monorepo** step to `update-homebrew-tap`, **before** the cask steps: pushes that file to `homebrew-tap` main via the same server-signed GraphQL path as the cask (`commit-cask-via-graphql.sh` takes a generic repo path + local file), diff-guarded (no-op when in sync). The subsequent cask commit's `post-release.yml` run then uses the just-synced workflow.

This is the "push CI → confirm → then run the cask/CI steps" pattern, matching how plugin/packages are synced.

## App permission

The RELEASE App already has **`workflows: write`** on `homebrew-tap` (confirmed), so the GraphQL push of the workflow file succeeds. The `update-homebrew-tap` token is now **scoped to least privilege** — `permission-contents: write` + `permission-workflows: write` — instead of inheriting the App's full permission set.

## Failure behavior

The sync **hard-fails** the release if the push is rejected or errors, so a stale/broken tap CI is never shipped silently.

## Notes

- `actionlint` clean; YAML parses.
- The tap's current `post-release.yml` already matches this source (from homebrew-tap#5), so the first release syncs only the added header. No revert of homebrew-tap#5 needed.
- Companion to #240 (the `brew trust` fix), which is part of the synced workflow.