### PR TITLE
feat(contrib): add git-credential-dotsecenv credential helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,14 @@ name: CI
 #   test (matrix) ─┐
 #                  ├─► e2e (matrix)
 #                  ├─► e2e-terraform
-#   build-docs ────┤
+#   build-docs ────┤─► e2e-git-credential
 #                  ├─► e2e-action-default-args
 #                  └─► e2e-action-init-config
 #
 # `test` and `build-docs` are the two roots — both fast, both build the
 # binary, and they run in parallel so the slower of the two sets the
 # critical path's first stage. Everything downstream gates on BOTH.
-# Single-os (ubuntu) jobs: e2e-terraform, e2e-action-*, build-docs.
+# Single-os (ubuntu) jobs: e2e-terraform, e2e-git-credential, e2e-action-*, build-docs.
 # Matrix (ubuntu+macos): test, e2e.
 #
 # Scoped to Go-related changes via `paths:` allowlist below — touches to
@@ -176,6 +176,20 @@ jobs:
       - run: terraform version
 
       - run: make build e2e-terraform
+
+  e2e-git-credential:
+    name: E2E Git Credential Helper
+    needs: [test, build-docs]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+        with:
+          go-version-file: "go.mod"
+          cache-dependency-path: "go.sum"
+
+      - run: make build e2e-git-credential
 
   e2e-action-default-args:
     name: E2E Action default-args

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,8 @@ name: CI
 #   test (matrix) ─┐
 #                  ├─► e2e (matrix)
 #                  ├─► e2e-terraform
-#   build-docs ────┤─► e2e-git-credential
+#                  ├─► e2e-git-credential
+#   build-docs ────┤
 #                  ├─► e2e-action-default-args
 #                  └─► e2e-action-init-config
 #

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -146,6 +146,8 @@ nfpms:
       - gnupg
     suggests:
       - bash-completion
+      # jq is required by the bundled git-credential-dotsecenv helper
+      - jq
     rpm:
       packager: DotSecEnv <release@dotsecenv.com>
       signature:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -174,6 +174,11 @@ nfpms:
         dst: /usr/share/terraform/plugins/terraform-credentials-dotsecenv
         file_info:
           mode: 0755
+      # git resolves git-credential-* from PATH, so install into a PATH dir
+      - src: contrib/git-credential-dotsecenv
+        dst: /usr/bin/git-credential-dotsecenv
+        file_info:
+          mode: 0755
       - src: build/plugin/dotsecenv.plugin.zsh
         dst: /usr/share/dotsecenv/plugin/dotsecenv.plugin.zsh
       - src: build/plugin/dotsecenv.plugin.bash

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -85,7 +85,14 @@ homebrew_casks:
     # plugin/) to a stable path, mirroring the Linux packages'
     # /usr/share/dotsecenv/plugin/. HOMEBREW_PREFIX interpolates at cask
     # load time; artifact-declared files are removed on `brew uninstall`.
+    #
+    # The git credential helper needs a `binary` stanza, not an `artifact`:
+    # git resolves git-credential-* by searching PATH, and `binary` symlinks
+    # into HOMEBREW_PREFIX/bin, which brew relinks on upgrade. Without this the
+    # cask stages the helper into the version-scoped Caskroom and nothing puts
+    # it on PATH, so `credential.helper dotsecenv` never resolves.
     custom_block: |
+      binary "contrib/git-credential-dotsecenv"
       artifact "plugin/dotsecenv.plugin.zsh", target: "#{HOMEBREW_PREFIX}/share/dotsecenv/plugin/dotsecenv.plugin.zsh"
       artifact "plugin/dotsecenv.plugin.bash", target: "#{HOMEBREW_PREFIX}/share/dotsecenv/plugin/dotsecenv.plugin.bash"
       artifact "plugin/_dotsecenv_core.sh", target: "#{HOMEBREW_PREFIX}/share/dotsecenv/plugin/_dotsecenv_core.sh"

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ help:
 	@echo "  make test-race      - Run tests with race condition detection"
 	@echo "  make e2e            - Run end-to-end tests using bin/dotsecenv"
 	@echo "  make e2e-terraform  - Run Terraform credentials helper E2E tests"
+	@echo "  make e2e-git-credential - Run git credential helper E2E tests"
 	@echo "  make e2e-install    - Run install.sh E2E tests (requires network)"
 	@echo "  make sandbox        - Create an interactive sandbox environment"
 	@echo "  make demo           - Run demo recording in sandbox (requires asciinema)"
@@ -24,7 +25,7 @@ help:
 	@echo "  make install-tools  - Install all dev tools"
 
 .PHONY: all
-all: clean update build lint test test-race e2e e2e-terraform e2e-install completions docs man plugin
+all: clean update build lint test test-race e2e e2e-terraform e2e-git-credential e2e-install completions docs man plugin
 
 # Common ldflags for version info
 LDFLAGS := -X main.version=$$(git describe --tags --always --dirty) -X main.commit=$$(git rev-parse --short HEAD) -X main.date=$$(date -u +%Y-%m-%dT%H:%M:%SZ)
@@ -125,6 +126,30 @@ e2e-terraform:
 	bash ./e2e-terraform.sh && \
 	rm -rf "$$E2E_HOME" && \
 	echo "Terraform e2e tests passed, cleaned up $$E2E_HOME"
+
+# Git credential helper E2E tests
+# Requires bin/dotsecenv, contrib/, git, and jq to exist
+.PHONY: e2e-git-credential
+e2e-git-credential:
+	@echo "Running git credential helper e2e tests..."
+	@E2E_HOME=$$(mktemp -d) && \
+	mkdir -p "$$E2E_HOME/.gnupg" "$$E2E_HOME/.config" "$$E2E_HOME/.local/share" "$$E2E_HOME/.local/state" "$$E2E_HOME/.cache" "$$E2E_HOME/bin" "$$E2E_HOME/contrib" && \
+	chmod 700 "$$E2E_HOME/.gnupg" && \
+	cp bin/dotsecenv "$$E2E_HOME/bin/" && \
+	cp contrib/git-credential-dotsecenv "$$E2E_HOME/contrib/" && \
+	cp scripts/e2e-git-credential.sh "$$E2E_HOME/" && \
+	echo "E2E environment: $$E2E_HOME" && \
+	cd "$$E2E_HOME" && \
+	HOME="$$E2E_HOME" \
+	PATH="$$E2E_HOME/bin:$$PATH" \
+	GNUPGHOME="$$E2E_HOME/.gnupg" \
+	XDG_CONFIG_HOME="$$E2E_HOME/.config" \
+	XDG_DATA_HOME="$$E2E_HOME/.local/share" \
+	XDG_STATE_HOME="$$E2E_HOME/.local/state" \
+	XDG_CACHE_HOME="$$E2E_HOME/.cache" \
+	bash ./e2e-git-credential.sh && \
+	rm -rf "$$E2E_HOME" && \
+	echo "Git credential e2e tests passed, cleaned up $$E2E_HOME"
 
 # Install script E2E tests (requires network)
 .PHONY: e2e-install

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ e2e-terraform:
 	echo "Terraform e2e tests passed, cleaned up $$E2E_HOME"
 
 # Git credential helper E2E tests
-# Requires bin/dotsecenv, contrib/, git, and jq to exist
+# Requires bin/dotsecenv, contrib/, gpg, and jq to exist
 .PHONY: e2e-git-credential
 e2e-git-credential:
 	@echo "Running git credential helper e2e tests..."

