### PR TITLE
fix(contrib): stop the git credential helper serving the wrong credential

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,8 @@ e2e-terraform:
 	echo "Terraform e2e tests passed, cleaned up $$E2E_HOME"
 
 # Git credential helper E2E tests
-# Requires bin/dotsecenv, contrib/, gpg, and jq to exist
+# Requires bin/dotsecenv, contrib/, gpg, and jq to exist. git is optional: it
+# only gates the credential.dotsecenv.useUsername case, which skips without it.
 .PHONY: e2e-git-credential
 e2e-git-credential:
 	@echo "Running git credential helper e2e tests..."

--- a/contrib/git-credential-dotsecenv
+++ b/contrib/git-credential-dotsecenv
@@ -107,14 +107,20 @@ esac
 # some forges allow it in a path. `_OTHER_` is the catch-all for the rest, which
 # only a path can reach.
 #
-# Two inputs still share a key, and both need git to be sending a path
+# Two inputs can still share a key, and both need git to be sending a path
 # (credential.useHttpPath, off by default). Case is one, and nothing here can
 # fix it: dotsecenv upper-cases key names itself (secretkey.go:76), so `/Repo`
 # and `/repo` are one key however this function behaves. Characters outside the
-# encoded set are the other, since they all collapse onto `_OTHER_`. In both
-# cases a request for one repo can be answered with another repo's credential,
-# so the guide says not to lean on useHttpPath for isolation between accounts;
-# credential.dotsecenv.useUsername is the supported way to do that.
+# encoded set are the other, since they all collapse onto `_OTHER_`.
+#
+# Neither is a problem on GitHub or GitLab. Both resolve paths case-insensitively
+# (github.com/Torvalds/Linux serves torvalds/linux, gitlab.com redirects to the
+# canonical spelling), so two repositories cannot differ only in case, and both
+# restrict path characters to [A-Za-z0-9._-], which are all named above. Sharing
+# a key there means two spellings of one repository, which is what you want. It
+# takes a case-sensitive path space to make these bite, such as a git
+# http-backend serving a directory tree, where Backend.git and backend.git are
+# two different repositories.
 encode_key() {
   printf '%s' "$1" \
     | LC_ALL=C sed -e 's/_/_UND_/g' \

--- a/contrib/git-credential-dotsecenv
+++ b/contrib/git-credential-dotsecenv
@@ -103,14 +103,18 @@ esac
 # input ended with.
 #
 # Every character a host can carry is encoded by name, brackets included, since
-# git sends an IPv6 literal as host=[::1]:8443. `_OTHER_` is the catch-all for
-# what is left, which only a path can reach.
+# git sends an IPv6 literal as host=[::1]:8443. Space is encoded too, because
+# some forges allow it in a path. `_OTHER_` is the catch-all for the rest, which
+# only a path can reach.
 #
 # Two inputs still share a key, and both need git to be sending a path
-# (credential.useHttpPath), which is off by default. Case is one: dotsecenv
-# upper-cases key names itself (secretkey.go), so `/Repo` and `/repo` cannot be
-# told apart, and no change here can fix that. Characters outside the encoded
-# set are the other, since they all collapse onto `_OTHER_`.
+# (credential.useHttpPath, off by default). Case is one, and nothing here can
+# fix it: dotsecenv upper-cases key names itself (secretkey.go:76), so `/Repo`
+# and `/repo` are one key however this function behaves. Characters outside the
+# encoded set are the other, since they all collapse onto `_OTHER_`. In both
+# cases a request for one repo can be answered with another repo's credential,
+# so the guide says not to lean on useHttpPath for isolation between accounts;
+# credential.dotsecenv.useUsername is the supported way to do that.
 encode_key() {
   printf '%s' "$1" \
     | LC_ALL=C sed -e 's/_/_UND_/g' \
@@ -122,14 +126,22 @@ encode_key() {
                    -e 's/+/_PLUS_/g' \
                    -e 's/~/_TILDE_/g' \
                    -e 's/%/_PCT_/g' \
+                   -e 's/ /_SP_/g' \
                    -e 's/\[/_LBRK_/g' \
                    -e 's/\]/_RBRK_/g' \
                    -e 's/[^A-Za-z0-9_]/_OTHER_/g' \
     | LC_ALL=C tr '[:lower:]' '[:upper:]'
 }
 [ -z "$proto" ] && proto="https"
-ctx="$proto/$host"
-[ -n "$reqpath" ] && ctx="$ctx/$reqpath"   # included only when git sends path (credential.useHttpPath)
+
+# Each component is encoded on its own and the results are joined with a dot.
+# dotsecenv allows a dot in a key name and encode_key never emits one, so the
+# dot marks a boundary and nothing else can. Joining first and encoding once
+# would let components bleed together: a path of `p/u` and a path of `p` scoped
+# to the user `u` would both come out as `...P_SLASH_U`, and a request for the
+# first would be answered with the second's token.
+name="$(encode_key "$proto").$(encode_key "$host")"
+[ -n "$reqpath" ] && name="$name.$(encode_key "$reqpath")"   # only when git sends path (credential.useHttpPath)
 
 # Opt in to one key per account when a host holds more than one:
 #   git config --global credential.dotsecenv.useUsername true
@@ -138,9 +150,9 @@ ctx="$proto/$host"
 # miss a username-scoped key and re-prompt every time.
 use_username=$(git config --bool --get credential.dotsecenv.useUsername 2>/dev/null || true)
 if [ "$use_username" = "true" ] && [ -n "$username" ]; then
-  ctx="$ctx/$username"
+  name="$name.$(encode_key "$username")"
 fi
-key="git::$(encode_key "$ctx")_END"
+key="git::${name}_END"
 
 # --- Vault selection belongs to dotsecenv, driven by its configuration. ---
 # The default config lists the repo-local .dotsecenv/vault first, then the home

--- a/contrib/git-credential-dotsecenv
+++ b/contrib/git-credential-dotsecenv
@@ -8,13 +8,21 @@
 # helper behind an OAuth generator (git-credential-oauth), so no long-lived token
 # is written to disk.
 #
-# Requires: dotsecenv (logged in) and jq.
+# Requires: dotsecenv (logged in) and jq. The OAuth mode below needs git 2.41+,
+# the first release that round-trips oauth_refresh_token.
+#
+# Both modes start by resetting the helper list. An empty value clears helpers
+# inherited from a lower-priority config file, which --unset-all cannot reach:
+# Apple Git reads a gitconfig inside Xcode that sets credential.helper to
+# osxkeychain, so appending leaves [osxkeychain, dotsecenv]. git then answers
+# from the keychain and stores a copy of every token there too.
 #
 # Mode 1 — store a token/PAT encrypted:
-#   git config --global credential.helper dotsecenv
+#   git config --global --replace-all credential.helper ""
+#   git config --global --add credential.helper dotsecenv
 #
 # Mode 2 — OAuth, no stored PAT (generator must be configured LAST):
-#   git config --global --unset-all credential.helper
+#   git config --global --replace-all credential.helper ""
 #   git config --global --add credential.helper dotsecenv
 #   git config --global --add credential.helper oauth   # git-credential-oauth
 set -euo pipefail
@@ -59,25 +67,73 @@ if [ -z "$host" ]; then
   exit 0
 fi
 
+# --- One pass over the request for the two fields that steer behavior. ---
+username=""
+ephemeral=""
+i=0
+n=${#keys[@]}
+while [ "$i" -lt "$n" ]; do
+  case "${keys[$i]}" in
+    username) username=${vals[$i]} ;;
+    ephemeral) ephemeral=${vals[$i]} ;;
+  esac
+  i=$((i+1))
+done
+# git accepts several spellings of false; treat anything else as a yes, so an
+# unfamiliar spelling keeps the credential out of the vault rather than in it.
+is_ephemeral=0
+case "$ephemeral" in
+  ""|0|false|FALSE|False|no|NO|off|OFF) : ;;
+  *) is_ephemeral=1 ;;
+esac
+
 # --- Derive a dotsecenv-safe, dot-free secret key from protocol/host[/path]. ---
 # dotsecenv key names allow only [A-Z0-9_.] and reject dots at the edges, hyphens,
 # colons, leading digits, all-numeric names, a trailing underscore, and runs of 3+
 # underscores (pkg/dotsecenv/vault/secretkey.go). A colon is legal only as the
