### PR TITLE
ci: pin pnpm to 11.11.0 in website workflows

### DIFF
--- a/.github/workflows/ci-website.yml
+++ b/.github/workflows/ci-website.yml
@@ -35,7 +35,8 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
         with:
-          version: 11
+          # Exact pin: the action's bundled pnpm crashes self-updating to 11.12.0
+          version: 11.11.0
 
       - name: Install dependencies
         run: make install

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -42,7 +42,8 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271  # v6.0.9
         with:
-          version: 11
+          # Exact pin: the action's bundled pnpm crashes self-updating to 11.12.0
+          version: 11.11.0
 
       - name: Install dependencies
         run: make install

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -11,6 +11,10 @@ All notable changes to dotsecenv are documented here. Each version includes chan
 
 _Unreleased_
 
+### Other
+
+- Pin pnpm to 11.11.0 in the website CI workflows; pnpm 11.12.0 breaks the setup action's self-update (#254)
+
 ---
 
 ## v0.7.2


### PR DESCRIPTION
## Summary

`pnpm/action-setup` resolves `version: 11` to the latest 11.x. Since pnpm 11.12.0 was published, the action's bundled pnpm 11.7.0 crashes while self-updating to it:

```
Cannot use 'in' operator to search for 'integrity' in undefined
    at createFullPkgId (.../pnpm.mjs:154891)
    at lockfileToDepGraph ...
    at installPnpmToGlobalDir ...
```

This broke `ci-website` on main (both runs since July 12) and on every open Renovate PR, including #246. Reproduced locally: `pnpm self-update 11.12.0` from 11.7.0 crashes identically; `self-update 11.11.0` succeeds.

## Changes

- Pin `pnpm/action-setup` to exact `version: 11.11.0` in `ci-website.yml` and `deploy-website.yml`, with a comment explaining the pin.
- Changelog entry under Upcoming.

Once merged, re-running checks on the open Renovate PRs picks up the fixed workflow via the merge ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)