--- a/contrib/git-credential-dotsecenv
+++ b/contrib/git-credential-dotsecenv
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# git-credential-dotsecenv — git credential helper backed by the dotsecenv vault
+# https://git-scm.com/docs/gitcredentials  https://git-scm.com/docs/git-credential
+#
+# Stores git credentials as GPG-encrypted secrets in your dotsecenv vault instead
+# of plaintext ~/.git-credentials or the OS keychain. Because it preserves git's
+# oauth_refresh_token and password_expiry_utc fields, it also works as the storage
+# helper behind an OAuth generator (git-credential-oauth), so no long-lived token
+# is written to disk.
+#
+# Requires: dotsecenv (logged in) and jq.
+#
+# Mode 1 — store a token/PAT encrypted:
+#   git config --global credential.helper dotsecenv
+#
+# Mode 2 — OAuth, no stored PAT (generator must be configured LAST):
+#   git config --global --unset-all credential.helper
+#   git config --global --add credential.helper dotsecenv
+#   git config --global --add credential.helper oauth   # git-credential-oauth
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+  echo "usage: git-credential-dotsecenv <get|store|erase>" >&2
+  exit 1
+fi
+op="${*: -1}"
+
+# --- Parse git's key=value attributes from stdin (terminated by a blank line). ---
+# Kept in parallel indexed arrays for bash 3.2 compatibility (no associative arrays).
+keys=()
+vals=()
+proto=""
+host=""
+reqpath=""
+while IFS= read -r line; do
+  if [ -z "$line" ]; then
+    break
+  fi
+  case "$line" in
+    *=*) : ;;
+    *) continue ;;
+  esac
+  k=${line%%=*}
+  v=${line#*=}
+  case "$k" in
+    protocol) proto=$v ;;
+    host) host=$v ;;
+    path) reqpath=$v ;;
+  esac
+  keys+=("$k")
+  vals+=("$v")
+done
+
+# Nothing to key on — stay silent so git falls through to the next helper / prompt.
+if [ -z "$host" ]; then
+  exit 0
+fi
+
+# --- Derive a dotsecenv-safe, dot-free secret key from protocol/host[/path]. ---
+# dotsecenv key names allow only [A-Z0-9_.] and reject dots at the edges, hyphens,
+# colons, leading digits, and all-numeric names. Encode structural characters
+# explicitly and let the protocol prefix guarantee a leading letter.
+encode_key() {
+  printf '%s' "$1" \
+    | LC_ALL=C sed -e 's/\./_DOT_/g' -e 's#/#_SLASH_#g' -e 's/-/_DASH_/g' -e 's/:/_COLON_/g' -e 's/[^A-Za-z0-9_]/_/g' \
+    | LC_ALL=C tr '[:lower:]' '[:upper:]' \
+    | LC_ALL=C sed -E 's/_{3,}/__/g; s/^_+//; s/_+$//'
+}
+[ -z "$proto" ] && proto="https"
+ctx="$proto/$host"
+[ -n "$reqpath" ] && ctx="$ctx/$reqpath"   # included only when git sends path (credential.useHttpPath)
+# Multi-account (off by default): uncomment to scope the key by username.
+# username=""; i=0; while [ "$i" -lt "${#keys[@]}" ]; do [ "${keys[$i]}" = "username" ] && username="${vals[$i]}"; i=$((i+1)); done
+# [ -n "$username" ] && ctx="$ctx/$username"
+key="git::$(encode_key "$ctx")"
+
+case "$op" in
+  get)
+    # Return the stored JSON credential as git key=value lines. Any failure
+    # (jq missing, not logged in, not found, GPG error) → print nothing, exit 0
+    # so git prompts or tries the next helper.
+    command -v jq >/dev/null 2>&1 || exit 0
+    json=$(dotsecenv secret get "$key" 2>/dev/null) || exit 0
+    if [ -n "$json" ]; then
+      printf '%s' "$json" | jq -r 'to_entries[] | "\(.key)=\(.value)"' 2>/dev/null || exit 0
+    fi
+    exit 0
+    ;;
+
+  store)
+    # Persist every credential-bearing field git sent (username, password,
+    # password_expiry_utc, oauth_refresh_token, and any future scalar) as one
+    # JSON object. Preserving the OAuth fields is what lets git refresh tokens
+    # through a generator helper with dotsecenv as the encrypted store.
+    command -v jq >/dev/null 2>&1 || { echo "git-credential-dotsecenv: jq is required for store" >&2; exit 1; }
+    json_args=()
+    i=0
+    n=${#keys[@]}
+    while [ "$i" -lt "$n" ]; do
+      k=${keys[$i]}
+      v=${vals[$i]}
+      i=$((i+1))
+      case "$k" in
+        protocol|host|path|url) continue ;;   # routing/context, not a credential
+        *'[]') continue ;;                     # multi-valued protocol fields (wwwauth[], capability[], state[])
+      esac
+      json_args+=(--arg "$k" "$v")
+    done
+    if [ "${#json_args[@]}" -eq 0 ]; then
+      exit 0
+    fi
+    jq -cn "${json_args[@]}" '$ARGS.named' | dotsecenv secret store "$key" --json
+    ;;
+
+  erase)
+    # Idempotent: exit 0 even if the credential was never stored.
+    dotsecenv secret forget "$key" --ignore-not-found
+    ;;
+
+  *)
+    echo "git-credential-dotsecenv: unsupported operation '$op'" >&2
+    exit 1
+    ;;
+esac

--- a/contrib/git-credential-dotsecenv
+++ b/contrib/git-credential-dotsecenv
@@ -79,18 +79,15 @@ ctx="$proto/$host"
 # [ -n "$username" ] && ctx="$ctx/$username"
 key="git::$(encode_key "$ctx")"
 
-# --- Pin the vault: git credentials are user-scoped, never project-scoped. ---
-# A repo-local .dotsecenv/vault is meant to be committed, so a git token must
-# never land there. Without an explicit -v, `store` and `erase` abort with
-# "multiple vaults configured and no terminal available" in any repo that has
-# its own vault — and a failed `erase` leaves a revoked credential live.
-# Resolves the home vault the same way dotsecenv does (internal/xdg/xdg.go).
-# Set DOTSECENV_GIT_VAULT to key credentials off a different vault. If the
-# resolved vault does not exist, fall back to unpinned so a single-vault setup
-# at a custom path keeps working.
-git_vault="${DOTSECENV_GIT_VAULT:-${XDG_DATA_HOME:-$HOME/.local/share}/dotsecenv/vault}"
-vault_args=()
-[ -f "$git_vault" ] && vault_args=(-v "$git_vault")
+# --- Vault selection belongs to dotsecenv, driven by its configuration. ---
+# The default config lists the repo-local .dotsecenv/vault first, then the home
+# vault (internal/xdg/xdg.go), so inside a repo that carries a committed vault
+# the credential is stored there, encrypted to that vault's recipients — by
+# design. When more than one configured vault resolves, `store` and `erase`
+# open dotsecenv's vault picker on /dev/tty, and fail with "multiple vaults
+# configured and no terminal available" when there is none (GUI clients, CI).
+# To keep git credentials in a separate setup, point the CLI's own
+# DOTSECENV_CONFIG env var at an alternate config file.
 
 case "$op" in
   get)
@@ -98,7 +95,7 @@ case "$op" in
     # (jq missing, not logged in, not found, GPG error) → print nothing, exit 0
     # so git prompts or tries the next helper.
     command -v jq >/dev/null 2>&1 || exit 0
-    json=$(dotsecenv secret get ${vault_args[@]+"${vault_args[@]}"} "$key" 2>/dev/null) || exit 0
+    json=$(dotsecenv secret get "$key" 2>/dev/null) || exit 0
     if [ -n "$json" ]; then
       printf '%s' "$json" | jq -r 'to_entries[] | "\(.key)=\(.value)"' 2>/dev/null || exit 0
     fi
@@ -134,12 +131,12 @@ case "$op" in
     # stdin parser above already relies on.
     printf '%s\n' "${kv[@]}" \
       | jq -cRn '[inputs] as $a | reduce range(0; ($a|length); 2) as $i ({}; .[$a[$i]] = $a[$i+1])' \
-      | dotsecenv secret store ${vault_args[@]+"${vault_args[@]}"} "$key" --json
+      | dotsecenv secret store "$key" --json
     ;;
 
   erase)
     # Idempotent: exit 0 even if the credential was never stored.
-    dotsecenv secret forget ${vault_args[@]+"${vault_args[@]}"} "$key" --ignore-not-found
+    dotsecenv secret forget "$key" --ignore-not-found
     ;;
 
   *)

--- a/contrib/git-credential-dotsecenv
+++ b/contrib/git-credential-dotsecenv
@@ -61,7 +61,9 @@ fi
 
 # --- Derive a dotsecenv-safe, dot-free secret key from protocol/host[/path]. ---
 # dotsecenv key names allow only [A-Z0-9_.] and reject dots at the edges, hyphens,