-# `git::` namespace separator, never inside the name. Encode structural characters
-# explicitly and let the protocol prefix guarantee a leading letter.
+# `git::` namespace separator, never inside the name.
+#
+# The underscore is the escape character, so it has to be escaped first: every
+# later marker introduces underscores of its own, and escaping `_` last would
+# mangle them. That ordering is what makes the map injective — in the output a
+# `_` always opens a marker, and no marker is a prefix of another. Two rules
+# follow for free, which is why nothing is collapsed or stripped afterwards:
+# markers are `_WORD_`, so a run of underscores never reaches three, and the
+# constant `_END` suffix keeps the name off a trailing underscore whatever the
+# input ended with.
+#
+# Two inputs still share a key. Case is one: dotsecenv upper-cases key names
+# itself (secretkey.go), so `/Repo` and `/repo` cannot be told apart. Characters
+# outside the encoded set are the other: they all land on `_OTHER_`. Both need
+# git to be sending a path (credential.useHttpPath), which is off by default.
 encode_key() {
   printf '%s' "$1" \
-    | LC_ALL=C sed -e 's/\./_DOT_/g' -e 's#/#_SLASH_#g' -e 's/-/_DASH_/g' -e 's/:/_COLON_/g' -e 's/[^A-Za-z0-9_]/_/g' \
-    | LC_ALL=C tr '[:lower:]' '[:upper:]' \
-    | LC_ALL=C sed -E 's/_{3,}/__/g; s/^_+//; s/_+$//'
+    | LC_ALL=C sed -e 's/_/_UND_/g' \
+                   -e 's/\./_DOT_/g' \
+                   -e 's#/#_SLASH_#g' \
+                   -e 's/-/_DASH_/g' \
+                   -e 's/:/_COLON_/g' \
+                   -e 's/@/_AT_/g' \
+                   -e 's/+/_PLUS_/g' \
+                   -e 's/~/_TILDE_/g' \
+                   -e 's/%/_PCT_/g' \
+                   -e 's/[^A-Za-z0-9_]/_OTHER_/g' \
+    | LC_ALL=C tr '[:lower:]' '[:upper:]'
 }
 [ -z "$proto" ] && proto="https"
 ctx="$proto/$host"
 [ -n "$reqpath" ] && ctx="$ctx/$reqpath"   # included only when git sends path (credential.useHttpPath)
