### PR TITLE
fix(install): report the helpers the installer actually wrote

### DIFF
--- a/scripts/e2e-install.sh
+++ b/scripts/e2e-install.sh
@@ -475,6 +475,50 @@ run_test "--version invalid exits non-zero" bash -c "
 "
 
 # ===================================================================
+# L. Optional helper reporting
+# ===================================================================
+echo ""
+echo "==> L. Optional helper reporting"
+
+# Test 33: a release archive that predates the git credential helper leaves the
+# summary quiet about it. The installer skips the file it cannot find, and the
+# summary used to name a path that was never written.
+run_test "missing git helper stays out of the summary" bash -c "
+    source '${INSTALL_SCRIPT}'
+    tmp=\$(mktemp -d)
+    mkdir -p \"\$tmp/contrib\" \"\$tmp/bin\"
+    INSTALL_DIR=\"\$tmp/bin\"
+    install_git_credential_helper \"\$tmp\" >/dev/null 2>&1 || true
+    summary=\$(print_summary 2>&1)
+    rm -rf \"\$tmp\"
+    [ -z \"\${GIT_HELPER_TARGET}\" ] && ! echo \"\$summary\" | grep -q 'Git helper:'
+"
+
+# Test 34: when the archive does carry it, the summary names where it landed.
+run_test "installed git helper is named in the summary" bash -c "
+    source '${INSTALL_SCRIPT}'
+    tmp=\$(mktemp -d)
+    mkdir -p \"\$tmp/contrib\" \"\$tmp/bin\"
+    cp '${SCRIPT_DIR}/../contrib/git-credential-dotsecenv' \"\$tmp/contrib/\"
+    INSTALL_DIR=\"\$tmp/bin\"
+    install_git_credential_helper \"\$tmp\" >/dev/null 2>&1
+    summary=\$(print_summary 2>&1)
+    rm -rf \"\$tmp\"
+    [ -n \"\${GIT_HELPER_TARGET}\" ] && echo \"\$summary\" | grep -q 'Git helper:'
+"
+
+# Test 35: the same gate covers the Terraform helper, which skips identically.
+run_test "missing TF helper stays out of the summary" bash -c "
+    source '${INSTALL_SCRIPT}'
+    tmp=\$(mktemp -d)
+    mkdir -p \"\$tmp/contrib\"
+    install_tf_helper \"\$tmp\" >/dev/null 2>&1 || true
+    summary=\$(print_summary 2>&1)
+    rm -rf \"\$tmp\"
+    [ -z \"\${TF_HELPER_TARGET}\" ] && ! echo \"\$summary\" | grep -q 'TF helper:'
+"
+
+# ===================================================================
 # Final Report
 # ===================================================================
 echo ""

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -53,6 +53,13 @@ VERIFY="${VERIFY:-1}"
 
 TMPDIR_ROOT=""
 
+# Where the optional helpers actually landed. Empty means nothing was written,
+# either because the component was turned off or because the release archive
+# did not carry it, so the summary can report what is on disk rather than what
+# was asked for.
+TF_HELPER_TARGET=""
+GIT_HELPER_TARGET=""
+
 # ---------------------------------------------------------------------------
 # Cleanup
 # ---------------------------------------------------------------------------
@@ -597,6 +604,7 @@ install_tf_helper() {
         mkdir -p "${tf_plugin_dir}"
         install -m 755 "${helper_src}" "${tf_plugin_dir}/terraform-credentials-dotsecenv"
     fi
+    TF_HELPER_TARGET="${tf_plugin_dir}"
     success "Terraform credentials helper installed to ${tf_plugin_dir}"
 
     printf "\n"
@@ -629,34 +637,63 @@ install_git_credential_helper() {
     else
         install -m 755 "${helper_src}" "${dest}"
     fi
+    GIT_HELPER_TARGET="${dest}"
     success "Git credential helper installed to ${dest}"
+
+    check_git_version_for_helper
 
     printf "\n"
     printf "${BLUE}==>${RESET} Enable it with:\n"
     cat <<'GITEOF'
 
-    git config --global credential.helper dotsecenv
+    git config --global --replace-all credential.helper ""
+    git config --global --add credential.helper dotsecenv
 
 GITEOF
+    printf "  The empty value first clears any helper set by a lower-priority\n"
+    printf "  config file, such as the osxkeychain that Apple Git enables.\n"
     printf "  Requires ${BOLD}jq${RESET}. For OAuth without a stored token, also add a\n"
     printf "  generator such as git-credential-oauth (configured last).\n"
+}
+
+# The OAuth workflow needs git 2.41, the first release that round-trips
+# oauth_refresh_token. Older git drops the field without saying anything, so the
+# generator re-runs its browser flow on every fetch and nothing points at why.
+# A stored token works on any version, so this is a warning, not a failure.
+check_git_version_for_helper() {
+    local raw major minor rest
+    raw="$(git --version 2>/dev/null | awk '{print $3}')"
+
+    if [ -z "${raw}" ]; then
+        warn "git is not on PATH; install git to use the credential helper"
+        return 0
+    fi
+
+    major="${raw%%.*}"
+    rest="${raw#*.}"
+    minor="${rest%%.*}"
+    case "${major}" in ''|*[!0-9]*) return 0 ;; esac
+    case "${minor}" in ''|*[!0-9]*) return 0 ;; esac
+
+    if [ "${major}" -lt 2 ] || { [ "${major}" -eq 2 ] && [ "${minor}" -lt 41 ]; }; then
+        warn "git ${raw} predates 2.41, which is where oauth_refresh_token round-trips."
+        warn "A stored token works fine. The OAuth workflow will loop back to the browser."
+    fi
 }
 
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 print_summary() {
-    local share_prefix comp_dir man_dir tf_dir
+    local share_prefix comp_dir man_dir
     if is_system_install; then
         share_prefix="/usr/share"
         [ "$(uname -s)" = "Darwin" ] && share_prefix="/usr/local/share"
         comp_dir="${share_prefix}"
         man_dir="/usr/local/share/man/man1"
-        tf_dir="${share_prefix}/terraform/plugins"
     else
         comp_dir="${HOME}/.local/share"
         man_dir="${HOME}/.local/share/man/man1"
-        tf_dir="${HOME}/.terraform.d/plugins"
     fi
 
     printf "\n"
@@ -676,8 +713,11 @@ print_summary() {
         fi
         printf "  Shell plugin: ${plugin_summary_dir}/\n"
     fi
-    [ "${INSTALL_TF_CREDENTIALS_HELPER}" = "1" ] && printf "  TF helper:    ${tf_dir}/\n"
-    [ "${INSTALL_GIT_CREDENTIALS_HELPER}" = "1" ] && printf "  Git helper:   ${INSTALL_DIR}/git-credential-dotsecenv\n"
+    # Both helpers skip themselves when the archive does not carry them, which is
+    # what happens on a release older than the one that added them. Report the
+    # path only once something is there to report.
+    [ -n "${TF_HELPER_TARGET}" ] && printf "  TF helper:    ${TF_HELPER_TARGET}/\n"
+    [ -n "${GIT_HELPER_TARGET}" ] && printf "  Git helper:   ${GIT_HELPER_TARGET}\n"
     printf "\n"
     printf "  Get started:  ${BOLD}dotsecenv --help${RESET}\n"
     printf "\n"

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -11,6 +11,14 @@ All notable changes to dotsecenv are documented here. Each version includes chan
 
 _Unreleased_
 
+### Bug Fixes
+
+- `install.sh` no longer reports a Terraform or git credential helper it skipped: both are absent from release archives older than the one that added them, and the summary now names only what it wrote. Installing the git credential helper also warns when git predates 2.41, where the OAuth workflow's `oauth_refresh_token` starts round-tripping (#302)
+
+### Other
+
+- Document `--[no-]install-git-credentials-helper` and `INSTALL_GIT_CREDENTIALS_HELPER` in the installation tutorial (#302)
+
 ---
 
 ## v0.8.1

--- a/website/src/content/docs/tutorials/installation.mdx
+++ b/website/src/content/docs/tutorials/installation.mdx
@@ -290,6 +290,7 @@ Every setting can be configured via a CLI flag or an environment variable. CLI f
 | Completions | `--[no-]install-completions` | `INSTALL_COMPLETIONS` | `1` (yes) | Install shell completions for bash, zsh, and fish |
 | Man pages | `--[no-]install-man-pages` | `INSTALL_MAN_PAGES` | `1` (yes) | Install man pages |
 | TF credentials helper | `--[no-]install-tf-credentials-helper` | `INSTALL_TF_CREDENTIALS_HELPER` | `1` (yes) | Install the Terraform credentials helper |
+| Git credentials helper | `--[no-]install-git-credentials-helper` | `INSTALL_GIT_CREDENTIALS_HELPER` | `1` (yes) | Install the git credential helper next to the binary |
 | Verification | `--[no-]verify` | `VERIFY` | `1` (yes) | Verify SHA-256 checksums and GPG signatures |
 | Help | `-h`, `--help` | — | — | Show help and exit |
 
@@ -304,6 +305,7 @@ Every setting can be configured via a CLI flag or an environment variable. CLI f
 7. Installs man pages under `~/.local/share/man/man1/` by default (or system man directories with `--system`)
 8. Installs the shell plugin: clones to `~/.local/share/dotsecenv/plugin/` by default (or system share path with `--system`), and also integrates with detected plugin managers (Oh My Zsh, Zinit, Antidote, Oh My Bash, Fisher, Oh My Fish). Fish `conf.d` is linked automatically if fish is present.
 9. Installs the Terraform credentials helper to `~/.terraform.d/plugins/` by default (or system share path with `--system`). Skip with `--no-install-tf-credentials-helper`.
+10. Installs the git credential helper next to the binary, since git resolves `git-credential-*` from your `PATH`. Skip with `--no-install-git-credentials-helper`. Both helpers report only what they wrote, so a release that predates one of them leaves it out of the summary.
 
 #### Install Paths
 
@@ -314,6 +316,7 @@ Every setting can be configured via a CLI flag or an environment variable. CLI f
 | Man pages | `~/.local/share/man/man1/` | `/usr/local/share/man/man1/` | `/usr/local/share/man/man1/` |
 | Shell plugin | `~/.local/share/dotsecenv/plugin/` | `/usr/local/share/dotsecenv/plugin/` | `/usr/share/dotsecenv/plugin/` |
 | TF helper | `~/.terraform.d/plugins/` | `/usr/local/share/terraform/plugins/` | `/usr/share/terraform/plugins/` |
+| Git helper | `~/.local/bin/` | `/usr/local/bin/` | `/usr/local/bin/` |
 
 #### Examples
 


### PR DESCRIPTION
Follow-up to #255. The installer summary claimed it had installed things it had skipped, and nothing warned about the git version the OAuth workflow needs.

## The summary described intent, not disk

`install_git_credential_helper` warns and returns when the release archive has no helper in it:

```
warning: Git credential helper not found in archive; skipping
```

`print_summary` then printed the path anyway, because it keyed off `INSTALL_GIT_CREDENTIALS_HELPER`, which is the request rather than the result:

```
  Git helper:   /home/you/.local/bin/git-credential-dotsecenv
```

This is not hypothetical. `install.sh` fetches the latest release, which is v0.8.1, and #255 merged after it. Every run today warns and then claims the helper is installed, pointing at a path with nothing at it. The Terraform helper has the same shape and the same bug, reachable by installing any release before v0.5.0, so both are fixed together.

Each installer now records where it wrote, and the summary prints a line only when a helper landed.

## git version

The OAuth workflow needs git 2.41, the first release where `oauth_refresh_token` survives a round trip through a storage helper. Older git drops the field silently, so the generator re-runs its browser flow on every fetch and nothing on screen says why. Ubuntu 22.04 ships 2.34 and Debian 12 ships 2.39, so this is a live case rather than a museum piece.

The installer now warns while it installs the helper, and says plainly that a stored token still works:

```
warning: git 2.39.5 predates 2.41, which is where oauth_refresh_token round-trips.
warning: A stored token works fine. The OAuth workflow will loop back to the browser.
```

Silent for 2.41+, for Apple Git's `2.50.1 (Apple Git-155)`, for a hypothetical 3.x, and for an unparseable string. A missing git gets its own line instead.

## Setup lines

The commands the installer prints now reset the helper list rather than appending to it:

```bash
git config --global --replace-all credential.helper ""
git config --global --add credential.helper dotsecenv
```

Apple Git reads a gitconfig inside Xcode that sets `credential.helper` to `osxkeychain`. Appending leaves the keychain first in the list, where it answers every `get` and receives a copy of every stored token. An empty value clears helpers from lower-priority config files, which is the only way to reach that one.

## Docs and tests

`installation.mdx` documents `--[no-]install-git-credentials-helper` and `INSTALL_GIT_CREDENTIALS_HELPER`, which were shipped in #255 but never written down, unlike the Terraform equivalent. The helper is also in the install-paths table now.

Three cases in `scripts/e2e-install.sh`, all offline, driving the installer functions directly the way the existing unit-style cases do. Reverting the summary gate turns two of them red, and the positive case stays green, which is the split you want.

Independent of the other follow-ups; it touches no file they touch.

---