-# colons, leading digits, and all-numeric names. Encode structural characters
+# colons, leading digits, all-numeric names, a trailing underscore, and runs of 3+
+# underscores (pkg/dotsecenv/vault/secretkey.go). A colon is legal only as the
+# `git::` namespace separator, never inside the name. Encode structural characters
 # explicitly and let the protocol prefix guarantee a leading letter.
 encode_key() {
   printf '%s' "$1" \
@@ -96,7 +98,7 @@ case "$op" in
     # JSON object. Preserving the OAuth fields is what lets git refresh tokens
     # through a generator helper with dotsecenv as the encrypted store.
     command -v jq >/dev/null 2>&1 || { echo "git-credential-dotsecenv: jq is required for store" >&2; exit 1; }
-    json_args=()
+    kv=()
     i=0
     n=${#keys[@]}
     while [ "$i" -lt "$n" ]; do
@@ -107,12 +109,19 @@ case "$op" in
         protocol|host|path|url) continue ;;   # routing/context, not a credential
         *'[]') continue ;;                     # multi-valued protocol fields (wwwauth[], capability[], state[])
       esac
-      json_args+=(--arg "$k" "$v")
+      kv+=("$k" "$v")
     done
-    if [ "${#json_args[@]}" -eq 0 ]; then
+    if [ "${#kv[@]}" -eq 0 ]; then
       exit 0
     fi
-    jq -cn "${json_args[@]}" '$ARGS.named' | dotsecenv secret store "$key" --json
+    # Pairs go to jq over stdin, never as --arg: a process argument vector is
+    # readable by other local processes (ps, /proc/PID/cmdline) for the lifetime
+    # of the call, and these values are the credential. Git's protocol is
+    # line-based, so values never contain newlines — the same guarantee the
+    # stdin parser above already relies on.
+    printf '%s\n' "${kv[@]}" \
+      | jq -cRn '[inputs] as $a | reduce range(0; ($a|length); 2) as $i ({}; .[$a[$i]] = $a[$i+1])' \
+      | dotsecenv secret store "$key" --json
     ;;
 
   erase)

--- a/contrib/git-credential-dotsecenv
+++ b/contrib/git-credential-dotsecenv
@@ -79,13 +79,26 @@ ctx="$proto/$host"
 # [ -n "$username" ] && ctx="$ctx/$username"
 key="git::$(encode_key "$ctx")"
 
+# --- Pin the vault: git credentials are user-scoped, never project-scoped. ---
+# A repo-local .dotsecenv/vault is meant to be committed, so a git token must
+# never land there. Without an explicit -v, `store` and `erase` abort with
+# "multiple vaults configured and no terminal available" in any repo that has
+# its own vault — and a failed `erase` leaves a revoked credential live.
+# Resolves the home vault the same way dotsecenv does (internal/xdg/xdg.go).
+# Set DOTSECENV_GIT_VAULT to key credentials off a different vault. If the
+# resolved vault does not exist, fall back to unpinned so a single-vault setup
+# at a custom path keeps working.
+git_vault="${DOTSECENV_GIT_VAULT:-${XDG_DATA_HOME:-$HOME/.local/share}/dotsecenv/vault}"
+vault_args=()
+[ -f "$git_vault" ] && vault_args=(-v "$git_vault")
+
 case "$op" in
   get)
     # Return the stored JSON credential as git key=value lines. Any failure
     # (jq missing, not logged in, not found, GPG error) → print nothing, exit 0
     # so git prompts or tries the next helper.
     command -v jq >/dev/null 2>&1 || exit 0
-    json=$(dotsecenv secret get "$key" 2>/dev/null) || exit 0
+    json=$(dotsecenv secret get ${vault_args[@]+"${vault_args[@]}"} "$key" 2>/dev/null) || exit 0
     if [ -n "$json" ]; then
       printf '%s' "$json" | jq -r 'to_entries[] | "\(.key)=\(.value)"' 2>/dev/null || exit 0
     fi
@@ -121,12 +134,12 @@ case "$op" in
     # stdin parser above already relies on.
     printf '%s\n' "${kv[@]}" \
       | jq -cRn '[inputs] as $a | reduce range(0; ($a|length); 2) as $i ({}; .[$a[$i]] = $a[$i+1])' \
-      | dotsecenv secret store "$key" --json
+      | dotsecenv secret store ${vault_args[@]+"${vault_args[@]}"} "$key" --json
     ;;
 
   erase)
     # Idempotent: exit 0 even if the credential was never stored.
-    dotsecenv secret forget "$key" --ignore-not-found
+    dotsecenv secret forget ${vault_args[@]+"${vault_args[@]}"} "$key" --ignore-not-found
     ;;
 
   *)

--- a/contrib/git-credential-dotsecenv
+++ b/contrib/git-credential-dotsecenv
@@ -23,6 +23,9 @@ if [ "$#" -lt 1 ]; then
   echo "usage: git-credential-dotsecenv <get|store|erase>" >&2
   exit 1
 fi
+# Git appends the operation LAST, after any arguments baked into the helper string
+# (`credential.helper = "dotsecenv --foo"` runs `... --foo get`), so $1 is not it.
+# With @ or * as the parameter, ${*: -1} slices positional params, not characters.
 op="${*: -1}"
 
 # --- Parse git's key=value attributes from stdin (terminated by a blank line). ---