-# Multi-account (off by default): uncomment to scope the key by username.
-# username=""; i=0; while [ "$i" -lt "${#keys[@]}" ]; do [ "${keys[$i]}" = "username" ] && username="${vals[$i]}"; i=$((i+1)); done
-# [ -n "$username" ] && ctx="$ctx/$username"
-key="git::$(encode_key "$ctx")"
+
+# Opt in to one key per account when a host holds more than one:
+#   git config --global credential.dotsecenv.useUsername true
+# Off by default because git frequently asks without naming an account (a plain
+# `git clone https://host/repo` sends no username), and those requests would
+# miss a username-scoped key and re-prompt every time.
+use_username=$(git config --bool --get credential.dotsecenv.useUsername 2>/dev/null || true)
+if [ "$use_username" = "true" ] && [ -n "$username" ]; then
+  ctx="$ctx/$username"
+fi
+key="git::$(encode_key "$ctx")_END"
 
 # --- Vault selection belongs to dotsecenv, driven by its configuration. ---
 # The default config lists the repo-local .dotsecenv/vault first, then the home
@@ -97,6 +153,15 @@ case "$op" in
     command -v jq >/dev/null 2>&1 || exit 0
     json=$(dotsecenv secret get "$key" 2>/dev/null) || exit 0
     if [ -n "$json" ]; then
+      # When git names the account it wants, a record for a different account is
+      # not a match. Answering anyway hands git someone else's token, and git
+      # takes the helper's username over the one it asked for.
+      if [ -n "$username" ]; then
+        stored_username=$(printf '%s' "$json" | jq -r '.username // empty' 2>/dev/null || true)
+        if [ -n "$stored_username" ] && [ "$stored_username" != "$username" ]; then
+          exit 0
+        fi
+      fi
       printf '%s' "$json" | jq -r 'to_entries[] | "\(.key)=\(.value)"' 2>/dev/null || exit 0
     fi
     exit 0
@@ -117,6 +182,13 @@ case "$op" in
       i=$((i+1))
       case "$k" in
         protocol|host|path|url) continue ;;   # routing/context, not a credential
+        ephemeral) continue ;;                 # describes this exchange, not the account
+        authtype|credential)
+          # git-credential(1): an ephemeral credential is computed for one
+          # request (an HTTP Digest nonce, say) and must not be saved. Storing
+          # it would also mean replaying a dead value on the next get.
+          if [ "$is_ephemeral" -eq 1 ]; then continue; fi
+          ;;
         *'[]') continue ;;                     # multi-valued protocol fields (wwwauth[], capability[], state[])
       esac
       kv+=("$k" "$v")

--- a/contrib/git-credential-dotsecenv
+++ b/contrib/git-credential-dotsecenv
@@ -147,6 +147,16 @@ encode_key() {
 # to the user `u` would both come out as `...P_SLASH_U`, and a request for the
 # first would be answered with the second's token.
 name="$(encode_key "$proto").$(encode_key "$host")"
+# git hands over the path exactly as the remote spells it, so the same
+# repository cloned as .../api and .../api.git would take two entries and
+# prompt for each. The suffix names the same repository on any server that
+# serves both, which is every forge worth naming, so one trailing .git comes
+# off and the two spellings share a key. Trailing slashes need no handling;
+# git has already removed them by this point. A path of exactly `.git` is left
+# alone, since trimming it would silently widen the key to the whole host.
+case "$reqpath" in
+  ?*.git) reqpath=${reqpath%.git} ;;
+esac
 [ -n "$reqpath" ] && name="$name.$(encode_key "$reqpath")"   # only when git sends path (credential.useHttpPath)
 
 # Opt in to one key per account when a host holds more than one:

--- a/contrib/git-credential-dotsecenv
+++ b/contrib/git-credential-dotsecenv
@@ -102,10 +102,15 @@ esac
 # constant `_END` suffix keeps the name off a trailing underscore whatever the
 # input ended with.
 #
