### PR TITLE
ci: align the git credential job with the workflow's action pins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,9 +192,9 @@ jobs:
     needs: [test, build-docs]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
-      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16  # v6.5.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: "go.mod"
           cache-dependency-path: "go.sum"

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -11,6 +11,10 @@ All notable changes to dotsecenv are documented here. Each version includes chan
 
 _Unreleased_
 
+### Other
+
+- Align the `e2e-git-credential` CI job with the action pins the rest of `ci.yml` already uses (#303)
+
 ---
 
 ## v0.8.1


### PR DESCRIPTION
Follow-up to #255. The `e2e-git-credential` job it added pinned `actions/checkout` to v7.0.0 and `actions/setup-go` to v6.5.0, while the six jobs around it were already on v7.0.1 and v7.0.0.

Renovate bumps a pin wherever it recognizes one, so a job holding a different SHA keeps its own older copy and misses whatever the newer tag carried. `ci.yml` now resolves to exactly one SHA per action:

```
actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1   # v7.0.1
actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e   # v7.0.0
```

Both SHAs are the ones the other jobs already run, so nothing new is being trusted here. actionlint is clean.

---