--- a/scripts/e2e-git-credential.sh
+++ b/scripts/e2e-git-credential.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+# e2e-git-credential.sh — E2E tests for the git credential helper
+# Assumes isolated environment (HOME, GNUPGHOME, XDG_*) set up by Makefile
+set -e
+
+BIN="bin/dotsecenv"
+HELPER="contrib/git-credential-dotsecenv"
+chmod +x "$BIN" "$HELPER"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required for the git credential helper e2e tests" >&2
+    exit 1
+fi
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+pass() { echo "  PASS: $*"; ((TESTS_PASSED++)) || true; }
+fail() { echo "  FAIL: $*"; ((TESTS_FAILED++)) || true; }
+
+echo "==> Generating test key"
+"$BIN" identity create --name "Git Cred Test" --email "git@test" --algo RSA4096 --no-passphrase
+
+echo "==> Initializing vault"
+mkdir -p "$XDG_DATA_HOME/dotsecenv"
+"$BIN" init config
+# Strip config to a single vault so the helper works without -v in non-TTY
+sed -i.bak '/^  - .dotsecenv\/vault$/d; /^  - \/var\/lib\/dotsecenv\/vault$/d' "$XDG_CONFIG_HOME/dotsecenv/config"
+rm -f "$XDG_CONFIG_HOME/dotsecenv/config.bak"
+"$BIN" init vault -v "$XDG_DATA_HOME/dotsecenv/vault"
+KEY=$(gpg --list-keys --with-colons git@test | awk -F: '/^fpr:/{print $10; exit}')
+"$BIN" login "$KEY"
+
+echo "==> Testing git credential helper"
+
+# Test 1: store then get round-trips username + password through the JSON layer
+((TESTS_RUN++)) || true
+printf 'protocol=https\nhost=gitlab.com\nusername=me\npassword=glpat-xxx\n\n' | "$HELPER" store 2>/dev/null
+get_out=$(printf 'protocol=https\nhost=gitlab.com\n\n' | "$HELPER" get 2>/dev/null)
+if echo "$get_out" | grep -q '^username=me$' && echo "$get_out" | grep -q '^password=glpat-xxx$'; then
+    pass "store then get round-trips username + password"
+else
+    fail "store/get round-trip failed, got: $get_out"
+fi
+
+# Test 2: get on a never-stored host prints nothing and exits 0
+((TESTS_RUN++)) || true
+get_out=$(printf 'protocol=https\nhost=never.stored.example\n\n' | "$HELPER" get 2>/dev/null); rc=$?
+if [ -z "$get_out" ] && [ "$rc" -eq 0 ]; then
+    pass "get on never-stored host is empty, exit 0"
+else
+    fail "get on never-stored host should be empty/exit0, got: '$get_out' rc=$rc"
+fi
+
+# Test 3: get degrades to empty/exit 0 when the environment has no login/config
+((TESTS_RUN++)) || true
+brokencfg=$(mktemp -d)
+get_out=$(printf 'protocol=https\nhost=gitlab.com\n\n' | XDG_CONFIG_HOME="$brokencfg" XDG_DATA_HOME="$brokencfg" "$HELPER" get 2>/dev/null); rc=$?
+if [ -z "$get_out" ] && [ "$rc" -eq 0 ]; then
+    pass "get with no login/config degrades to empty, exit 0"
+else
+    fail "get should degrade to empty/exit0, got: '$get_out' rc=$rc"
+fi
+rm -rf "$brokencfg"
+
+# Test 4: erase then get returns empty
+((TESTS_RUN++)) || true
+printf 'protocol=https\nhost=gitlab.com\n\n' | "$HELPER" erase 2>/dev/null
+get_out=$(printf 'protocol=https\nhost=gitlab.com\n\n' | "$HELPER" get 2>/dev/null)
+if [ -z "$get_out" ]; then
+    pass "erase then get returns empty"
+else
+    fail "get after erase should be empty, got: $get_out"
+fi
+
+# Test 5: erase on a never-stored host exits 0 (idempotent)
+((TESTS_RUN++)) || true
+if printf 'protocol=https\nhost=never.stored.example\n\n' | "$HELPER" erase 2>/dev/null; then
+    pass "erase on never-stored host exits 0"
+else
+    fail "erase on never-stored host should exit 0"
+fi
+
+# Test 6: hyphenated host round-trips (proves _DASH_ / _DOT_ encoding)
+((TESTS_RUN++)) || true
+h="git-codecommit.us-east-1.amazonaws.com"
+printf 'protocol=https\nhost=%s\nusername=u\npassword=p6\n\n' "$h" | "$HELPER" store 2>/dev/null
+get_out=$(printf 'protocol=https\nhost=%s\n\n' "$h" | "$HELPER" get 2>/dev/null)
+if echo "$get_out" | grep -q '^password=p6$'; then
+    pass "hyphenated host round-trips"
+else
+    fail "hyphenated host failed, got: $get_out"
+fi
+
+# Test 7: host with port round-trips (proves _COLON_ encoding)
+((TESTS_RUN++)) || true
+printf 'protocol=https\nhost=example.com:8080\nusername=u\npassword=p7\n\n' | "$HELPER" store 2>/dev/null
+get_out=$(printf 'protocol=https\nhost=example.com:8080\n\n' | "$HELPER" get 2>/dev/null)
+if echo "$get_out" | grep -q '^password=p7$'; then
+    pass "host with port round-trips"
+else
+    fail "host with port failed, got: $get_out"
+fi
+
+# Test 8: IP-address host round-trips (proves protocol prefix + dot-free encoding)
+((TESTS_RUN++)) || true
+printf 'protocol=https\nhost=192.168.1.1\nusername=u\npassword=p8\n\n' | "$HELPER" store 2>/dev/null
+get_out=$(printf 'protocol=https\nhost=192.168.1.1\n\n' | "$HELPER" get 2>/dev/null)
+if echo "$get_out" | grep -q '^password=p8$'; then
+    pass "IP-address host round-trips"
+else
+    fail "IP-address host failed, got: $get_out"
+fi
+
+# Test 9: OAuth fields are preserved (Mode 2 contract)
+((TESTS_RUN++)) || true
+printf 'protocol=https\nhost=oauth.example\nusername=oauth2\npassword=at123\npassword_expiry_utc=1799999999\noauth_refresh_token=rt456\n\n' | "$HELPER" store 2>/dev/null
+get_out=$(printf 'protocol=https\nhost=oauth.example\n\n' | "$HELPER" get 2>/dev/null)
+if echo "$get_out" | grep -q '^oauth_refresh_token=rt456$' && echo "$get_out" | grep -q '^password_expiry_utc=1799999999$'; then
+    pass "OAuth refresh token + expiry preserved"
+else
+    fail "OAuth fields not preserved, got: $get_out"
+fi
+
+# Test 10: stored secret names are dot-free (encoded)
+((TESTS_RUN++)) || true
+key_list=$("$BIN" secret get 2>/dev/null || true)
+if echo "$key_list" | grep -qi 'HTTPS_SLASH_GITLAB_DOT_COM' && ! echo "$key_list" | grep -qi 'GITLAB\.COM'; then
+    pass "secret names are dot-free (encoded)"
+else
+    fail "expected encoded dot-free key, got keys: $key_list"
+fi
+
+# Test 11: store with no credential fields (host only) stores nothing, exit 0
+((TESTS_RUN++)) || true
+printf 'protocol=https\nhost=empty.example\n\n' | "$HELPER" store 2>/dev/null; rc=$?
+get_out=$(printf 'protocol=https\nhost=empty.example\n\n' | "$HELPER" get 2>/dev/null)
+if [ "$rc" -eq 0 ] && [ -z "$get_out" ]; then
+    pass "store with no fields stores nothing, exit 0"
+else
+    fail "empty store should be a no-op, rc=$rc get='$get_out'"
+fi
+
+# Test 12: unsupported operation exits non-zero
+((TESTS_RUN++)) || true
+if printf 'protocol=https\nhost=gitlab.com\n\n' | "$HELPER" bogus 2>/dev/null; then
+    fail "unsupported operation should exit non-zero"
+else
+    pass "unsupported operation exits non-zero"
+fi
+
+echo ""
+echo "==> Git credential helper E2E results"
+echo "Tests run:    $TESTS_RUN"
+echo "Tests passed: $TESTS_PASSED"
+echo "Tests failed: $TESTS_FAILED"
+
+if [ "$TESTS_FAILED" -gt 0 ]; then
+    exit 1
+fi
+echo "==> All tests passed"

--- a/scripts/e2e-git-credential.sh
+++ b/scripts/e2e-git-credential.sh
@@ -26,7 +26,7 @@ echo "==> Initializing vault"
 mkdir -p "$XDG_DATA_HOME/dotsecenv"
 "$BIN" init config
 # Strip config to a single vault so the helper works without -v in non-TTY
-sed -i.bak '/^  - .dotsecenv\/vault$/d; /^  - \/var\/lib\/dotsecenv\/vault$/d' "$XDG_CONFIG_HOME/dotsecenv/config"
+sed -i.bak '/^  - \.dotsecenv\/vault$/d; /^  - \/var\/lib\/dotsecenv\/vault$/d' "$XDG_CONFIG_HOME/dotsecenv/config"
 rm -f "$XDG_CONFIG_HOME/dotsecenv/config.bak"
 "$BIN" init vault -v "$XDG_DATA_HOME/dotsecenv/vault"
 KEY=$(gpg --list-keys --with-colons git@test | awk -F: '/^fpr:/{print $10; exit}')

--- a/scripts/e2e-git-credential.sh
+++ b/scripts/e2e-git-credential.sh
@@ -25,8 +25,9 @@ echo "==> Generating test key"
 echo "==> Initializing vault"
 mkdir -p "$XDG_DATA_HOME/dotsecenv"
 "$BIN" init config
-# Deliberately keep the default multi-vault config: the helper must pin the home
-# vault itself. Stripping the config here would hide the regression test 13 covers.
+# Keep the config exactly as `init config` writes it (repo-local
+# .dotsecenv/vault first, then the home vault): the helper leans on dotsecenv's
+# own vault resolution, and test 13 exercises the repo-vault half of it.
 "$BIN" init vault -v "$XDG_DATA_HOME/dotsecenv/vault"
 KEY=$(gpg --list-keys --with-colons git@test | awk -F: '/^fpr:/{print $10; exit}')
 "$BIN" login "$KEY"
@@ -45,7 +46,8 @@ fi
 
 # Test 2: get on a never-stored host prints nothing and exits 0
 ((TESTS_RUN++)) || true
-get_out=$(printf 'protocol=https\nhost=never.stored.example\n\n' | "$HELPER" get 2>/dev/null); rc=$?
+rc=0
+get_out=$(printf 'protocol=https\nhost=never.stored.example\n\n' | "$HELPER" get 2>/dev/null) || rc=$?
 if [ -z "$get_out" ] && [ "$rc" -eq 0 ]; then
     pass "get on never-stored host is empty, exit 0"
 else
@@ -55,7 +57,8 @@ fi
 # Test 3: get degrades to empty/exit 0 when the environment has no login/config
 ((TESTS_RUN++)) || true
 brokencfg=$(mktemp -d)
-get_out=$(printf 'protocol=https\nhost=gitlab.com\n\n' | XDG_CONFIG_HOME="$brokencfg" XDG_DATA_HOME="$brokencfg" "$HELPER" get 2>/dev/null); rc=$?
+rc=0
+get_out=$(printf 'protocol=https\nhost=gitlab.com\n\n' | XDG_CONFIG_HOME="$brokencfg" XDG_DATA_HOME="$brokencfg" "$HELPER" get 2>/dev/null) || rc=$?
 if [ -z "$get_out" ] && [ "$rc" -eq 0 ]; then
     pass "get with no login/config degrades to empty, exit 0"
 else
@@ -133,7 +136,8 @@ fi
 
 # Test 11: store with no credential fields (host only) stores nothing, exit 0
 ((TESTS_RUN++)) || true