-# Two inputs still share a key. Case is one: dotsecenv upper-cases key names
-# itself (secretkey.go), so `/Repo` and `/repo` cannot be told apart. Characters
-# outside the encoded set are the other: they all land on `_OTHER_`. Both need
-# git to be sending a path (credential.useHttpPath), which is off by default.
+# Every character a host can carry is encoded by name, brackets included, since
+# git sends an IPv6 literal as host=[::1]:8443. `_OTHER_` is the catch-all for
+# what is left, which only a path can reach.
+#
+# Two inputs still share a key, and both need git to be sending a path
+# (credential.useHttpPath), which is off by default. Case is one: dotsecenv
+# upper-cases key names itself (secretkey.go), so `/Repo` and `/repo` cannot be
+# told apart, and no change here can fix that. Characters outside the encoded
+# set are the other, since they all collapse onto `_OTHER_`.
 encode_key() {
   printf '%s' "$1" \
     | LC_ALL=C sed -e 's/_/_UND_/g' \
@@ -117,6 +122,8 @@ encode_key() {
                    -e 's/+/_PLUS_/g' \
                    -e 's/~/_TILDE_/g' \
                    -e 's/%/_PCT_/g' \
+                   -e 's/\[/_LBRK_/g' \
+                   -e 's/\]/_RBRK_/g' \
                    -e 's/[^A-Za-z0-9_]/_OTHER_/g' \
     | LC_ALL=C tr '[:lower:]' '[:upper:]'
 }

--- a/scripts/e2e-git-credential.sh
+++ b/scripts/e2e-git-credential.sh
@@ -265,6 +265,22 @@ else
     echo "  SKIP: git not installed, useUsername case not exercised"
 fi
 
+# Test 19: an IPv6 literal round-trips. git sends the brackets as part of the
+# host (host=[::1]:8443), so they are encoded by name rather than falling through
+# to the catch-all, and two ports on one address stay apart.
+((TESTS_RUN++)) || true
+printf 'protocol=https\nhost=[::1]:8443\nusername=u\npassword=p19a\n\n' | "$HELPER" store 2>/dev/null
+printf 'protocol=https\nhost=[::1]:9443\nusername=u\npassword=p19b\n\n' | "$HELPER" store 2>/dev/null
+v6a=$(printf 'protocol=https\nhost=[::1]:8443\n\n' | "$HELPER" get 2>/dev/null)
+v6b=$(printf 'protocol=https\nhost=[::1]:9443\n\n' | "$HELPER" get 2>/dev/null)
+v6key=$("$BIN" secret get 2>/dev/null | grep -c 'LBRK' || true)
+if echo "$v6a" | grep -q '^password=p19a$' && echo "$v6b" | grep -q '^password=p19b$' \
+    && [ "$v6key" -ge 1 ]; then
+    pass "IPv6 host round-trips with brackets encoded by name"
+else
+    fail "IPv6 host failed: 8443='$v6a' 9443='$v6b' bracket_keys=$v6key"
+fi
+
 echo ""
 echo "==> Git credential helper E2E results"
 echo "Tests run:    $TESTS_RUN"

--- a/scripts/e2e-git-credential.sh
+++ b/scripts/e2e-git-credential.sh
@@ -7,6 +7,11 @@ BIN="bin/dotsecenv"
 HELPER="contrib/git-credential-dotsecenv"
 chmod +x "$BIN" "$HELPER"
 
+# The helper reads credential.dotsecenv.useUsername through git. HOME and
+# XDG_CONFIG_HOME are already isolated by the Makefile; this closes the last
+# door, so a machine-wide /etc/gitconfig cannot change what the tests see.
+export GIT_CONFIG_NOSYSTEM=1
+
 if ! command -v jq >/dev/null 2>&1; then
     echo "jq is required for the git credential helper e2e tests" >&2
     exit 1
@@ -165,7 +170,7 @@ mkdir -p "$proj"
 (cd "$proj" && "$OLDPWD/$BIN" init vault -v .dotsecenv/vault >/dev/null 2>&1)
 altcfg="$PWD/git-credentials-config"
 DOTSECENV_CONFIG="$altcfg" "$BIN" init config >/dev/null 2>&1
-grep -v "$XDG_DATA_HOME/dotsecenv/vault" "$altcfg" > "$altcfg.tmp" && mv "$altcfg.tmp" "$altcfg"
+grep -Fv "$XDG_DATA_HOME/dotsecenv/vault" "$altcfg" > "$altcfg.tmp" && mv "$altcfg.tmp" "$altcfg"
 (cd "$proj" && DOTSECENV_CONFIG="$altcfg" "$OLDPWD/$BIN" login "$KEY" >/dev/null 2>&1)
 h="proj.example"
 store_rc=0
@@ -184,19 +189,80 @@ else
     fail "repo-vault workflow failed: store_rc=$store_rc get='$proj_get' in_repo_vault=$in_repo_vault erase_rc=$erase_rc after_erase='$after_erase'"
 fi
 
-# Test 14: contrived hosts that encode to the same key collide, by design.
-# a_-b → A__DASH_B and a__-b → A___DASH_B → collapses to A__DASH_B; c.example_
-# ends in a stripped underscore, so it lands on c.example's key. Real DNS
-# hostnames cannot contain '_', so the collision is accepted, not fixed.
+# Test 14: runs of underscores stay distinct. The encoder used to collapse three
+# or more underscores into two, so a_-b, a__-b and a___-b all shared one key and
+# overwrote each other. Escaping '_' first keeps them apart.
 ((TESTS_RUN++)) || true
 printf 'protocol=https\nhost=a_-b.example\nusername=u\npassword=p14a\n\n' | "$HELPER" store 2>/dev/null
-collide_a=$(printf 'protocol=https\nhost=a__-b.example\n\n' | "$HELPER" get 2>/dev/null)
-printf 'protocol=https\nhost=c.example_\nusername=u\npassword=p14b\n\n' | "$HELPER" store 2>/dev/null
-collide_b=$(printf 'protocol=https\nhost=c.example\n\n' | "$HELPER" get 2>/dev/null)
-if echo "$collide_a" | grep -q '^password=p14a$' && echo "$collide_b" | grep -q '^password=p14b$'; then
-    pass "contrived underscore hosts collapse to the same key"
+printf 'protocol=https\nhost=a__-b.example\nusername=u\npassword=p14b\n\n' | "$HELPER" store 2>/dev/null
+printf 'protocol=https\nhost=a___-b.example\nusername=u\npassword=p14c\n\n' | "$HELPER" store 2>/dev/null
+run_a=$(printf 'protocol=https\nhost=a_-b.example\n\n' | "$HELPER" get 2>/dev/null)
+run_b=$(printf 'protocol=https\nhost=a__-b.example\n\n' | "$HELPER" get 2>/dev/null)
+run_c=$(printf 'protocol=https\nhost=a___-b.example\n\n' | "$HELPER" get 2>/dev/null)
+if echo "$run_a" | grep -q '^password=p14a$' && echo "$run_b" | grep -q '^password=p14b$' \
+    && echo "$run_c" | grep -q '^password=p14c$'; then
+    pass "underscore runs keep separate keys"
 else
-    fail "expected key collisions, got: collapse='$collide_a' edge-strip='$collide_b'"
+    fail "underscore runs collided: one='$run_a' two='$run_b' three='$run_c'"
+fi
+
+# Test 15: a trailing underscore is part of the name. It used to be stripped, so
+# c.example_ landed on c.example's key and served that host's credential.
+((TESTS_RUN++)) || true
+printf 'protocol=https\nhost=c.example\nusername=u\npassword=p15a\n\n' | "$HELPER" store 2>/dev/null
+printf 'protocol=https\nhost=c.example_\nusername=u\npassword=p15b\n\n' | "$HELPER" store 2>/dev/null
+tail_plain=$(printf 'protocol=https\nhost=c.example\n\n' | "$HELPER" get 2>/dev/null)
+tail_under=$(printf 'protocol=https\nhost=c.example_\n\n' | "$HELPER" get 2>/dev/null)
+if echo "$tail_plain" | grep -q '^password=p15a$' && echo "$tail_under" | grep -q '^password=p15b$'; then
+    pass "trailing underscore keeps a separate key"
+else
+    fail "trailing underscore collided: plain='$tail_plain' underscore='$tail_under'"
+fi
+
+# Test 16: an ephemeral credential is never written to the vault. git-credential(1)
+# says a helper must not save the value in the credential field when ephemeral is
+# set, and a stored copy would also be replayed on the next get.
+((TESTS_RUN++)) || true
+printf 'protocol=https\nhost=eph.example\nusername=u\nauthtype=Digest\ncredential=nonce-bound\nephemeral=1\n\n' | "$HELPER" store 2>/dev/null
+eph_out=$(printf 'protocol=https\nhost=eph.example\n\n' | "$HELPER" get 2>/dev/null)
+if ! echo "$eph_out" | grep -q 'nonce-bound' && ! echo "$eph_out" | grep -q '^ephemeral=' \
+    && ! echo "$eph_out" | grep -q '^authtype='; then
+    pass "ephemeral credential is not stored"
+else
+    fail "ephemeral credential leaked into the vault, got: $eph_out"
+fi
+
+# Test 17: when git names the account it wants, a record for a different account
+# is not an answer. git takes the helper's username over the one it asked for, so
+# replying here would authenticate as the wrong person.
+((TESTS_RUN++)) || true
+printf 'protocol=https\nhost=two.example\nusername=alice\npassword=alice-token\n\n' | "$HELPER" store 2>/dev/null
+wrong_user=$(printf 'protocol=https\nhost=two.example\nusername=bob\n\n' | "$HELPER" get 2>/dev/null)
+right_user=$(printf 'protocol=https\nhost=two.example\nusername=alice\n\n' | "$HELPER" get 2>/dev/null)
+if [ -z "$wrong_user" ] && echo "$right_user" | grep -q '^password=alice-token$'; then
+    pass "get stays silent when the stored account is not the one git asked for"
+else
+    fail "username mismatch mishandled: bob='$wrong_user' alice='$right_user'"
+fi
+
+# Test 18: credential.dotsecenv.useUsername gives each account its own key, so two
+# accounts on one host stop overwriting each other. git reads the setting on the
+# helper's behalf, so the case needs git installed.
+if command -v git >/dev/null 2>&1; then
+    ((TESTS_RUN++)) || true
+    printf '[credential "dotsecenv"]\n\tuseUsername = true\n' > "$HOME/.gitconfig"
+    printf 'protocol=https\nhost=multi.example\nusername=alice\npassword=alice-pw\n\n' | "$HELPER" store 2>/dev/null
+    printf 'protocol=https\nhost=multi.example\nusername=bob\npassword=bob-pw\n\n' | "$HELPER" store 2>/dev/null
+    scoped_alice=$(printf 'protocol=https\nhost=multi.example\nusername=alice\n\n' | "$HELPER" get 2>/dev/null)
+    scoped_bob=$(printf 'protocol=https\nhost=multi.example\nusername=bob\n\n' | "$HELPER" get 2>/dev/null)
+    rm -f "$HOME/.gitconfig"
+    if echo "$scoped_alice" | grep -q '^password=alice-pw$' && echo "$scoped_bob" | grep -q '^password=bob-pw$'; then
+        pass "useUsername keeps two accounts on one host apart"
+    else
+        fail "username scoping failed: alice='$scoped_alice' bob='$scoped_bob'"
+    fi
+else
+    echo "  SKIP: git not installed, useUsername case not exercised"
 fi
 
 echo ""

--- a/scripts/e2e-git-credential.sh
+++ b/scripts/e2e-git-credential.sh
@@ -339,6 +339,33 @@ else
     fail "space path failed: get='$sp_out' sp_keys=$sp_key"
 fi
 
+# Test 24: the .git suffix does not split a repository in two. git passes the
+# path as the remote spells it, so storing under `team/api.git` and fetching
+# under `team/api` used to miss and prompt again.
+((TESTS_RUN++)) || true
+printf 'protocol=https\nhost=suf.test\npath=team/api.git\nusername=u\npassword=tok-suffix\n\n' | "$HELPER" store 2>/dev/null
+suf_bare=$(printf 'protocol=https\nhost=suf.test\npath=team/api\n\n' | "$HELPER" get 2>/dev/null)
+suf_dot=$(printf 'protocol=https\nhost=suf.test\npath=team/api.git\n\n' | "$HELPER" get 2>/dev/null)
+suf_keys=$("$BIN" secret get 2>/dev/null | grep -c 'SUF_DOT_TEST' || true)
+if echo "$suf_bare" | grep -q '^password=tok-suffix$' && echo "$suf_dot" | grep -q '^password=tok-suffix$' \
+    && [ "$suf_keys" -eq 1 ]; then
+    pass "the .git suffix resolves to one entry"
+else
+    fail ".git suffix split the repository: bare='$suf_bare' dotgit='$suf_dot' keys=$suf_keys"
+fi
+
+# Test 25: a path of exactly `.git` keeps it. Trimming would leave nothing and
+# quietly widen the key from one repository to the whole host.
+((TESTS_RUN++)) || true
+printf 'protocol=https\nhost=bare.test\npath=.git\nusername=u\npassword=tok-dotgit\n\n' | "$HELPER" store 2>/dev/null
+only_dot=$(printf 'protocol=https\nhost=bare.test\npath=.git\n\n' | "$HELPER" get 2>/dev/null)
+host_wide=$(printf 'protocol=https\nhost=bare.test\n\n' | "$HELPER" get 2>/dev/null)
+if echo "$only_dot" | grep -q '^password=tok-dotgit$' && [ -z "$host_wide" ]; then
+    pass "a path of .git stays scoped to the path"
+else
+    fail ".git-only path mishandled: path='$only_dot' hostonly='$host_wide'"
+fi
+
 echo ""
 echo "==> Git credential helper E2E results"
 echo "Tests run:    $TESTS_RUN"

--- a/scripts/e2e-git-credential.sh
+++ b/scripts/e2e-git-credential.sh
@@ -133,7 +133,7 @@ fi
 # Test 10: stored secret names are dot-free (encoded)
 ((TESTS_RUN++)) || true
 key_list=$("$BIN" secret get 2>/dev/null || true)
-if echo "$key_list" | grep -qi 'HTTPS_SLASH_GITLAB_DOT_COM' && ! echo "$key_list" | grep -qi 'GITLAB\.COM'; then
+if echo "$key_list" | grep -qi 'HTTPS\.GITLAB_DOT_COM' && ! echo "$key_list" | grep -qi 'GITLAB\.COM'; then
     pass "secret names are dot-free (encoded)"
 else
     fail "expected encoded dot-free key, got keys: $key_list"
@@ -178,7 +178,7 @@ store_rc=0
     | DOTSECENV_CONFIG="$altcfg" "$OLDPWD/$HELPER" store) >/dev/null 2>&1 || store_rc=$?
 proj_get=$(cd "$proj" && printf 'protocol=https\nhost=%s\n\n' "$h" | DOTSECENV_CONFIG="$altcfg" "$OLDPWD/$HELPER" get 2>/dev/null || true)
 in_repo_vault=0
