### PR TITLE
fix(cli): keep the recipient set when re-storing a shared secret

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -393,7 +393,11 @@ reasoning about behavior. They are also what reviewers will check.
 - **Multi-recipient PGP encryption.** A single `value` entry carries one
   ciphertext encrypted to multiple recipients (the union of fingerprints
   in `available_to`). Sharing or revoking access re-encrypts only that
-  value entry; previous entries are preserved verbatim.
+  value entry; previous entries are preserved verbatim. `secret store` on
+  an existing key carries the latest entry's recipient set forward (warning
+  and prompting when others are on it; `--share`/`--no-share` skip the
+  prompt), so rotation never silently narrows access — narrowing is
+  `secret revoke`'s job, or an explicit `--no-share`.
 - **No identity in policy.** `login` and `vault` are forbidden keys in
   policy fragments — identity is per-user (cryptographically bound to a
   private key) and policy must not erase user vaults. See the policy

--- a/cmd/dotsecenv/cmd_secret.go
+++ b/cmd/dotsecenv/cmd_secret.go
@@ -35,7 +35,16 @@ Keys are case-insensitive and normalized when stored:
   - Key name part: UPPERCASE
 
 The secret value is read from stdin. Use -v to specify which vault
-to store the secret in (either a path or 1-based index).`,
+to store the secret in (either a path or 1-based index).
+
+Storing over an existing secret keeps its current recipient set: the new
+value is encrypted to every fingerprint on the latest entry's available_to,
+not just yours. When that set includes other identities, store warns and,
+if a terminal is available, asks for confirmation.
+
+Options:
+  --share     Keep the recipient set without warning or confirmation
+  --no-share  Encrypt the new value only to your identity`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if err := cobra.ExactArgs(1)(cmd, args); err != nil {
 			return err
@@ -90,13 +99,24 @@ to store the secret in (either a path or 1-based index).`,
 		}
 		defer func() { _ = cli.Close() }()
 
-		exitErr := cli.SecretPut(secretKey, vaultPath, fromIndex, preReadValue)
+		shareMode := clilib.StoreSharePrompt
+		if secretPutShare {
+			shareMode = clilib.StoreShareAlways
+		} else if secretPutNoShare {
+			shareMode = clilib.StoreShareNever
+		}
+
+		exitErr := cli.SecretPut(secretKey, vaultPath, fromIndex, preReadValue, shareMode)
 		exitWithError(exitErr)
 	},
 }
 
 // secret store flags
-var secretPutJSON bool
+var (
+	secretPutJSON    bool
+	secretPutShare   bool
+	secretPutNoShare bool
+)
 
 // secret get flags
 var (
@@ -371,6 +391,9 @@ or 1-based index).`,
 func init() {
 	// secret store flags
 	secretPutCmd.Flags().BoolVar(&secretPutJSON, "json", false, "Validate stdin is valid JSON before storing")
+	secretPutCmd.Flags().BoolVar(&secretPutShare, "share", false, "Keep the existing recipient set without warning or confirmation")
+	secretPutCmd.Flags().BoolVar(&secretPutNoShare, "no-share", false, "Encrypt the new value only to your identity")
+	secretPutCmd.MarkFlagsMutuallyExclusive("share", "no-share")
 
 	// secret get flags
 	secretGetCmd.Flags().BoolVar(&secretGetAll, "all", false, "Retrieve all values")

--- a/cmd/dotsecenv/security_test.go
+++ b/cmd/dotsecenv/security_test.go
@@ -197,15 +197,13 @@ func TestIssue_RevokeWithoutAccess(t *testing.T) {
 	// 3. Share with C
 	_, _, _ = runCmdWithEnv(env, "-c", configPathA, "secret", "share", "SEC1", fpC)
 
-	// 4. A updates secret (v4) -> Only A has access
-	cmd = exec.Command(binaryPath, "-c", configPathA, "secret", "store", "SEC1")
-	cmd.Env = append(filteredEnv(), env...)
-	cmd.Stdin = strings.NewReader("v4")
-	_ = cmd.Run()
+	// 4. A revokes B -> latest value is available to A and C only.
+	// (secret store carries the recipient set forward, so an explicit revoke
+	// is what removes B from the latest value.)
+	_, _, _ = runCmdWithEnv(env, "-c", configPathA, "secret", "revoke", "SEC1", fpB)
 
 	// 5. B tries to revoke C.
-	// B has access to v2 and v3.
-	// B does NOT have access to v4 (latest).
+	// B has access to earlier values but NOT to the latest one.
 	// B tries to revoke C from SEC1.
 	_, stderr, err := runCmdWithEnv(env, "-c", configPathB, "secret", "revoke", "SEC1", fpC)
 

--- a/examples/08-compact-vault/run.sh
+++ b/examples/08-compact-vault/run.sh
@@ -92,9 +92,10 @@ echo "aws-v2" | "$BIN" -c "$CONFIG" secret store AWS_KEY
 echo "aws-v3" | "$BIN" -c "$CONFIG" secret store AWS_KEY
 echo "aws-v4" | "$BIN" -c "$CONFIG" secret store AWS_KEY
 
-# Share the latest of each with Bob. `secret store` encrypts only to the
-# logged-in identity, so we share last to make the newest value readable by
-# both Alice and Bob — then compaction collapses each secret to that one value.
+# Share the latest of each with Bob. The stores above were encrypted only to
+# Alice (a first-time store targets the storer; re-stores carry the recipient
+# set forward), so we share last to make the newest value readable by both
+# Alice and Bob — then compaction collapses each secret to that one value.
 echo "==> share the latest DB_PASSWORD and AWS_KEY with Bob"
 "$BIN" -c "$CONFIG" secret share DB_PASSWORD "$BOB_FP" >/dev/null
 "$BIN" -c "$CONFIG" secret share AWS_KEY "$BOB_FP" >/dev/null

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dotsecenv/dotsecenv
 
-go 1.26.4
+go 1.26.5
 
 require (
 	charm.land/bubbletea/v2 v2.0.8

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -47,8 +47,9 @@ type CLI struct {
 	gpgClient     gpg.Client
 	stdin         io.Reader
 	Silent        bool
-	output        *output.Handler // Unified output handler
-	hasTTY        func() bool     // Returns true if a controlling terminal is present
+	output        *output.Handler                                      // Unified output handler
+	hasTTY        func() bool                                          // Returns true if a controlling terminal is present
+	promptConfirm func(prompt string, stderr io.Writer) (bool, *Error) // y/n confirmation; nil means PromptConfirm
 }
 
 // Policy returns the loaded system policy. Empty Policy means no policy is enforced.

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -79,7 +79,7 @@ func TestSecretPut_WithVaultPath(t *testing.T) {
 	}
 
 	// Use -v flag
-	putErr := cli.SecretPut("MY_SECRET", vaultPath, 0, "")
+	putErr := cli.SecretPut("MY_SECRET", vaultPath, 0, "", StoreSharePrompt)
 	if putErr != nil {
 		t.Fatalf("SecretPut with -v failed unexpectedly: %v", putErr)
 	}
@@ -151,7 +151,7 @@ func TestSecretPut_WithFromIndex(t *testing.T) {
 	}
 
 	// Test --from 2 (index 1)
-	err := cli.SecretPut("MY_SECRET", "", 2, "")
+	err := cli.SecretPut("MY_SECRET", "", 2, "", StoreSharePrompt)
 	if err != nil {
 		t.Fatalf("SecretPut with --from 2 failed unexpectedly: %v", err)
 	}
@@ -208,7 +208,7 @@ func TestSecretPut_FromIndexOutOfRange(t *testing.T) {
 	}
 
 	// Test -v 4 (out of range)
-	err := cli.SecretPut("MY_SECRET", "", 4, "")
+	err := cli.SecretPut("MY_SECRET", "", 4, "", StoreSharePrompt)
 	switch {
 	case err == nil:
 		t.Fatalf("Expected SecretPut with -v 4 to fail, but it succeeded")
@@ -605,7 +605,7 @@ func TestSecretPut_BlockedByDeleted(t *testing.T) {
 	}
 
 	// Try to put to a deleted secret
-	putErr := cli.SecretPut("DELETED_SECRET", vaultPath, 0, "")
+	putErr := cli.SecretPut("DELETED_SECRET", vaultPath, 0, "", StoreSharePrompt)
 	switch {
 	case putErr == nil:
 		t.Fatal("SecretPut should fail for deleted secret")

--- a/internal/cli/secret.go
+++ b/internal/cli/secret.go
@@ -46,7 +46,21 @@ func smartJSONValue(s string) interface{} {
 // SecretPut stores a secret in the vault.
 // If preReadValue is non-empty, it's used as the secret value (for piped input read before vault lock).
 // If preReadValue is empty, the secret is read from stdin (interactive TTY mode).
-func (c *CLI) SecretPut(secretKeyArg, vaultPath string, fromIndex int, preReadValue string) *Error {
+// StoreShareMode controls what SecretPut does when the secret being
+// overwritten is shared with other identities.
+type StoreShareMode int
+
+const (
+	// StoreSharePrompt warns that the new value stays shared and asks for
+	// confirmation when a terminal is available. This is the default.
+	StoreSharePrompt StoreShareMode = iota
+	// StoreShareAlways keeps the recipient set without warning (--share).
+	StoreShareAlways
+	// StoreShareNever encrypts only to the storer's identity (--no-share).
+	StoreShareNever
+)
+
+func (c *CLI) SecretPut(secretKeyArg, vaultPath string, fromIndex int, preReadValue string, shareMode StoreShareMode) *Error {
 	secretKey, normErr := vault.NormalizeSecretKey(secretKeyArg)
 	if normErr != nil {
 		return NewError(vault.FormatSecretKeyError(normErr), ExitValidationError)
@@ -90,7 +104,11 @@ func (c *CLI) SecretPut(secretKeyArg, vaultPath string, fromIndex int, preReadVa
 		return NewError(fmt.Sprintf("identity not found in vault: %s", fp), ExitAccessDenied)
 	}
 
-	// Check if secret exists and if we have access to the latest value
+	// Check if secret exists and if we have access to the latest value.
+	// When overwriting, the latest value's recipient set carries forward to the
+	// new entry: rotating a shared secret must not silently narrow access to
+	// just the storer. Narrowing the set is 'secret revoke'.
+	recipients := []string{fp}
 	existingSecret := c.vaultResolver.GetSecretByKeyFromVault(targetIndex, secretKey)
 	if existingSecret != nil && len(existingSecret.Values) > 0 {
 		// Check if secret has been deleted
@@ -101,6 +119,38 @@ func (c *CLI) SecretPut(secretKeyArg, vaultPath string, fromIndex int, preReadVa
 		if !slices.Contains(latestValue.AvailableTo, fp) {
 			return NewError(fmt.Sprintf("access denied: you do not have access to the latest value of secret '%s'", secretKey), ExitAccessDenied)
 		}
+		recipients = make([]string, len(latestValue.AvailableTo))
+		copy(recipients, latestValue.AvailableTo)
+		sort.Strings(recipients)
+	}
+
+	// Recipients other than the storer: the identities a re-store keeps sharing with.
+	others := make([]string, 0, len(recipients))
+	for _, recipientFP := range recipients {
+		if recipientFP != fp {
+			others = append(others, recipientFP)
+		}
+	}
+	if len(others) > 0 {
+		switch shareMode {
+		case StoreShareNever:
+			recipients = []string{fp}
+		case StoreShareAlways:
+			// Keep the carried-forward set without warning.
+		default:
+			if confirmErr := c.confirmSharedStore(secretKey, others); confirmErr != nil {
+				return confirmErr
+			}
+		}
+	}
+
+	recipientPublicKeys := make([]string, 0, len(recipients))
+	for _, recipientFP := range recipients {
+		recipientIdentity := c.vaultResolver.GetIdentityByFingerprint(recipientFP)
+		if recipientIdentity == nil {
+			return NewError(fmt.Sprintf("recipient identity not found: %s", recipientFP), ExitVaultError)
+		}
+		recipientPublicKeys = append(recipientPublicKeys, recipientIdentity.PublicKey)
 	}
 
 	var secretValue string
@@ -126,7 +176,7 @@ func (c *CLI) SecretPut(secretKeyArg, vaultPath string, fromIndex int, preReadVa
 
 	encryptedArmored, encErr := c.gpgClient.EncryptToRecipients(
 		[]byte(secretValue),
-		[]string{identity.PublicKey},
+		recipientPublicKeys,
 		nil,
 	)
 	if encErr != nil {
@@ -156,7 +206,7 @@ func (c *CLI) SecretPut(secretKeyArg, vaultPath string, fromIndex int, preReadVa
 	// Build secret value struct (without hash/signature)
 	newValue := vault.SecretValue{
 		AddedAt:     now,
-		AvailableTo: []string{fp},
+		AvailableTo: recipients,
 		SignedBy:    fp,
 		Value:       encryptedBase64,
 		Deleted:     false,
@@ -182,6 +232,43 @@ func (c *CLI) SecretPut(secretKeyArg, vaultPath string, fromIndex int, preReadVa
 	}
 
 	_, _ = fmt.Fprintf(c.output.Stdout(), "Secret '%s' stored successfully\n", secretKey)
+	return nil
+}
+
+// confirmSharedStore warns that re-storing a shared secret keeps its recipient
+// set and, when a terminal is available, asks for confirmation. Without a
+// terminal it proceeds after the warning so piped and CI stores keep working.
+func (c *CLI) confirmSharedStore(secretKey string, others []string) *Error {
+	stderr := c.output.Stderr()
+	_, _ = fmt.Fprintf(stderr, "warning: secret '%s' is shared; the new value stays readable by:\n", secretKey)
+	for _, otherFP := range others {
+		label := otherFP
+		if id := c.vaultResolver.GetIdentityByFingerprint(otherFP); id != nil && id.UID != "" {
+			label = fmt.Sprintf("%s (%s)", otherFP, id.UID)
+		}
+		_, _ = fmt.Fprintf(stderr, "  - %s\n", label)
+	}
+
+	hasTTY := c.hasTTY
+	if hasTTY == nil {
+		hasTTY = defaultHasTTY
+	}
+	if !hasTTY() {
+		_, _ = fmt.Fprintf(stderr, "warning: no terminal to confirm; keeping the recipient set (--share silences this warning, --no-share stores only for yourself)\n")
+		return nil
+	}
+
+	promptConfirm := c.promptConfirm
+	if promptConfirm == nil {
+		promptConfirm = PromptConfirm
+	}
+	confirmed, promptErr := promptConfirm("Keep sharing the new value with them?", stderr)
+	if promptErr != nil {
+		return promptErr
+	}
+	if !confirmed {
+		return NewError("store cancelled; re-run with --share to keep the recipient set or --no-share to store only for yourself", ExitGeneralError)
+	}
 	return nil
 }
 

--- a/internal/cli/secret_store_test.go
+++ b/internal/cli/secret_store_test.go
@@ -1,6 +1,8 @@
 package cli
 
 import (
+	"encoding/base64"
+	"io"
 	"strings"
 	"testing"
 
@@ -21,7 +23,7 @@ import (
 // The injected GPG mock and signed login make checkFingerprintRequired succeed
 // so the vault-existence guard inside SecretPut is reached. Stderr is captured
 // so tests can assert the absence of the identity auto-add warnings.
-func newSecretStoreCLI(t *testing.T, entryPaths, availablePaths []string) (*CLI, *strings.Builder) {
+func newSecretStoreCLI(t *testing.T, entryPaths, availablePaths []string) (*CLI, *MockVaultResolver, *strings.Builder) {
 	t.Helper()
 
 	mock := NewMockVaultResolver()
@@ -53,9 +55,12 @@ func newSecretStoreCLI(t *testing.T, entryPaths, availablePaths []string) (*CLI,
 		vaultResolver: mock,
 		gpgClient:     gpgMock,
 		output:        output.NewHandler(stdout, stderr),
+		// No terminal by default so shared-store confirmation never opens
+		// /dev/tty under 'go test'; prompt-path tests stub promptConfirm.
+		hasTTY: func() bool { return false },
 	}
 
-	return cli, stderr
+	return cli, mock, stderr
 }
 
 // TestSecretStore_MissingVaultFile_FriendlyError verifies that 'secret store'
@@ -64,9 +69,9 @@ func newSecretStoreCLI(t *testing.T, entryPaths, availablePaths []string) (*CLI,
 // prints the misleading identity auto-add warnings.
 func TestSecretStore_MissingVaultFile_FriendlyError(t *testing.T) {
 	// Vault index 1 is configured but did not load (no matching available path).
-	cli, stderr := newSecretStoreCLI(t, []string{"/vault1.yaml"}, nil)
+	cli, _, stderr := newSecretStoreCLI(t, []string{"/vault1.yaml"}, nil)
 
-	err := cli.SecretPut("PULUMI_CONFIG_PASSPHRASE", "", 1, "v")
+	err := cli.SecretPut("PULUMI_CONFIG_PASSPHRASE", "", 1, "v", StoreSharePrompt)
 
 	if err == nil {
 		t.Fatal("SecretPut against a missing vault: got nil error, want a friendly failure")
@@ -102,11 +107,257 @@ func TestSecretStore_MissingVaultFile_FriendlyError(t *testing.T) {
 // ensureIdentityInVault.
 func TestSecretStore_ExistingVault_NoMissingError(t *testing.T) {
 	// Vault index 1 is both configured and available (loaded).
-	cli, _ := newSecretStoreCLI(t, []string{"/vault1.yaml"}, []string{"/vault1.yaml"})
+	cli, _, _ := newSecretStoreCLI(t, []string{"/vault1.yaml"}, []string{"/vault1.yaml"})
 
-	err := cli.SecretPut("PULUMI_CONFIG_PASSPHRASE", "", 1, "secret-value")
+	err := cli.SecretPut("PULUMI_CONFIG_PASSPHRASE", "", 1, "secret-value", StoreSharePrompt)
 
 	if err != nil && strings.Contains(err.Message, "does not exist") {
 		t.Errorf("vault is available but SecretPut returned a 'does not exist' error: %q", err.Message)
+	}
+}
+
+// storeTestIdentity returns a minimal valid identity for SecretPut tests.
+func storeTestIdentity(fingerprint, publicKey string) vault.Identity {
+	return vault.Identity{
+		Fingerprint:   fingerprint,
+		UID:           fingerprint + " <" + strings.ToLower(fingerprint) + "@example.com>",
+		Algorithm:     "RSA",
+		AlgorithmBits: 4096,
+		PublicKey:     publicKey,
+	}
+}
+
+// seedSharedSecret places a secret in vault 0 whose latest value is available
+// to the given fingerprints (pre-sorted by the caller).
+func seedSharedSecret(mock *MockVaultResolver, key string, availableTo []string) {
+	mock.Secrets[0] = map[string]vault.Secret{
+		key: {
+			Key: key,
+			Values: []vault.SecretValue{
+				{
+					AvailableTo: availableTo,
+					SignedBy:    availableTo[len(availableTo)-1],
+					Value:       "b2xkLXZhbHVl", // base64("old-value")
+				},
+			},
+		},
+	}
+}
+
+// TestSecretStore_ExistingSharedSecret_CarriesRecipientsForward verifies that
+// re-storing a shared secret preserves the latest value's recipient set: the
+// new entry must stay available to (and be encrypted to) every prior
+// recipient, not just the storer. Narrowing access is 'secret revoke'.
+// Without a terminal, the default mode warns about the kept recipients and
+// proceeds, so piped and CI stores keep working.
+func TestSecretStore_ExistingSharedSecret_CarriesRecipientsForward(t *testing.T) {
+	cli, mock, stderr := newSecretStoreCLI(t, []string{"/vault1.yaml"}, []string{"/vault1.yaml"})
+
+	_ = mock.AddIdentity(storeTestIdentity("MYFINGERPRINT", "my-pubkey"), 0)
+	_ = mock.AddIdentity(storeTestIdentity("CIFINGERPRINT", "ci-pubkey"), 0)
+	seedSharedSecret(mock, "DATABASE_URL", []string{"CIFINGERPRINT", "MYFINGERPRINT"})
+
+	err := cli.SecretPut("DATABASE_URL", "", 1, "rotated-value", StoreSharePrompt)
+	if err != nil {
+		t.Fatalf("SecretPut over a shared secret failed: %s", err.Message)
+	}
+
+	stderrText := stderr.String()
+	if !strings.Contains(stderrText, "is shared") || !strings.Contains(stderrText, "CIFINGERPRINT") {
+		t.Errorf("stderr does not warn about the kept recipient set:\n%s", stderrText)
+	}
+
+	stored, ok := mock.Secrets[0]["DATABASE_URL"]
+	if !ok || len(stored.Values) == 0 {
+		t.Fatal("no secret value was stored")
+	}
+	newValue := stored.Values[len(stored.Values)-1]
+
+	wantRecipients := []string{"CIFINGERPRINT", "MYFINGERPRINT"}
+	if len(newValue.AvailableTo) != len(wantRecipients) {
+		t.Fatalf("available_to = %v, want %v", newValue.AvailableTo, wantRecipients)
+	}
+	for i, fp := range wantRecipients {
+		if newValue.AvailableTo[i] != fp {
+			t.Errorf("available_to[%d] = %q, want %q (full set: %v)", i, newValue.AvailableTo[i], fp, newValue.AvailableTo)
+		}
+	}
+
+	// The mock encodes the recipient public keys into the ciphertext, so the
+	// stored value proves the encryption call included every recipient.
+	ciphertext, decodeErr := base64.StdEncoding.DecodeString(newValue.Value)
+	if decodeErr != nil {
+		t.Fatalf("stored value is not valid base64: %v", decodeErr)
+	}
+	for _, pubKey := range []string{"ci-pubkey", "my-pubkey"} {
+		if !strings.Contains(string(ciphertext), pubKey) {
+			t.Errorf("ciphertext %q was not encrypted to %q", ciphertext, pubKey)
+		}
+	}
+}
+
+// TestSecretStore_NewSecret_EncryptedToStorerOnly verifies that a first-time
+// store still targets only the storer's key.
+func TestSecretStore_NewSecret_EncryptedToStorerOnly(t *testing.T) {
+	cli, mock, _ := newSecretStoreCLI(t, []string{"/vault1.yaml"}, []string{"/vault1.yaml"})
+
+	_ = mock.AddIdentity(storeTestIdentity("MYFINGERPRINT", "my-pubkey"), 0)
+
+	err := cli.SecretPut("API_KEY", "", 1, "fresh-value", StoreSharePrompt)
+	if err != nil {
+		t.Fatalf("SecretPut for a new secret failed: %s", err.Message)
+	}
+
+	stored := mock.Secrets[0]["API_KEY"]
+	if len(stored.Values) == 0 {
+		t.Fatal("no secret value was stored")
+	}
+	newValue := stored.Values[len(stored.Values)-1]
+	if len(newValue.AvailableTo) != 1 || newValue.AvailableTo[0] != "MYFINGERPRINT" {
+		t.Errorf("available_to = %v, want [MYFINGERPRINT]", newValue.AvailableTo)
+	}
+}
+
+// TestSecretStore_ShareFlag_SkipsWarning verifies that --share keeps the
+// recipient set with no warning and no confirmation attempt.
+func TestSecretStore_ShareFlag_SkipsWarning(t *testing.T) {
+	cli, mock, stderr := newSecretStoreCLI(t, []string{"/vault1.yaml"}, []string{"/vault1.yaml"})
+	cli.hasTTY = func() bool { return true }
+	cli.promptConfirm = func(prompt string, _ io.Writer) (bool, *Error) {
+		t.Fatalf("promptConfirm called with %q despite --share", prompt)
+		return false, nil
+	}
+
+	_ = mock.AddIdentity(storeTestIdentity("MYFINGERPRINT", "my-pubkey"), 0)
+	_ = mock.AddIdentity(storeTestIdentity("CIFINGERPRINT", "ci-pubkey"), 0)
+	seedSharedSecret(mock, "DATABASE_URL", []string{"CIFINGERPRINT", "MYFINGERPRINT"})
+
+	err := cli.SecretPut("DATABASE_URL", "", 1, "rotated-value", StoreShareAlways)
+	if err != nil {
+		t.Fatalf("SecretPut --share failed: %s", err.Message)
+	}
+
+	if strings.Contains(stderr.String(), "is shared") {
+		t.Errorf("--share must not print the shared-secret warning:\n%s", stderr.String())
+	}
+
+	newValue := mock.Secrets[0]["DATABASE_URL"].Values[0]
+	if len(newValue.AvailableTo) != 2 {
+		t.Errorf("available_to = %v, want both recipients", newValue.AvailableTo)
+	}
+}
+
+// TestSecretStore_NoShareFlag_EncryptsToStorerOnly verifies that --no-share
+// narrows the new value to the storer's identity with no warning.
+func TestSecretStore_NoShareFlag_EncryptsToStorerOnly(t *testing.T) {
+	cli, mock, stderr := newSecretStoreCLI(t, []string{"/vault1.yaml"}, []string{"/vault1.yaml"})
+
+	_ = mock.AddIdentity(storeTestIdentity("MYFINGERPRINT", "my-pubkey"), 0)
+	_ = mock.AddIdentity(storeTestIdentity("CIFINGERPRINT", "ci-pubkey"), 0)
+	seedSharedSecret(mock, "DATABASE_URL", []string{"CIFINGERPRINT", "MYFINGERPRINT"})
+
+	err := cli.SecretPut("DATABASE_URL", "", 1, "rotated-value", StoreShareNever)
+	if err != nil {
+		t.Fatalf("SecretPut --no-share failed: %s", err.Message)
+	}
+
+	if strings.Contains(stderr.String(), "is shared") {
+		t.Errorf("--no-share must not print the shared-secret warning:\n%s", stderr.String())
+	}
+
+	newValue := mock.Secrets[0]["DATABASE_URL"].Values[0]
+	if len(newValue.AvailableTo) != 1 || newValue.AvailableTo[0] != "MYFINGERPRINT" {
+		t.Fatalf("available_to = %v, want [MYFINGERPRINT]", newValue.AvailableTo)
+	}
+
+	ciphertext, decodeErr := base64.StdEncoding.DecodeString(newValue.Value)
+	if decodeErr != nil {
+		t.Fatalf("stored value is not valid base64: %v", decodeErr)
+	}
+	if strings.Contains(string(ciphertext), "ci-pubkey") {
+		t.Errorf("--no-share ciphertext %q was encrypted to the CI key", ciphertext)
+	}
+}
+
+// TestSecretStore_PromptConfirmed_KeepsSharing verifies the interactive path:
+// with a terminal, the default mode asks for confirmation and a "yes" keeps
+// the recipient set.
+func TestSecretStore_PromptConfirmed_KeepsSharing(t *testing.T) {
+	cli, mock, stderr := newSecretStoreCLI(t, []string{"/vault1.yaml"}, []string{"/vault1.yaml"})
+	cli.hasTTY = func() bool { return true }
+	prompted := false
+	cli.promptConfirm = func(string, io.Writer) (bool, *Error) {
+		prompted = true
+		return true, nil
+	}
+
+	_ = mock.AddIdentity(storeTestIdentity("MYFINGERPRINT", "my-pubkey"), 0)
+	_ = mock.AddIdentity(storeTestIdentity("CIFINGERPRINT", "ci-pubkey"), 0)
+	seedSharedSecret(mock, "DATABASE_URL", []string{"CIFINGERPRINT", "MYFINGERPRINT"})
+
+	err := cli.SecretPut("DATABASE_URL", "", 1, "rotated-value", StoreSharePrompt)
+	if err != nil {
+		t.Fatalf("SecretPut after confirmation failed: %s", err.Message)
+	}
+	if !prompted {
+		t.Error("confirmation prompt was never shown despite a terminal being available")
+	}
+	if !strings.Contains(stderr.String(), "is shared") {
+		t.Errorf("stderr does not warn about the kept recipient set:\n%s", stderr.String())
+	}
+
+	newValue := mock.Secrets[0]["DATABASE_URL"].Values[0]
+	if len(newValue.AvailableTo) != 2 {
+		t.Errorf("available_to = %v, want both recipients", newValue.AvailableTo)
+	}
+}
+
+// TestSecretStore_PromptDeclined_AbortsWithoutWriting verifies that declining
+// the confirmation cancels the store entirely: no value entry is written and
+// the error points at the --share/--no-share flags.
+func TestSecretStore_PromptDeclined_AbortsWithoutWriting(t *testing.T) {
+	cli, mock, _ := newSecretStoreCLI(t, []string{"/vault1.yaml"}, []string{"/vault1.yaml"})
+	cli.hasTTY = func() bool { return true }
+	cli.promptConfirm = func(string, io.Writer) (bool, *Error) {
+		return false, nil
+	}
+
+	_ = mock.AddIdentity(storeTestIdentity("MYFINGERPRINT", "my-pubkey"), 0)
+	_ = mock.AddIdentity(storeTestIdentity("CIFINGERPRINT", "ci-pubkey"), 0)
+	seedSharedSecret(mock, "DATABASE_URL", []string{"CIFINGERPRINT", "MYFINGERPRINT"})
+
+	err := cli.SecretPut("DATABASE_URL", "", 1, "rotated-value", StoreSharePrompt)
+	if err == nil {
+		t.Fatal("SecretPut succeeded despite the user declining the confirmation")
+	}
+	if !strings.Contains(err.Message, "--share") || !strings.Contains(err.Message, "--no-share") {
+		t.Errorf("cancellation message %q does not point at the --share/--no-share flags", err.Message)
+	}
+
+	stored := mock.Secrets[0]["DATABASE_URL"]
+	if len(stored.Values) != 1 || stored.Values[0].Value != "b2xkLXZhbHVl" {
+		t.Errorf("vault was modified after a declined confirmation: %+v", stored.Values)
+	}
+}
+
+// TestSecretStore_MissingRecipientIdentity_Fails verifies that when a prior
+// recipient's identity cannot be resolved, store fails loudly instead of
+// silently dropping them from the new entry.
+func TestSecretStore_MissingRecipientIdentity_Fails(t *testing.T) {
+	cli, mock, _ := newSecretStoreCLI(t, []string{"/vault1.yaml"}, []string{"/vault1.yaml"})
+
+	_ = mock.AddIdentity(storeTestIdentity("MYFINGERPRINT", "my-pubkey"), 0)
+	// GHOSTFINGERPRINT is on the recipient list but has no identity entry.
+	seedSharedSecret(mock, "DATABASE_URL", []string{"GHOSTFINGERPRINT", "MYFINGERPRINT"})
+
+	err := cli.SecretPut("DATABASE_URL", "", 1, "rotated-value", StoreSharePrompt)
+	if err == nil {
+		t.Fatal("SecretPut succeeded despite an unresolvable recipient; it must fail rather than drop them")
+	}
+	if !strings.Contains(err.Message, "recipient identity not found") {
+		t.Errorf("error message %q does not name the missing recipient problem", err.Message)
+	}
+	if err.ExitCode != ExitVaultError {
+		t.Errorf("exit code = %d, want ExitVaultError (%d)", err.ExitCode, ExitVaultError)
 	}
 }

--- a/internal/cli/secret_store_test.go
+++ b/internal/cli/secret_store_test.go
@@ -241,7 +241,8 @@ func TestSecretStore_ShareFlag_SkipsWarning(t *testing.T) {
 		t.Errorf("--share must not print the shared-secret warning:\n%s", stderr.String())
 	}
 
-	newValue := mock.Secrets[0]["DATABASE_URL"].Values[0]
+	stored := mock.Secrets[0]["DATABASE_URL"]
+	newValue := stored.Values[len(stored.Values)-1]
 	if len(newValue.AvailableTo) != 2 {
 		t.Errorf("available_to = %v, want both recipients", newValue.AvailableTo)
 	}

--- a/skills/secrets/SKILL.md
+++ b/skills/secrets/SKILL.md
@@ -187,6 +187,8 @@ dotsecenv secret revoke SECRET_NAME FINGERPRINT --all
 dotsecenv secret forget SECRET_NAME
 ```
 
+`secret store` on an existing secret keeps its current recipient set: the new value is encrypted to every fingerprint on the latest entry's `available_to`. When that set includes other identities, store warns and (with a terminal) asks for confirmation. Pass `--share` to keep the set without prompting, or `--no-share` to encrypt only to the current identity. Rotation never silently narrows access, so never advise re-sharing after a rotation; removing someone is `secret revoke`.
+
 ## Departed teammate offboarding
 
 When the user describes removing a departing team member's GPG key, follow the [Offboard a Departing Team Member runbook](https://dotsecenv.com/runbooks/team-member-offboarding/). The shape of the workflow:

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -13,10 +13,12 @@ _Unreleased_
 
 ### Features
 
+- `secret store` now warns when the secret being overwritten is shared, lists who keeps access, and asks for confirmation when a terminal is attached; new `--share` and `--no-share` flags skip the prompt and keep the recipient set or encrypt to your identity only
 - The Homebrew cask now installs the zsh/bash/fish shell plugins to `$(brew --prefix)/share/dotsecenv/plugin/`, matching the Linux packages (#253)
 
 ### Bug Fixes
 
+- `secret store` on an existing secret now keeps the current recipient set: the new value is encrypted to everyone on the latest entry's `available_to`, so rotating a shared secret no longer silently locks out CI and teammates
 - `secret get` now tells apart a secret that does not exist ("not found in any vault") from one that exists but your identity cannot read ("access denied", with the share command to request access) (#253)
 - The shell plugin prints a fetch error once per secret; other keys mapped to the same failed secret get a one-line notice instead of a repeated error (#253)
 

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -13,12 +13,12 @@ _Unreleased_
 
 ### Features
 
-- `secret store` now warns when the secret being overwritten is shared, lists who keeps access, and asks for confirmation when a terminal is attached; new `--share` and `--no-share` flags skip the prompt and keep the recipient set or encrypt to your identity only
+- `secret store` now warns when the secret being overwritten is shared, lists who keeps access, and asks for confirmation when a terminal is attached; new `--share` and `--no-share` flags skip the prompt and keep the recipient set or encrypt to your identity only (#277)
 - The Homebrew cask now installs the zsh/bash/fish shell plugins to `$(brew --prefix)/share/dotsecenv/plugin/`, matching the Linux packages (#253)
 
 ### Bug Fixes
 
-- `secret store` on an existing secret now keeps the current recipient set: the new value is encrypted to everyone on the latest entry's `available_to`, so rotating a shared secret no longer silently locks out CI and teammates
+- `secret store` on an existing secret now keeps the current recipient set: the new value is encrypted to everyone on the latest entry's `available_to`, so rotating a shared secret no longer silently locks out CI and teammates (#277)
 - `secret get` now tells apart a secret that does not exist ("not found in any vault") from one that exists but your identity cannot read ("access denied", with the share command to request access) (#253)
 - The shell plugin prints a fetch error once per secret; other keys mapped to the same failed secret get a one-line notice instead of a repeated error (#253)
 

--- a/website/src/content/docs/concepts/audit-trail.mdx
+++ b/website/src/content/docs/concepts/audit-trail.mdx
@@ -23,7 +23,7 @@ Each entry in a vault is a JSONL line carrying signed metadata. The full schema 
 | `signature`    | identity, secret, value | Detached GPG signature over the entry hash                         |
 | `hash`         | identity, secret, value | SHA-256/SHA-512 of the entry's canonical form                      |
 
-Three operations write entries: `identity add` writes an identity entry; `secret store` writes a secret-definition entry the first time and a value entry every time; `secret share` and `secret revoke` write a new value entry with an updated `available_to`. `secret forget` writes a value entry with empty `available_to` and `deleted: true`.
+Three operations write entries: `identity add` writes an identity entry; `secret store` writes a secret-definition entry the first time and a value entry every time, carrying the previous entry's `available_to` forward; `secret share` and `secret revoke` write a new value entry with an updated `available_to`. `secret forget` writes a value entry with empty `available_to` and `deleted: true`.
 
 ## What append-only can and cannot prove
 

--- a/website/src/content/docs/reference.mdx
+++ b/website/src/content/docs/reference.mdx
@@ -493,6 +493,20 @@ Store an encrypted secret value.
 dotsecenv secret store SECRET [flags]
 ```
 
+Storing over an existing secret keeps its current recipient set: the new value is encrypted to every fingerprint on the latest entry's `available_to`, not just yours. Rotating a shared secret therefore never removes anyone's access. To narrow access, use `secret revoke` (before or after storing).
+
+When the kept recipient set includes identities other than yours, `secret store` warns and lists them. With a terminal attached it then asks for confirmation; declining cancels the store without writing anything. Without a terminal (piped input, CI) it proceeds after the warning. The `--share` and `--no-share` flags skip both the warning and the confirmation.
+
+**Options:**
+
+| Flag | Description |
+|------|-------------|
+| `--share` | Keep the existing recipient set without warning or confirmation |
+| `--no-share` | Encrypt the new value only to your identity |
+| `--json` | Validate that stdin is valid JSON before storing |
+
+`--share` and `--no-share` are mutually exclusive. Note that `--no-share` does not revoke anything by itself: prior entries stay readable to their recipients, and reads by those identities fall back to the newest entry they can decrypt.
+
 **Secret key formats:**
 
 - Namespaced: `namespace::KEY_NAME` (e.g., `myapp::DATABASE_URL`)
@@ -522,6 +536,12 @@ cat ~/.ssh/private_key | dotsecenv secret store SSH_PRIVATE_KEY
 
 # Store in specific vault
 echo "value" | dotsecenv secret store -v ./vault SECRET_NAME
+
+# Rotate a shared secret, keeping the recipient set, without prompting
+echo "new-value" | dotsecenv secret store --share DATABASE_PASSWORD
+
+# Rotate a shared secret for yourself only
+echo "new-value" | dotsecenv secret store --no-share DATABASE_PASSWORD
 ```
 
 ### secret share

--- a/website/src/content/docs/runbooks/team-member-offboarding.mdx
+++ b/website/src/content/docs/runbooks/team-member-offboarding.mdx
@@ -53,6 +53,8 @@ Use [Rotate a Compromised GPG Key](/runbooks/rotate-compromised-key/) instead.
    echo "<new-value>" | dotsecenv secret store SECRET_NAME
    ```
 
+   The new value is encrypted to everyone still on the recipient list, so remaining teammates and CI keep access without re-sharing.
+
 5. **Commit.**
 
    ```bash


### PR DESCRIPTION
## Summary

- `secret store` on an existing key used to encrypt the new value only to the storer, silently revoking every other recipient (including CI) while `vault describe` still showed them on the superseded entry. The new value now carries the latest entry's `available_to` forward and encrypts to every fingerprint on it; an unresolvable recipient fails the store loudly instead of being dropped.
- When the kept set includes other identities, store warns and lists them; with a terminal attached it asks for confirmation via `/dev/tty` (declining cancels without writing), and without one it proceeds after the warning so piped/CI stores keep working.
- New mutually exclusive flags skip the prompt: `--share` keeps the recipient set silently, `--no-share` encrypts only to the storer's identity.
- Docs updated: CLI reference (`secret store` behavior, options table, examples), audit-trail and AGENTS.md model descriptions, offboarding runbook (rotation no longer requires re-sharing), the `secrets` skill, changelog, and a stale comment in `examples/08-compact-vault/run.sh`.
- `TestIssue_RevokeWithoutAccess` relied on the old narrowing behavior to build its fixture; it now uses an explicit revoke. The guarded property (no revoking without access to the latest value) is unchanged.

## Test plan

- [x] New unit tests: carry-forward, first-time store, missing-recipient failure, `--share`/`--no-share`, confirm-yes, decline-aborts-without-writing, no-TTY warn-and-proceed
- [x] `go test ./...` green
- [x] `bash .claude/skills/cli-reference-drift/check.sh` — no drift
- [x] Built binary rejects `--share --no-share` (cobra mutual exclusion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)