-printf 'protocol=https\nhost=empty.example\n\n' | "$HELPER" store 2>/dev/null; rc=$?
+rc=0
+printf 'protocol=https\nhost=empty.example\n\n' | "$HELPER" store 2>/dev/null || rc=$?
 get_out=$(printf 'protocol=https\nhost=empty.example\n\n' | "$HELPER" get 2>/dev/null)
 if [ "$rc" -eq 0 ] && [ -z "$get_out" ]; then
     pass "store with no fields stores nothing, exit 0"
@@ -149,29 +153,50 @@ else
     pass "unsupported operation exits non-zero"
 fi
 
-# Test 13: a repo with its own committed vault must not break store/erase.
-# Without an explicit -v the helper aborts here with "multiple vaults configured
-# and no terminal available", and a failed erase leaves a revoked credential live.
+# Test 13: a repo-local committed vault is a first-class store target, by
+# design. Vault selection is dotsecenv's: with DOTSECENV_CONFIG pointing at a
+# config that resolves only the repo vault, the credential lands encrypted in
+# the repo's own .dotsecenv/vault and erase works the same way. (With several
+# resolvable vaults, store/erase use dotsecenv's interactive picker — not
+# testable without a TTY, and covered by the CLI's own tests.)
 ((TESTS_RUN++)) || true
 proj="$PWD/projrepo"
 mkdir -p "$proj"
 (cd "$proj" && "$OLDPWD/$BIN" init vault -v .dotsecenv/vault >/dev/null 2>&1)
+altcfg="$PWD/git-credentials-config"
+DOTSECENV_CONFIG="$altcfg" "$BIN" init config >/dev/null 2>&1
+grep -v "$XDG_DATA_HOME/dotsecenv/vault" "$altcfg" > "$altcfg.tmp" && mv "$altcfg.tmp" "$altcfg"
+(cd "$proj" && DOTSECENV_CONFIG="$altcfg" "$OLDPWD/$BIN" login "$KEY" >/dev/null 2>&1)
 h="proj.example"
 store_rc=0
 (cd "$proj" && printf 'protocol=https\nhost=%s\nusername=me\npassword=pv-1\n\n' "$h" \
-    | "$OLDPWD/$HELPER" store) >/dev/null 2>&1 || store_rc=$?
-proj_get=$(cd "$proj" && printf 'protocol=https\nhost=%s\n\n' "$h" | "$OLDPWD/$HELPER" get 2>/dev/null || true)
+    | DOTSECENV_CONFIG="$altcfg" "$OLDPWD/$HELPER" store) >/dev/null 2>&1 || store_rc=$?
+proj_get=$(cd "$proj" && printf 'protocol=https\nhost=%s\n\n' "$h" | DOTSECENV_CONFIG="$altcfg" "$OLDPWD/$HELPER" get 2>/dev/null || true)
+in_repo_vault=0
+grep -q 'HTTPS_SLASH_PROJ' "$proj/.dotsecenv/vault" 2>/dev/null && in_repo_vault=1
 erase_rc=0
-(cd "$proj" && printf 'protocol=https\nhost=%s\n\n' "$h" | "$OLDPWD/$HELPER" erase) >/dev/null 2>&1 || erase_rc=$?
-after_erase=$(cd "$proj" && printf 'protocol=https\nhost=%s\n\n' "$h" | "$OLDPWD/$HELPER" get 2>/dev/null || true)
-# The token must never be written into the committable project vault.
-leaked=0
-grep -q 'HTTPS_SLASH_PROJ' "$proj/.dotsecenv/vault" 2>/dev/null && leaked=1
+(cd "$proj" && printf 'protocol=https\nhost=%s\n\n' "$h" | DOTSECENV_CONFIG="$altcfg" "$OLDPWD/$HELPER" erase) >/dev/null 2>&1 || erase_rc=$?
+after_erase=$(cd "$proj" && printf 'protocol=https\nhost=%s\n\n' "$h" | DOTSECENV_CONFIG="$altcfg" "$OLDPWD/$HELPER" get 2>/dev/null || true)
 if [ "$store_rc" -eq 0 ] && echo "$proj_get" | grep -q 'password=pv-1' \
-    && [ "$erase_rc" -eq 0 ] && [ -z "$after_erase" ] && [ "$leaked" -eq 0 ]; then
-    pass "store/get/erase work in a repo that has its own vault"
+    && [ "$in_repo_vault" -eq 1 ] && [ "$erase_rc" -eq 0 ] && [ -z "$after_erase" ]; then
+    pass "repo-local vault is the store target via DOTSECENV_CONFIG"
 else
-    fail "repo-local vault broke the helper: store_rc=$store_rc get='$proj_get' erase_rc=$erase_rc after_erase='$after_erase' leaked=$leaked"
+    fail "repo-vault workflow failed: store_rc=$store_rc get='$proj_get' in_repo_vault=$in_repo_vault erase_rc=$erase_rc after_erase='$after_erase'"
+fi
+
+# Test 14: contrived hosts that encode to the same key collide, by design.
+# a_-b → A__DASH_B and a__-b → A___DASH_B → collapses to A__DASH_B; c.example_
+# ends in a stripped underscore, so it lands on c.example's key. Real DNS
+# hostnames cannot contain '_', so the collision is accepted, not fixed.
+((TESTS_RUN++)) || true
+printf 'protocol=https\nhost=a_-b.example\nusername=u\npassword=p14a\n\n' | "$HELPER" store 2>/dev/null
+collide_a=$(printf 'protocol=https\nhost=a__-b.example\n\n' | "$HELPER" get 2>/dev/null)
+printf 'protocol=https\nhost=c.example_\nusername=u\npassword=p14b\n\n' | "$HELPER" store 2>/dev/null
+collide_b=$(printf 'protocol=https\nhost=c.example\n\n' | "$HELPER" get 2>/dev/null)
+if echo "$collide_a" | grep -q '^password=p14a$' && echo "$collide_b" | grep -q '^password=p14b$'; then
+    pass "contrived underscore hosts collapse to the same key"
+else
+    fail "expected key collisions, got: collapse='$collide_a' edge-strip='$collide_b'"
 fi
 
 echo ""

--- a/scripts/e2e-git-credential.sh
+++ b/scripts/e2e-git-credential.sh
@@ -25,9 +25,8 @@ echo "==> Generating test key"
 echo "==> Initializing vault"
 mkdir -p "$XDG_DATA_HOME/dotsecenv"
 "$BIN" init config
-# Strip config to a single vault so the helper works without -v in non-TTY
-sed -i.bak '/^  - \.dotsecenv\/vault$/d; /^  - \/var\/lib\/dotsecenv\/vault$/d' "$XDG_CONFIG_HOME/dotsecenv/config"
-rm -f "$XDG_CONFIG_HOME/dotsecenv/config.bak"
+# Deliberately keep the default multi-vault config: the helper must pin the home
+# vault itself. Stripping the config here would hide the regression test 13 covers.
 "$BIN" init vault -v "$XDG_DATA_HOME/dotsecenv/vault"
 KEY=$(gpg --list-keys --with-colons git@test | awk -F: '/^fpr:/{print $10; exit}')
 "$BIN" login "$KEY"
@@ -148,6 +147,31 @@ if printf 'protocol=https\nhost=gitlab.com\n\n' | "$HELPER" bogus 2>/dev/null; t
     fail "unsupported operation should exit non-zero"
 else
     pass "unsupported operation exits non-zero"