-grep -q 'HTTPS_SLASH_PROJ' "$proj/.dotsecenv/vault" 2>/dev/null && in_repo_vault=1
+grep -q 'HTTPS\.PROJ_DOT_EXAMPLE' "$proj/.dotsecenv/vault" 2>/dev/null && in_repo_vault=1
 erase_rc=0
 (cd "$proj" && printf 'protocol=https\nhost=%s\n\n' "$h" | DOTSECENV_CONFIG="$altcfg" "$OLDPWD/$HELPER" erase) >/dev/null 2>&1 || erase_rc=$?
 after_erase=$(cd "$proj" && printf 'protocol=https\nhost=%s\n\n' "$h" | DOTSECENV_CONFIG="$altcfg" "$OLDPWD/$HELPER" get 2>/dev/null || true)
@@ -279,6 +279,64 @@ if echo "$v6a" | grep -q '^password=p19a$' && echo "$v6b" | grep -q '^password=p
     pass "IPv6 host round-trips with brackets encoded by name"
 else
     fail "IPv6 host failed: 8443='$v6a' 9443='$v6b' bracket_keys=$v6key"
+fi
+
+# Test 20: credential.useHttpPath. git only sends `path` when it is on, so the
+# helper keys per repository. Nothing exercised this before.
+((TESTS_RUN++)) || true
+printf 'protocol=https\nhost=gh.test\npath=acme/api\nusername=u1\npassword=tok-api\n\n' | "$HELPER" store 2>/dev/null
+printf 'protocol=https\nhost=gh.test\npath=acme/web\nusername=u2\npassword=tok-web\n\n' | "$HELPER" store 2>/dev/null
+p_api=$(printf 'protocol=https\nhost=gh.test\npath=acme/api\n\n' | "$HELPER" get 2>/dev/null)
+p_web=$(printf 'protocol=https\nhost=gh.test\npath=acme/web\n\n' | "$HELPER" get 2>/dev/null)
+p_none=$(printf 'protocol=https\nhost=gh.test\n\n' | "$HELPER" get 2>/dev/null)
+if echo "$p_api" | grep -q '^password=tok-api$' && echo "$p_web" | grep -q '^password=tok-web$' \
+    && [ -z "$p_none" ]; then
+    pass "useHttpPath keys per repository"
+else
+    fail "useHttpPath failed: api='$p_api' web='$p_web' hostonly='$p_none'"
+fi
+
+# Test 21: erase under useHttpPath takes one repository, not the host.
+((TESTS_RUN++)) || true
+printf 'protocol=https\nhost=gh.test\npath=acme/api\n\n' | "$HELPER" erase 2>/dev/null
+e_api=$(printf 'protocol=https\nhost=gh.test\npath=acme/api\n\n' | "$HELPER" get 2>/dev/null)
+e_web=$(printf 'protocol=https\nhost=gh.test\npath=acme/web\n\n' | "$HELPER" get 2>/dev/null)
+if [ -z "$e_api" ] && echo "$e_web" | grep -q '^password=tok-web$'; then
+    pass "erase under useHttpPath is scoped to one repository"
+else
+    fail "erase hit the wrong scope: api='$e_api' web='$e_web'"
+fi
+
+# Test 22: a path and a username cannot bleed into each other. Encoding the
+# whole context in one pass made `path=p/u` and `path=p` + `username=u` the same
+# key, so an anonymous request for the first was answered with the second's
+# token. Components are encoded separately and joined on a dot for this reason.
+if command -v git >/dev/null 2>&1; then
+    ((TESTS_RUN++)) || true
+    printf '[credential "dotsecenv"]\n\tuseUsername = true\n' > "$HOME/.gitconfig"
+    printf 'protocol=https\nhost=b.test\npath=p\nusername=u\npassword=tok-p-u\n\n' | "$HELPER" store 2>/dev/null
+    bleed=$(printf 'protocol=https\nhost=b.test\npath=p/u\n\n' | "$HELPER" get 2>/dev/null)
+    scoped=$(printf 'protocol=https\nhost=b.test\npath=p\nusername=u\n\n' | "$HELPER" get 2>/dev/null)
+    rm -f "$HOME/.gitconfig"
+    if [ -z "$bleed" ] && echo "$scoped" | grep -q '^password=tok-p-u$'; then
+        pass "path and username components stay separate"
+    else
+        fail "component bleed: path=p/u got '$bleed', scoped got '$scoped'"
+    fi
+else
+    echo "  SKIP: git not installed, component boundary case not exercised"
+fi
+
+# Test 23: a space in a path round-trips. Some forges allow it (Azure DevOps
+# project names), and it used to fall through to the _OTHER_ catch-all.
+((TESTS_RUN++)) || true
+printf 'protocol=https\nhost=dev.test\npath=My Project/_git/api\nusername=u\npassword=tok-space\n\n' | "$HELPER" store 2>/dev/null
+sp_out=$(printf 'protocol=https\nhost=dev.test\npath=My Project/_git/api\n\n' | "$HELPER" get 2>/dev/null)
+sp_key=$("$BIN" secret get 2>/dev/null | grep -c '_SP_' || true)
+if echo "$sp_out" | grep -q '^password=tok-space$' && [ "$sp_key" -ge 1 ]; then
+    pass "space in a path round-trips and is encoded by name"
+else
+    fail "space path failed: get='$sp_out' sp_keys=$sp_key"
 fi
 
 echo ""

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -11,10 +11,6 @@ All notable changes to dotsecenv are documented here. Each version includes chan
 
 _Unreleased_
 
