### PR TITLE
chore: prepare v0.8.1 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotsecenv",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Manage GPG-encrypted environment secrets using the dotsecenv CLI",
   "author": {
     "name": "dotsecenv",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotsecenv",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Manage GPG-encrypted environment secrets using the dotsecenv CLI",
   "author": {
     "name": "dotsecenv",

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -11,9 +11,20 @@ All notable changes to dotsecenv are documented here. Each version includes chan
 
 _Unreleased_
 
+---
+
+## v0.8.1
+
+_August 3, 2026_
+
 ### Features
 
 - Add first-class Codex plugin packaging alongside Claude Code, backed by one shared set of agent skills (#282)
+
+### Other
+
+- Update the Astro ecosystem dependencies (#279)
+- Update pnpm to v11.18.0 (#280)
 
 ---
 


### PR DESCRIPTION
## Summary

Prepares the v0.8.1 patch release by stamping the accumulated changelog for
August 3, 2026 and synchronizing the Claude Code and Codex plugin manifests to
0.8.1. The marketplace catalog version remains independently versioned.

The release notes include the Codex plugin packaging and backfill the two
dependency PRs merged after v0.8.0.

## Validation

The changelog assessment covers every commit since v0.8.0. The CLI reference
drift check reports every command and flag documented with no duplicate
headings. Both product validators, the shared packaging validator at expected
version 0.8.1, the focused version-helper tests, and the diff whitespace check
pass.

---
