### PR TITLE
chore(claude): track the project plugin config in the repo

### DIFF
--- a/.claude/marketplace/.claude-plugin/marketplace.json
+++ b/.claude/marketplace/.claude-plugin/marketplace.json
@@ -1,0 +1,26 @@
+{
+  "name": "dotsecenv-project-local",
+  "owner": {
+    "name": "dotsecenv"
+  },
+  "metadata": {
+    "description": "Project-local marketplace wrapping third-party plugin repos that ship no marketplace manifest of their own"
+  },
+  "plugins": [
+    {
+      "name": "technical-docs",
+      "source": {
+        "source": "github",
+        "repo": "danielrosehill/Claude-Technical-Docs-Plugin"
+      },
+      "description": "Technical documentation workflow: README authoring, reference docs, changelogs, tech-stack capture, markdown conversion, fix-note archival",
+      "author": {
+        "name": "Daniel Rosehill"
+      },
+      "homepage": "https://github.com/danielrosehill/Claude-Technical-Docs-Plugin",
+      "license": "MIT",
+      "category": "documentation",
+      "keywords": ["documentation", "readme", "api-reference", "changelog"]
+    }
+  ]
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "enabledPlugins": {
+    "claude-blog@agricidaniel-blog": true,
+    "technical-docs@dotsecenv-project-local": true
+  },
+  "extraKnownMarketplaces": {
+    "agricidaniel-blog": {
+      "source": {
+        "source": "github",
+        "repo": "AgriciDaniel/claude-blog"
+      }
+    },
+    "dotsecenv-project-local": {
+      "source": {
+        "source": "directory",
+        "path": "./.claude/marketplace"
+      }
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,10 @@ website/.docusaurus
 website/.cache
 
 # Claude
+# A user-global ignore may exclude **/.claude/; re-include it here so the
+# shared project config and skills stay tracked.
+!.claude/
 .claude/settings.local.json
+# Claude Code fetches this plugin from GitHub on install; not vendored.
+.claude/marketplace/technical-docs/
 .worktrees/

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -25,6 +25,7 @@ _Unreleased_
 - Homebrew install docs now include the `brew trust dotsecenv/tap` step that Homebrew 6.0 requires for third-party taps (#253)
 - The Homebrew tap's README is now maintained in the monorepo and synced to the tap on release (#253)
 - Pin pnpm to 11.11.0 in the website CI workflows; pnpm 11.12.0 breaks the setup action's self-update (#254)
+- The repo now tracks its Claude Code plugin config in `.claude/`, so contributors get the `claude-blog` and `technical-docs` plugins without wiring them up by hand (#270)
 
 ---
 


### PR DESCRIPTION
Enables two Claude Code plugins for anyone working in this checkout, so the setup no longer lives only in one contributor's user-level config.

## What is tracked

`.claude/settings.json` declares the marketplaces and enables `claude-blog` and `technical-docs`. The marketplace path is relative (`./.claude/marketplace`), resolved against the project root, so it works on any machine.

`claude-blog` comes from its upstream marketplace manifest. `technical-docs` ships only a `plugin.json` and no marketplace manifest, so `claude plugin marketplace add` cannot take it directly; `.claude/marketplace/.claude-plugin/marketplace.json` is a small wrapper that gives it a catalogue entry. It points at the upstream GitHub repo rather than vendoring the plugin, so nothing third-party enters the tree.

This wrapper is deliberately separate from the repo's own `.claude-plugin/marketplace.json`, which publishes the dotsecenv plugin to users. Third-party entries must not leak into what we ship.

## Why .gitignore changes

A user-global ignore of `**/.claude/` hides the whole directory, which is why this config could not be committed before. A repo `.gitignore` outranks the global one, so `!.claude/` re-includes it. `settings.local.json` stays ignored, as does `.claude/marketplace/technical-docs/`, the local checkout Claude Code fetches on install.

## Note for reviewers

Enabling these plugins auto-loads code from two third-party GitHub accounts for anyone who opens this repo in Claude Code. That is a supply-chain surface worth a deliberate decision rather than a default. Installing `technical-docs` also clones over SSH, so a contributor without a loaded SSH key will see the install fail; the plugin config is otherwise inert.

---