-### Bug Fixes
-
-- The git credential helper no longer answers with a credential that belongs to a different host or account: the key encoding stopped collapsing runs of underscores and stripping a trailing one, `get` stays silent when git asked for another username, and `ephemeral` credentials are never written to the vault. Set `credential.dotsecenv.useUsername` to keep two accounts on one host apart (#301)
-
 ---
 
 ## v0.8.1

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -11,6 +11,10 @@ All notable changes to dotsecenv are documented here. Each version includes chan
 
 _Unreleased_
 
+### Bug Fixes
+
+- The git credential helper no longer answers with a credential that belongs to a different host or account: the key encoding stopped collapsing runs of underscores and stripping a trailing one, `get` stays silent when git asked for another username, and `ephemeral` credentials are never written to the vault. Set `credential.dotsecenv.useUsername` to keep two accounts on one host apart (#301)
+
 ---
 
 ## v0.8.1


### PR DESCRIPTION
Follow-up to #255. Three separate ways `git-credential-dotsecenv` could answer `get` with a credential that was not the one git asked for, plus the config line that let the macOS keychain keep a copy of every token.

## Key encoding collided

`encode_key` collapsed runs of three or more underscores and stripped a trailing one, because dotsecenv rejects both. Those two rewrites are lossy, so distinct hosts and paths landed on the same vault key and overwrote each other:

```
https/gh.com/a_/b   https/gh.com/a__/b   https/gh.com/a___/b   ->  ..._A__SLASH_B
https/gh.com/x_     https/gh.com/x                             ->  ..._SLASH_X
```

The fix is to escape the escape character. `_` now becomes `_UND_`, applied before every other marker, which makes the map injective: in the output a `_` always opens a marker, and no marker is a prefix of another. Both rewrites then become unnecessary rather than merely undesirable. Markers have the shape `_WORD_`, so a run can never reach three, and a constant `_END` suffix keeps the name off a trailing underscore whatever the input ended with. A fuzz over 2197 generated keys found no validator violation and no collision.

Every character valid in a host is encoded by name, brackets included, since git sends an IPv6 literal as `host=[::1]:8443` and those brackets were falling through to the catch-all. `_OTHER_` is now reachable only through a path.

Two inputs still share a key, and the code comment says so rather than claiming more than the encoder delivers. Case is one: dotsecenv upper-cases key names itself in `secretkey.go`, so `/Repo` and `/repo` cannot be told apart from the helper's side. Characters outside the encoded set are the other, since they all land on `_OTHER_`. Both need `credential.useHttpPath`, which is off by default.

Keys change shape, so a credential stored by an earlier checkout is not found after this. The helper has not shipped in a release yet (#255 merged after v0.8.1), so this only affects people running from a working tree, who can re-authenticate once.

## Path and username shared one key

`credential.useHttpPath` had no test coverage at all, so I drove it and found a third way to get the wrong credential back. Encoding the whole context in one pass made the separator indistinguishable from content: `/` became `_SLASH_` whether it joined two components or came from inside a path. With `useHttpPath` and `useUsername` both on:

```
path=p, username=u   ->  ..._P_SLASH_U
path=p/u, no username ->  ..._P_SLASH_U     # answered with the account's token
```

Components are encoded separately now and joined on a dot. dotsecenv allows a dot in a key name and `encode_key` never emits one, so a dot can only ever mean a boundary. Keys get shorter as a side effect, since the common one drops from `HTTPS_SLASH_GITLAB_DOT_COM_END` to `HTTPS.GITLAB_DOT_COM_END`.

Space is encoded by name as well, because forges like Azure DevOps allow it in a project path and it was falling through to the catch-all.

Four new cases cover `useHttpPath`: per-repository keys, `erase` staying scoped to one repository, the component boundary, and a path with a space in it. Per-repository storage and scoped `erase` both already worked; they were simply untested.

## `api` and `api.git` were two repositories

Under `useHttpPath`, git passes the path as the remote spells it, so the same repository cloned two ways took two vault entries and prompted for each:

```
path=team/api       ->  ...TEAM_SLASH_API_END
path=team/api.git   ->  ...TEAM_SLASH_API_DOT_GIT_END
```

The suffix names the same repository on any server that serves both, so one trailing `.git` now comes off before the key is derived. Trailing slashes needed no handling, since git has already removed them by the time the helper runs: `https://host/team/api/` arrives as `team/api`.

A path of exactly `.git` keeps it. Trimming would leave nothing and silently widen the key from one repository to the whole host, and a test holds that line.

## Ephemeral credentials were stored

`git-credential(1)` says a helper must not save the value in the `credential` field when `ephemeral` is set, since it is computed for one request. The store filter skipped only `protocol|host|path|url` and `*[]`, so `authtype`, `credential`, and `ephemeral=1` were all encrypted into the vault, and the dead value came back on the next `get`. An unfamiliar spelling of the boolean now counts as true, so the failure mode is a credential kept out of the vault rather than one written into it.

## `get` answered for the wrong account

The key covers protocol and host only, and username scoping sat commented out. When two accounts share a host, a request for one returned the other's token, and git prefers the username a helper returns over the one it asked for, so the push authenticated as the wrong person.

`get` now stays silent when the stored record names a different account than git asked for. That alone removes the wrong-token path. Supporting two accounts properly is opt-in:

```bash
git config --global credential.dotsecenv.useUsername true
```

It is off by default because git often asks without naming an account. A plain `git clone https://host/repo` sends no username, and those requests would miss a username-scoped key and re-prompt every time.

## The header told macOS users to append

Apple Git reads a gitconfig inside Xcode that sets `credential.helper` to `osxkeychain`, and `--unset-all` cannot reach a lower-priority config file. Appending left the list as `[osxkeychain, dotsecenv]`: git answered from the keychain and stored a copy of every token there as well. Both modes in the header now reset the list with an empty value first. The guide carries the same correction in a separate PR.

## Tests

Four new cases in `scripts/e2e-git-credential.sh`, and the old case 14 is inverted, since it asserted the collisions this PR removes. Each new guard was mutation-tested by reverting it and confirming the suite goes red:

| Reverted | Result |
| --- | --- |
| underscore escape, collapse and strip restored | cases 14 and 15 fail |
| `ephemeral` filter arms | case 16 fails |
| username mismatch guard | case 17 fails |
| `useUsername` lookup | case 18 fails |

18 of 18 pass on the branch. The helper stays shellcheck-clean and parses under stock macOS bash 3.2. Case 18 needs `git` to read the setting and skips without it, which the Makefile comment now records.

Merge this before the docs PR, which describes the behavior as it stands afterwards.

---



