### PR TITLE
Group the Astro ecosystem into one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>dotsecenv/.github"
+    "local>dotsecenv/.github",
+    "local>dotsecenv/.github:astro"
   ]
 }


### PR DESCRIPTION
> Requires **dotsecenv/.github#4**, which adds the profile. Merge that first or this resolves to nothing.

## Why

`website/`'s Astro packages are peer-locked to each other, so Renovate's default of one PR per dependency produces a set of PRs **none of which can pass CI** — each installs against a peer the others have not moved to yet.

`MihaiBojin/website` hit exactly this on the Astro v7 upgrade: `astro`, `@astrojs/mdx` and `astro-og-canvas` arrived as three separate PRs over two weeks, each red on its own, green only once merged together.

## What gets grouped

Seven packages in `website/package.json`:

```
astro, @astrojs/starlight, astro-og-canvas,
starlight-blog, starlight-contextual-menu,
starlight-llms-txt, starlight-markdown
```

The four `starlight-*` plugins are a second peer-lock layer — they pin ranges against `@astrojs/starlight`, which pins one against `astro`. So a Starlight major can break plugins independently of Astro itself.

Verified the globs against the live manifest: they match those seven and nothing else. `sharp`, `eslint`, `asciinema-player`, `canvaskit-wasm` and the fontsource packages all stay out and keep arriving individually.

## Effect

Astro-ecosystem updates arrive as one reviewable PR that can actually go green. Nothing else about this repo's Renovate behaviour changes.