### PR TITLE
release: v0.7.2

### DIFF
--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -13,6 +13,16 @@ _Unreleased_
 
 ---
 
+## v0.7.2
+
+_July 4, 2026_
+
+### Other
+
+- Maintenance release; no functional changes since v0.7.1
+
+---
+
 ## v0.7.1
 
 _July 4, 2026_


### PR DESCRIPTION
Maintenance release — no functional changes since v0.7.1. Cut to verify the release pipeline runs cleanly end-to-end (v0.7.1's run was cosmetically red from a transient GitHub Pages flake, since resolved).

Stamps the changelog for **v0.7.2**; merge, then the signed tag is cut on the merge commit.

## Gates
- CLI reference drift: no drift.
- Changelog assess: Upcoming covers everything since v0.7.1 (which is nothing — maintenance bump).