### PR TITLE
release: v0.7.1

### DIFF
--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -11,9 +11,16 @@ All notable changes to dotsecenv are documented here. Each version includes chan
 
 _Unreleased_
 
+---
+
+## v0.7.1
+
+_July 4, 2026_
+
 ### Other
 
 - The homebrew tap's post-release CI is now sourced from the monorepo and pushed to the tap on release, so all release automation lives in one place (#241)
+- Update starlight-llms-txt for the website build (#242)
 
 ---
 


### PR DESCRIPTION
Patch release. Stamps the changelog for **v0.7.1**; merge this, then the signed tag is cut on the merge commit.

## Changes since v0.7.0
- Homebrew tap CI is now sourced from the monorepo and pushed to the tap on release (#241)
- Update starlight-llms-txt (#242)

## Pre-release gates
- CLI reference drift: **no drift**.
- Changelog assess: all merged PRs since v0.7.0 recorded.

## After merge
Cut + push a signed `v0.7.1` tag on the merge commit, triggering `release.yml`. This is the **first release exercising the monorepo→tap CI sync** (#241) — I'll watch it to confirm the sync step pushes cleanly.