+fi
+
+# Test 13: a repo with its own committed vault must not break store/erase.
+# Without an explicit -v the helper aborts here with "multiple vaults configured
+# and no terminal available", and a failed erase leaves a revoked credential live.
+((TESTS_RUN++)) || true
+proj="$PWD/projrepo"
+mkdir -p "$proj"
+(cd "$proj" && "$OLDPWD/$BIN" init vault -v .dotsecenv/vault >/dev/null 2>&1)
+h="proj.example"
+store_rc=0
+(cd "$proj" && printf 'protocol=https\nhost=%s\nusername=me\npassword=pv-1\n\n' "$h" \
+    | "$OLDPWD/$HELPER" store) >/dev/null 2>&1 || store_rc=$?
+proj_get=$(cd "$proj" && printf 'protocol=https\nhost=%s\n\n' "$h" | "$OLDPWD/$HELPER" get 2>/dev/null || true)
+erase_rc=0
+(cd "$proj" && printf 'protocol=https\nhost=%s\n\n' "$h" | "$OLDPWD/$HELPER" erase) >/dev/null 2>&1 || erase_rc=$?
+after_erase=$(cd "$proj" && printf 'protocol=https\nhost=%s\n\n' "$h" | "$OLDPWD/$HELPER" get 2>/dev/null || true)
+# The token must never be written into the committable project vault.
+leaked=0
+grep -q 'HTTPS_SLASH_PROJ' "$proj/.dotsecenv/vault" 2>/dev/null && leaked=1
+if [ "$store_rc" -eq 0 ] && echo "$proj_get" | grep -q 'password=pv-1' \
+    && [ "$erase_rc" -eq 0 ] && [ -z "$after_erase" ] && [ "$leaked" -eq 0 ]; then
+    pass "store/get/erase work in a repo that has its own vault"
+else
+    fail "repo-local vault broke the helper: store_rc=$store_rc get='$proj_get' erase_rc=$erase_rc after_erase='$after_erase' leaked=$leaked"
 fi
 
 echo ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -45,6 +45,7 @@ VERSION="${VERSION:-latest}"
 INSTALL_DIR="${INSTALL_DIR:-}"
 INSTALL_SHELL_PLUGIN="${INSTALL_SHELL_PLUGIN:-1}"
 INSTALL_TF_CREDENTIALS_HELPER="${INSTALL_TF_CREDENTIALS_HELPER:-1}"
+INSTALL_GIT_CREDENTIALS_HELPER="${INSTALL_GIT_CREDENTIALS_HELPER:-1}"
 INSTALL_COMPLETIONS="${INSTALL_COMPLETIONS:-1}"
 INSTALL_MAN_PAGES="${INSTALL_MAN_PAGES:-1}"
 SYSTEM_INSTALL="${SYSTEM_INSTALL:-0}"
@@ -608,6 +609,40 @@ TFEOF
 }
 
 # ---------------------------------------------------------------------------
+# Git credential helper
+# ---------------------------------------------------------------------------
+install_git_credential_helper() {
+    local tmp_dir="$1"
+
+    info "Installing git credential helper..."
+
+    local helper_src="${tmp_dir}/contrib/git-credential-dotsecenv"
+    if [ ! -f "${helper_src}" ]; then
+        warn "Git credential helper not found in archive; skipping"
+        return 0
+    fi
+
+    # git resolves git-credential-* on PATH; install alongside the binary.
+    local dest="${INSTALL_DIR}/git-credential-dotsecenv"
+    if need_sudo "${INSTALL_DIR}" 2>/dev/null; then
+        maybe_sudo install -m 755 "${helper_src}" "${dest}"
+    else
+        install -m 755 "${helper_src}" "${dest}"
+    fi
+    success "Git credential helper installed to ${dest}"
+
+    printf "\n"
+    printf "${BLUE}==>${RESET} Enable it with:\n"
+    cat <<'GITEOF'
+
+    git config --global credential.helper dotsecenv
+
+GITEOF
+    printf "  Requires ${BOLD}jq${RESET}. For OAuth without a stored token, also add a\n"
+    printf "  generator such as git-credential-oauth (configured last).\n"
+}
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 print_summary() {
@@ -642,6 +677,7 @@ print_summary() {
         printf "  Shell plugin: ${plugin_summary_dir}/\n"
     fi
     [ "${INSTALL_TF_CREDENTIALS_HELPER}" = "1" ] && printf "  TF helper:    ${tf_dir}/\n"
+    [ "${INSTALL_GIT_CREDENTIALS_HELPER}" = "1" ] && printf "  Git helper:   ${INSTALL_DIR}/git-credential-dotsecenv\n"
     printf "\n"
     printf "  Get started:  ${BOLD}dotsecenv --help${RESET}\n"
     printf "\n"
@@ -669,6 +705,10 @@ parse_args() {
                 INSTALL_TF_CREDENTIALS_HELPER=1; shift ;;
             --no-install-tf-credentials-helper)
                 INSTALL_TF_CREDENTIALS_HELPER=0; shift ;;
+            --install-git-credentials-helper)
+                INSTALL_GIT_CREDENTIALS_HELPER=1; shift ;;
+            --no-install-git-credentials-helper)
+                INSTALL_GIT_CREDENTIALS_HELPER=0; shift ;;
             --install-completions)
                 INSTALL_COMPLETIONS=1; shift ;;
             --no-install-completions)
@@ -696,6 +736,7 @@ Options:
   --install-dir DIR                  Install binary to DIR (default: ~/.local/bin)
   --[no-]install-shell-plugin        Install shell plugin (default: yes)
   --[no-]install-tf-credentials-helper  Install Terraform helper (default: yes)
+  --[no-]install-git-credentials-helper Install git credential helper (default: yes)
   --[no-]install-completions         Install shell completions (default: yes)
   --[no-]install-man-pages           Install man pages (default: yes)
   --system                           Install system-wide (/usr/local/bin, shared
@@ -705,7 +746,8 @@ Options:
 
 Environment variables:
   VERSION, INSTALL_DIR, INSTALL_SHELL_PLUGIN, INSTALL_TF_CREDENTIALS_HELPER,
-  INSTALL_COMPLETIONS, INSTALL_MAN_PAGES, SYSTEM_INSTALL, VERIFY
+  INSTALL_GIT_CREDENTIALS_HELPER, INSTALL_COMPLETIONS, INSTALL_MAN_PAGES,
+  SYSTEM_INSTALL, VERIFY
 USAGE
                 exit 0
                 ;;
@@ -750,6 +792,10 @@ main() {
 
     if [ "${INSTALL_TF_CREDENTIALS_HELPER}" = "1" ]; then
         install_tf_helper "${tmp_dir}"
+    fi
+
+    if [ "${INSTALL_GIT_CREDENTIALS_HELPER}" = "1" ]; then
+        install_git_credential_helper "${tmp_dir}"
     fi
 
     print_summary

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -30,7 +30,7 @@ export default defineConfig({
           description:
             'Secure secrets management CLI that encrypts environment variables at rest using GPG, making them safe to commit to version control.',
           details:
-            'dotsecenv encrypts environment variables at rest using GPG and AES-256-GCM, storing them in vault files that are safe to commit to git. Documentation follows the Diataxis framework: Tutorials walk through tasks, Concepts explain the security model and architecture, Guides cover integrations (shell plugins, GitHub Actions, Terraform, Claude Code), and Reference documents the CLI surface.',
+            'dotsecenv encrypts environment variables at rest using GPG and AES-256-GCM, storing them in vault files that are safe to commit to git. Documentation follows the Diataxis framework: Tutorials walk through tasks, Concepts explain the security model and architecture, Guides cover integrations (shell plugins, GitHub Actions, Terraform, git credentials, Claude Code), and Reference documents the CLI surface.',
           // Surface index, getting-started, and the CLI reference at the top of llms.txt.
           promote: ['index*', 'getting-started*', 'reference*'],
           // Keep the blog out of the small/full bundles to save context budget.
@@ -52,7 +52,7 @@ export default defineConfig({
             {
               label: 'Guides',
               description:
-                'Integration guides: shell plugins, GitHub Action, Terraform credentials helper, Claude Code, plus the how-to lookup page.',
+                'Integration guides: shell plugins, GitHub Action, Terraform credentials helper, git credentials helper, Claude Code, plus the how-to lookup page.',
               paths: ['guides/**', 'how-to'],
             },
             {
@@ -201,6 +201,7 @@ export default defineConfig({
             { label: 'Shell Plugins', slug: 'guides/shell-plugins' },
             { label: 'GitHub Action', slug: 'guides/github-action' },
             { label: 'Terraform & OpenTofu', slug: 'guides/terraform-credentials-helper' },
+            { label: 'Git Credentials', slug: 'guides/git-credential-helper' },
             { label: 'Claude Code', slug: 'guides/claude-code' },
             { label: 'GPG Agent', slug: 'guides/gpg-agent' },
             { label: 'Multi-environment Vaults', slug: 'guides/multi-environment' },

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -14,7 +14,7 @@ _Unreleased_
 ### Features
 
 - The Homebrew cask now installs the zsh/bash/fish shell plugins to `$(brew --prefix)/share/dotsecenv/plugin/`, matching the Linux packages (#253)
-- Add `contrib/git-credential-dotsecenv`, a git credential helper that stores HTTPS credentials encrypted in your vault and preserves OAuth `oauth_refresh_token`/`password_expiry_utc` fields so it can back a generator like git-credential-oauth (no stored PAT) (#255)
+- Add `contrib/git-credential-dotsecenv`, a git credential helper that stores HTTPS credentials encrypted in your vault and preserves OAuth `oauth_refresh_token`/`password_expiry_utc` fields so it can back a generator like git-credential-oauth (no stored PAT); the deb/rpm/Arch packages and install.sh install it to a `PATH` directory (#255)
 
 ### Bug Fixes
 

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -14,6 +14,7 @@ _Unreleased_
 ### Features
 
 - The Homebrew cask now installs the zsh/bash/fish shell plugins to `$(brew --prefix)/share/dotsecenv/plugin/`, matching the Linux packages (#253)
+- Add `contrib/git-credential-dotsecenv`, a git credential helper that stores HTTPS credentials encrypted in your vault and preserves OAuth `oauth_refresh_token`/`password_expiry_utc` fields so it can back a generator like git-credential-oauth (no stored PAT)
 
 ### Bug Fixes
 

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -14,7 +14,7 @@ _Unreleased_
 ### Features
 
 - The Homebrew cask now installs the zsh/bash/fish shell plugins to `$(brew --prefix)/share/dotsecenv/plugin/`, matching the Linux packages (#253)
-- Add `contrib/git-credential-dotsecenv`, a git credential helper that stores HTTPS credentials encrypted in your vault and preserves OAuth `oauth_refresh_token`/`password_expiry_utc` fields so it can back a generator like git-credential-oauth (no stored PAT)
+- Add `contrib/git-credential-dotsecenv`, a git credential helper that stores HTTPS credentials encrypted in your vault and preserves OAuth `oauth_refresh_token`/`password_expiry_utc` fields so it can back a generator like git-credential-oauth (no stored PAT) (#255)
 
 ### Bug Fixes
 

--- a/website/src/content/docs/guides/git-credential-helper.mdx
+++ b/website/src/content/docs/guides/git-credential-helper.mdx
@@ -1,0 +1,161 @@
+---
+title: Git Credentials Helper
+description: Use dotsecenv as an encrypted credential store for git over HTTPS
+---
+
+import { Tabs, TabItem, Aside, Steps } from "@astrojs/starlight/components";
+
+<Aside type="note" title="Available in v0.8.0+">
+  The `git-credential-dotsecenv` helper ships in v0.8.0.
+</Aside>
+
+Use dotsecenv as a [git credential helper](https://git-scm.com/docs/gitcredentials). Tokens for HTTPS remotes are encrypted at rest in your vault instead of sitting in plaintext `~/.git-credentials` or the OS keychain.
+
+The same helper backs two workflows. In the first, git asks for a username and password once and dotsecenv keeps the token encrypted, a drop-in replacement for `credential.helper store` and `osxkeychain`. In the second, you pair it with a generator like [`git-credential-oauth`](https://github.com/hickford/git-credential-oauth): dotsecenv holds only the OAuth refresh token, git mints short-lived access tokens on demand, and no long-lived personal access token ever lands on disk.
+
+## How It Works
+
+git calls the helper with three operations and exchanges `key=value` attributes on stdin/stdout:
+
+| Operation | git sends            | dotsecenv behavior                                              |
+| --------- | -------------------- | -------------------------------------------------------------- |
+| `get`     | protocol, host, path | Returns the stored credential for that host, or nothing        |
+| `store`   | the full credential  | Saves every field as one encrypted JSON secret                 |
+| `erase`   | protocol, host, path | Marks the secret deleted (idempotent)                          |
+
+The helper derives the secret name from the request context. `https://gitlab.com` becomes the vault key `git::HTTPS_SLASH_GITLAB_DOT_COM`. Dots and other characters that git hosts carry but dotsecenv keys reject are encoded (`.` to `_DOT_`, `/` to `_SLASH_`, `-` to `_DASH_`, `:` to `_COLON_`), so hyphenated hosts, ports, and IP addresses all resolve to a valid key.
+
+Because `store` keeps every attribute git sends, the OAuth fields `oauth_refresh_token` and `password_expiry_utc` survive a round trip. That is all a generator helper needs to refresh an expired access token without a browser.
+
+## Prerequisites
+
+- dotsecenv installed and logged in, with at least one vault (see [Getting Started](/getting-started/))
+- [`jq`](https://jqlang.github.io/jq/) on your `PATH`
+- git with an HTTPS remote
+- For the OAuth workflow: a generator helper such as `git-credential-oauth`
+
+## Installation
+
+git looks for `git-credential-<name>` on your `PATH`, so the helper has to sit in a `PATH` directory.
+
+<Tabs>
+  <TabItem label="Linux (apt/rpm)">
+    The `git-credential-dotsecenv` helper is included in the deb, rpm, and Arch packages and installed to `/usr/bin/`.
+
+    Verify it's available:
+
+    ```bash
+    git-credential-dotsecenv 2>&1 | head -1
+    ```
+
+  </TabItem>
+
+  <TabItem label="macOS (Homebrew)">
+    After installing dotsecenv via Homebrew, the helper ships in the release archive. Symlink it onto your `PATH`:
+
+    ```bash
+    ln -s "$(brew --prefix dotsecenv)/contrib/git-credential-dotsecenv" \
+      "$(brew --prefix)/bin/git-credential-dotsecenv"
+    ```
+
+  </TabItem>
+
+  <TabItem label="Manual">
+    Copy the helper from `contrib/git-credential-dotsecenv` or download it, then place it in a `PATH` directory:
+
+    ```bash
+    BIN_DIR="${HOME}/.local/bin"   # any directory on your PATH
+    mkdir -p "$BIN_DIR"
+    curl -fsSL https://raw.githubusercontent.com/dotsecenv/dotsecenv/main/contrib/git-credential-dotsecenv \
+      -o "$BIN_DIR/git-credential-dotsecenv"
+    chmod +x "$BIN_DIR/git-credential-dotsecenv"
+    ```
+
+  </TabItem>
+</Tabs>
+
+## Configuration
+
+<Steps>
+
+1. **Verify the helper resolves**
+
+    git should find it under the short name `dotsecenv`:
+
+    ```bash
+    git credential-dotsecenv 2>&1 | head -1
+    # usage: git-credential-dotsecenv <get|store|erase>
+    ```
+
+2. **Pick a workflow**
+
+    <Tabs>
+
+    <TabItem label="Stored token">
+    Point git's credential helper at dotsecenv:
+
+    ```bash
+    git config --global credential.helper dotsecenv
+    ```
+
+    The next time git prompts for a password on an HTTPS remote, it hands the token to dotsecenv, which encrypts it in your vault.
+    </TabItem>
+
+    <TabItem label="OAuth (no stored token)">
+    Chain dotsecenv as the store with a generator that runs last:
+
+    ```bash
+    git config --global --unset-all credential.helper
+    git config --global --add credential.helper dotsecenv
+    git config --global --add credential.helper oauth
+    ```
+
+    On the first push, dotsecenv has nothing, so the generator runs an OAuth flow and git saves the access token, `oauth_refresh_token`, and `password_expiry_utc` through dotsecenv. Once the access token expires, git reads the refresh token back from dotsecenv, the generator mints a fresh access token, and git re-stores the rotated result.
+
+    <Aside type="note">
+      Self-managed GitLab and other forges need the generator pointed at their OAuth endpoints (client id, scopes, token URL). Configure that on the generator; dotsecenv only stores what git hands it. See the [git-credential-oauth](https://github.com/hickford/git-credential-oauth) docs.
+    </Aside>
+    </TabItem>
+
+    </Tabs>
+
+</Steps>
+
+## Usage
+
+git drives the helper on its own during `clone`, `fetch`, and `push`. You can also call it directly to debug or script:
+
+```bash
+# Store
+printf 'protocol=https\nhost=gitlab.com\nusername=me\npassword=glpat-xxx\n\n' \
+  | git-credential-dotsecenv store
+
+# Retrieve
+printf 'protocol=https\nhost=gitlab.com\n\n' | git-credential-dotsecenv get
+
+# Erase
+printf 'protocol=https\nhost=gitlab.com\n\n' | git-credential-dotsecenv erase
+```
+
+Confirm the secret landed in your vault:
+
+```bash
+dotsecenv secret get 'git::HTTPS_SLASH_GITLAB_DOT_COM' --json
+```
+
+## Troubleshooting
+
+| Problem                                          | Cause                              | Solution                                                                                                                                                     |
+| ------------------------------------------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| git prompts for a password every time            | Helper not found, or `get` failing | Check `git credential-dotsecenv` runs, that you ran `dotsecenv login`, and that `jq` is installed                                                            |
+| `jq is required for store`                       | `jq` missing                       | Install `jq` and retry                                                                                                                                       |
+| git prompts on every fetch even when stored      | GPG agent not caching              | Set `default-cache-ttl 3600` and `max-cache-ttl 14400` in `~/.gnupg/gpg-agent.conf`, then `gpgconf --reload gpg-agent`. See the [GPG Agent guide](/guides/gpg-agent/) |
+| OAuth stops working, browser opens again         | Refresh token revoked or expired   | Re-run the generator's login flow; dotsecenv stores the new refresh token on the next `store`                                                                |
+
+---
+
+## Next Steps
+
+- [Getting Started](/getting-started/): set up dotsecenv and your first vault
+- [CLI Reference](/reference/): full command documentation
+- [Security Model](/concepts/security-model/): how encryption and access control work

--- a/website/src/content/docs/guides/git-credential-helper.mdx
+++ b/website/src/content/docs/guides/git-credential-helper.mdx
@@ -57,12 +57,13 @@ git looks for `git-credential-<name>` on your `PATH`, so the helper has to sit i
   </TabItem>
 
   <TabItem label="macOS (Homebrew)">
-    After installing dotsecenv via Homebrew, the helper ships in the release archive. Symlink it onto your `PATH`:
+    The cask puts the helper on your `PATH` alongside `dotsecenv`, so there is nothing to install. Check it resolved:
 
     ```bash
-    ln -s "$(brew --prefix dotsecenv)/contrib/git-credential-dotsecenv" \
-      "$(brew --prefix)/bin/git-credential-dotsecenv"
+    command -v git-credential-dotsecenv
     ```
+
+    Homebrew relinks it on every upgrade.
 
   </TabItem>
 

--- a/website/src/content/docs/guides/git-credential-helper.mdx
+++ b/website/src/content/docs/guides/git-credential-helper.mdx
@@ -27,6 +27,12 @@ The helper derives the secret name from the request context. `https://gitlab.com
 
 Because `store` keeps every attribute git sends, the OAuth fields `oauth_refresh_token` and `password_expiry_utc` survive a round trip. That is all a generator helper needs to refresh an expired access token without a browser.
 
+## Which vault credentials go to
+
+Git credentials belong to you, not to a project, so the helper always writes them to your home vault (`$XDG_DATA_HOME/dotsecenv/vault`, or `~/.local/share/dotsecenv/vault`). A repo-local `.dotsecenv/vault` is meant to be committed, and a personal token has no business in it.
+
+Set `DOTSECENV_GIT_VAULT` to point at a different vault file if you keep yours elsewhere. If the resolved vault does not exist, the helper falls back to whatever your config resolves.
+
 ## Prerequisites
 
 - dotsecenv installed and logged in, with at least one vault (see [Getting Started](/getting-started/))

--- a/website/src/content/docs/guides/git-credential-helper.mdx
+++ b/website/src/content/docs/guides/git-credential-helper.mdx
@@ -29,9 +29,13 @@ Because `store` keeps every attribute git sends, the OAuth fields `oauth_refresh
 
 ## Which vault credentials go to
 
-Git credentials belong to you, not to a project, so the helper always writes them to your home vault (`$XDG_DATA_HOME/dotsecenv/vault`, or `~/.local/share/dotsecenv/vault`). A repo-local `.dotsecenv/vault` is meant to be committed, and a personal token has no business in it.
+The helper does not pick a vault itself. Vault selection follows your dotsecenv configuration, exactly like any other `dotsecenv secret` command. The default config lists the repo-local `.dotsecenv/vault` first and your home vault (`~/.local/share/dotsecenv/vault`) second.
 
-Set `DOTSECENV_GIT_VAULT` to point at a different vault file if you keep yours elsewhere. If the resolved vault does not exist, the helper falls back to whatever your config resolves.
+Inside a repository that carries a committed vault, that vault is a resolvable target: storing a credential there encrypts it to the vault's recipients and ships it with the repo. This is by design — it is how a team shares a deploy token or CI credential alongside the code that needs it.
+
+When more than one configured vault resolves, dotsecenv asks you to pick one on `store` and `erase`. Git runs the helper with your terminal attached, so the picker works during a normal `git push`. Without a terminal (a GUI client, CI), the operation fails with `multiple vaults configured and no terminal available`.
+
+To route git credentials through a dedicated setup, point `DOTSECENV_CONFIG` at an alternate config file listing only the vault you want. The variable is the CLI's own config override, and the helper inherits it from git's environment — set it where git runs, since GUI clients don't source your shell profile.
 
 ## Prerequisites
 
@@ -156,6 +160,7 @@ dotsecenv secret get 'git::HTTPS_SLASH_GITLAB_DOT_COM' --json
 | ------------------------------------------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | git prompts for a password every time            | Helper not found, or `get` failing | Check `git credential-dotsecenv` runs, that you ran `dotsecenv login`, and that `jq` is installed                                                            |
 | `jq is required for store`                       | `jq` missing                       | Install `jq` and retry                                                                                                                                       |
+| `multiple vaults configured and no terminal available` | `store`/`erase` ran without a terminal while several vaults resolve | Run the git command in a terminal to get the vault picker, or set `DOTSECENV_CONFIG` to a config listing a single vault                        |
 | git prompts on every fetch even when stored      | GPG agent not caching              | Set `default-cache-ttl 3600` and `max-cache-ttl 14400` in `~/.gnupg/gpg-agent.conf`, then `gpgconf --reload gpg-agent`. See the [GPG Agent guide](/guides/gpg-agent/) |
 | OAuth stops working, browser opens again         | Refresh token revoked or expired   | Re-run the generator's login flow; dotsecenv stores the new refresh token on the next `store`                                                                |
 


### PR DESCRIPTION
Adds `contrib/git-credential-dotsecenv`, a pure-bash [git credential helper](https://git-scm.com/docs/gitcredentials) that stores git HTTPS credentials as GPG-encrypted secrets in the dotsecenv vault, modeled on the existing `terraform-credentials-dotsecenv` distribution pattern.

## Two workflows, one helper

- **Stored token** (`git config --global credential.helper dotsecenv`): a drop-in encrypted replacement for `credential.helper store` / `osxkeychain`.
- **OAuth, no stored PAT**: chained after a generator like [`git-credential-oauth`](https://github.com/hickford/git-credential-oauth). The helper preserves git's native `oauth_refresh_token` and `password_expiry_utc` fields, so dotsecenv holds only the refresh token (encrypted) and git mints short-lived access tokens on demand. No dotsecenv-side OAuth code.

## How it works

Each host maps to a `git::` secret under a dot-free encoding (`.`→`_DOT_`, `/`→`_SLASH_`, `-`→`_DASH_`, `:`→`_COLON_`), so hyphenated hosts, ports, and IPs all resolve to a valid key (`https://gitlab.com` → `git::HTTPS_SLASH_GITLAB_DOT_COM`). `store` builds one JSON object with `jq` and saves it via `secret store --json`; `get` pipes it back into git's `key=value` lines; `get` degrades to empty/exit 0 on any failure so git prompts or tries the next helper.

Vault selection follows dotsecenv configuration, like any `dotsecenv secret` command: the helper passes no `-v`, so a repo-local `.dotsecenv/vault` is a first-class store target (by design), and `DOTSECENV_CONFIG` — the CLI's own override, pointing at a config file — routes credentials through a different setup.

## Distribution & tests

- goreleaser nfpm entry to `/usr/bin` (git resolves `git-credential-*` on PATH); `install_git_credential_helper()` in `install.sh`.
- `scripts/e2e-git-credential.sh` (14 cases) + `make e2e-git-credential` + a CI job. All 14 pass, including the hyphen/port/IP encoding, OAuth-field-preservation, repo-vault-via-`DOTSECENV_CONFIG`, and accepted-key-collision cases.
- Helper is bash 3.2 compatible (stock macOS) and shellcheck-clean.
- New docs guide (`guides/git-credential-helper.mdx`) + sidebar + changelog entry.

## Notes

- Adds a `jq` runtime dependency (documented as a prerequisite), a consequence of the single-JSON-object storage layout.
- No new Cobra subcommand, so no `reference.mdx`/man/completion changes and the CLI-reference-drift gate is untouched.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
