### PR TITLE
docs(guides): correct the git credential helper page and mark it experimental

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ end-to-end test harness verified by network-namespace + strace in CI.
 | `internal/cli/`     | CLI command implementations, validators, interactive helpers, error mapping.   |
 | `internal/xdg/`     | XDG Base Directory resolution.                                                 |
 | `pkg/dotsecenv/`    | Public packages: `config/`, `crypto/`, `gpg/`, `identity/`, `output/`, `policy/`, `vault/`. |
-| `contrib/`          | `terraform-credentials-dotsecenv` Bash credentials helper for Terraform/OpenTofu. |
+| `contrib/`          | Bash helpers that plug dotsecenv into other tools: `terraform-credentials-dotsecenv` for Terraform/OpenTofu, `git-credential-dotsecenv` for git over HTTPS. |
 | `demos/`            | `demo.sh` for asciinema recording (driven by `make demo`).                     |
 | `skills/`           | Shared Claude Code and Codex plugin skills (`secenv/`, `secrets/`, `vault/`).     |
 | `.claude/skills/`   | Maintainer-only skills, NOT shipped to plugin installers (`changelog/`, `cli-reference-drift/`). |
@@ -243,6 +243,25 @@ What the script does NOT do — handle manually if needed:
   Features, `fix` -> Bug Fixes, else Other), ending with the PR number. Release
   notes build up per PR; the release PR stamps "Upcoming" to the tag.
   `bash .claude/skills/changelog/assess.sh` reports any merged PRs missing from it.
+- **Marking a feature experimental on the website:** use the shared
+  `Experimental` component, don't hand-roll an aside. Import it from
+  `website/src/components/Experimental.astro` and put it directly under the
+  page's imports, above the first paragraph, so a reader meets it before
+  following any instructions:
+
+  ```mdx
+  import Experimental from "../../../components/Experimental.astro";
+
+  <Experimental feature="The git credential helper" />
+  ```
+
+  `feature` is the sentence subject and defaults to "This feature". The notice
+  says the behavior and storage shape can change in any release with no
+  deprecation period, and to keep the feature off critical workloads. The
+  wording lives in one place so it reads the same everywhere; change the
+  component rather than the page. Drop the tag in the same PR that makes the
+  feature stable. Currently used by
+  `website/src/content/docs/guides/git-credential-helper.mdx`.
 - **Branches:** `feat/*`, `fix/*`, `docs/*`, etc. (see `CONTRIBUTING.md`).
 - **PRs only:** All changes land on `main` through pull requests. Don't
   push commits directly to `main`, even when your account holds a bypass

--- a/website/.markdownlint.json
+++ b/website/.markdownlint.json
@@ -3,7 +3,7 @@
   "MD013": false,
   "MD024": false,
   "MD033": {
-    "allowed_elements": ["Tabs", "TabItem", "Steps", "Aside", "Card", "CardGrid", "LinkCard", "AsciinemaPlayer", "DownloadCommands", "VersionOutput", "VersionExample", "a", "details", "summary", "div", "img", "Badge"]
+    "allowed_elements": ["Tabs", "TabItem", "Steps", "Aside", "Card", "CardGrid", "LinkCard", "AsciinemaPlayer", "DownloadCommands", "VersionOutput", "VersionExample", "Experimental", "a", "details", "summary", "div", "img", "Badge"]
   },
   "MD036": false,
   "MD041": false,

--- a/website/src/components/Experimental.astro
+++ b/website/src/components/Experimental.astro
@@ -1,0 +1,30 @@
+---
+/**
+ * Experimental - the standard notice for a feature that ships before its
+ * behavior has settled.
+ *
+ * Put it directly under the page's imports, above the first paragraph, so a
+ * reader meets it before following any instructions. Remove it in the same PR
+ * that makes the feature stable.
+ *
+ * Usage:
+ *   <Experimental />
+ *   <Experimental feature="The git credential helper" />
+ */
+import { Aside } from '@astrojs/starlight/components';
+
+interface Props {
+  /** What is experimental, as a sentence subject. Defaults to "This feature". */
+  feature?: string;
+}
+
+const { feature = 'This feature' } = Astro.props;
+---
+
+<Aside type="caution" title="Experimental">
+  <p>
+    {feature} is experimental. Its behavior and the shape of what it stores can change
+    in any release, with no deprecation period. Keep it away from critical workloads
+    until this notice is gone.
+  </p>
+</Aside>

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -13,12 +13,11 @@ _Unreleased_
 
 ### Features
 
-- Add `contrib/git-credential-dotsecenv`, an experimental git credential helper that stores HTTPS credentials encrypted in your vault and preserves OAuth `oauth_refresh_token`/`password_expiry_utc` fields so it can back a generator like git-credential-oauth (no stored PAT); the deb/rpm/Arch packages and install.sh install it to a `PATH` directory (#255)
+- Add `contrib/git-credential-dotsecenv`, an experimental git credential helper that stores HTTPS credentials encrypted in your vault and preserves OAuth `oauth_refresh_token`/`password_expiry_utc` fields so it can back a generator like git-credential-oauth (no stored PAT); the deb/rpm/Arch packages and install.sh install it to a `PATH` directory, and `jq` is a package Recommends since `store` needs it. Point git at it with `git config --global --replace-all credential.helper "" && git config --global --add credential.helper dotsecenv`, which keeps the macOS keychain out of the chain. Needs git 2.41+ for the OAuth workflow (#255, #301, #304, #305)
 
 ### Bug Fixes
 
 - `install.sh` no longer reports a Terraform or git credential helper it skipped: both are absent from release archives older than the one that added them, and the summary now names only what it wrote. Installing the git credential helper also warns when git predates 2.41, where the OAuth workflow's `oauth_refresh_token` starts round-tripping (#302)
-- The git credential helper guide no longer claims the helper shipped in v0.8.0, and its macOS setup resets `credential.helper` instead of appending to it, so the Xcode-provided osxkeychain stops answering first and stops receiving a copy of every stored token (#304)
 
 ### Other
 

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -18,10 +18,12 @@ _Unreleased_
 ### Bug Fixes
 
 - `install.sh` no longer reports a Terraform or git credential helper it skipped: both are absent from release archives older than the one that added them, and the summary now names only what it wrote. Installing the git credential helper also warns when git predates 2.41, where the OAuth workflow's `oauth_refresh_token` starts round-tripping (#302)
+- The git credential helper guide no longer claims the helper shipped in v0.8.0, and its macOS setup resets `credential.helper` instead of appending to it, so the Xcode-provided osxkeychain stops answering first and stops receiving a copy of every stored token (#304)
 
 ### Other
 
 - Document `--[no-]install-git-credentials-helper` and `INSTALL_GIT_CREDENTIALS_HELPER` in the installation tutorial (#302)
+- New `Experimental` website component carries one standard notice for features whose behavior can still change; the git credential helper guide is the first to use it (#304)
 
 ---
 

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -11,6 +11,10 @@ All notable changes to dotsecenv are documented here. Each version includes chan
 
 _Unreleased_
 
+### Features
+
+- Add `contrib/git-credential-dotsecenv`, an experimental git credential helper that stores HTTPS credentials encrypted in your vault and preserves OAuth `oauth_refresh_token`/`password_expiry_utc` fields so it can back a generator like git-credential-oauth (no stored PAT); the deb/rpm/Arch packages and install.sh install it to a `PATH` directory (#255)
+
 ### Bug Fixes
 
 - `install.sh` no longer reports a Terraform or git credential helper it skipped: both are absent from release archives older than the one that added them, and the summary now names only what it wrote. Installing the git credential helper also warns when git predates 2.41, where the OAuth workflow's `oauth_refresh_token` starts round-tripping (#302)
@@ -44,7 +48,6 @@ _July 31, 2026_
 
 - `secret store` now warns when the secret being overwritten is shared, lists who keeps access, and asks for confirmation when a terminal is attached; new `--share` and `--no-share` flags skip the prompt and keep the recipient set or encrypt to your identity only (#277)
 - The Homebrew cask now installs the zsh/bash/fish shell plugins to `$(brew --prefix)/share/dotsecenv/plugin/`, matching the Linux packages (#253)
-- Add `contrib/git-credential-dotsecenv`, a git credential helper that stores HTTPS credentials encrypted in your vault and preserves OAuth `oauth_refresh_token`/`password_expiry_utc` fields so it can back a generator like git-credential-oauth (no stored PAT); the deb/rpm/Arch packages and install.sh install it to a `PATH` directory (#255)
 
 ### Bug Fixes
 

--- a/website/src/content/docs/guides/git-credential-helper.mdx
+++ b/website/src/content/docs/guides/git-credential-helper.mdx
@@ -35,13 +35,20 @@ Because `store` keeps every credential attribute git sends, the OAuth fields `oa
 
 By default the key covers protocol and host, which is what git sends. Turning on `credential.useHttpPath` adds the repository path, so each repository gets its own credential.
 
-<Aside type="caution" title="useHttpPath is not account isolation">
-  Two paths that differ only in letter case share a key, because dotsecenv upper-cases
-  key names and the helper cannot change that. So do two paths differing only in a
-  character the encoder does not name, which all collapse together. Either way a
-  request for one repository can be answered with another's credential. Use the
-  username scoping below to keep accounts apart, not `useHttpPath`.
+<Aside type="note" title="Two things path scoping does not split">
+  The path is upper-cased into the key, so two paths differing only in letter case
+  share one entry. On GitHub and GitLab that is the behavior you want: both resolve
+  paths case-insensitively, so `Acme/Repo` and `acme/repo` are the same repository.
+  It only matters where two repositories really can differ only in case, such as a
+  `git http-backend` serving a directory tree.
+
+  The `.git` suffix is part of the path, so `https://host/team/api` and
+  `https://host/team/api.git` get separate entries and each prompts once. Every
+  path-scoped helper works this way, `credential.helper store` included.
 </Aside>
+
+Path scoping and the username scoping below solve different problems and compose:
+one credential per repository, one credential per account.
 
 ## Two accounts on one host
 

--- a/website/src/content/docs/guides/git-credential-helper.mdx
+++ b/website/src/content/docs/guides/git-credential-helper.mdx
@@ -35,16 +35,14 @@ Because `store` keeps every credential attribute git sends, the OAuth fields `oa
 
 By default the key covers protocol and host, which is what git sends. Turning on `credential.useHttpPath` adds the repository path, so each repository gets its own credential.
 
-<Aside type="note" title="Two things path scoping does not split">
-  The path is upper-cased into the key, so two paths differing only in letter case
-  share one entry. On GitHub and GitLab that is the behavior you want: both resolve
-  paths case-insensitively, so `Acme/Repo` and `acme/repo` are the same repository.
-  It only matters where two repositories really can differ only in case, such as a
-  `git http-backend` serving a directory tree.
+A repository keeps one entry however you spell the remote. git strips a trailing slash before the helper sees the path, and the helper drops a trailing `.git`, so `https://host/team/api` and `https://host/team/api.git` share a credential rather than prompting separately the way `credential.helper store` does.
 
-  The `.git` suffix is part of the path, so `https://host/team/api` and
-  `https://host/team/api.git` get separate entries and each prompts once. Every
-  path-scoped helper works this way, `credential.helper store` included.
+<Aside type="note" title="Case is folded into the key">
+  Paths are upper-cased in the vault key, so two that differ only in letter case share
+  one entry. On GitHub and GitLab that is what you want, since both resolve paths
+  case-insensitively and those are the same repository. It only matters on a server
+  where two repositories really can differ only in case, such as a `git http-backend`
+  serving a directory tree.
 </Aside>
 
 Path scoping and the username scoping below solve different problems and compose:

--- a/website/src/content/docs/guides/git-credential-helper.mdx
+++ b/website/src/content/docs/guides/git-credential-helper.mdx
@@ -29,11 +29,19 @@ git calls the helper with three operations and exchanges `key=value` attributes 
 | `store`   | the full credential  | Saves the credential fields as one encrypted JSON secret       |
 | `erase`   | protocol, host, path | Marks the secret deleted (idempotent)                          |
 
-The helper derives the secret name from the request context. `https://gitlab.com` becomes the vault key `git::HTTPS_SLASH_GITLAB_DOT_COM_END`. Characters that git hosts carry but dotsecenv keys reject are encoded (`.` to `_DOT_`, `/` to `_SLASH_`, `-` to `_DASH_`, `:` to `_COLON_`, and `_` itself to `_UND_`), so hyphenated hosts, ports, and IP addresses all resolve to a valid key. The `_END` suffix is there so a name never finishes on an underscore, which dotsecenv rejects.
+The helper derives the secret name from the request context. `https://gitlab.com` becomes the vault key `git::HTTPS.GITLAB_DOT_COM_END`. Characters that git hosts carry but dotsecenv keys reject are encoded (`.` to `_DOT_`, `/` to `_SLASH_`, `-` to `_DASH_`, `:` to `_COLON_`, and `_` itself to `_UND_`), so hyphenated hosts, ports, IPv6 literals, and IP addresses all resolve to a valid key. Each part of the context is encoded on its own and the parts are joined with a dot, which is the one character the encoder never produces, so a path can never be mistaken for an account. The `_END` suffix keeps the name off a trailing underscore, which dotsecenv rejects.
 
 Because `store` keeps every credential attribute git sends, the OAuth fields `oauth_refresh_token` and `password_expiry_utc` survive a round trip. That is all a generator helper needs to refresh an expired access token without a browser. An `ephemeral` credential is the exception: git marks those as valid for one request, and the helper drops them rather than storing a value that is already dead.
 
-By default the key covers protocol and host, which is what git sends. Turning on `credential.useHttpPath` adds the repository path, and two paths that differ only in letter case then land on the same key, because dotsecenv upper-cases key names. If you turned it on to separate two accounts, use the username scoping below instead.
+By default the key covers protocol and host, which is what git sends. Turning on `credential.useHttpPath` adds the repository path, so each repository gets its own credential.
+
+<Aside type="caution" title="useHttpPath is not account isolation">
+  Two paths that differ only in letter case share a key, because dotsecenv upper-cases
+  key names and the helper cannot change that. So do two paths differing only in a
+  character the encoder does not name, which all collapse together. Either way a
+  request for one repository can be answered with another's credential. Use the
+  username scoping below to keep accounts apart, not `useHttpPath`.
+</Aside>
 
 ## Two accounts on one host
 
@@ -191,7 +199,7 @@ printf 'protocol=https\nhost=gitlab.com\n\n' | git-credential-dotsecenv erase
 Confirm the secret landed in your vault:
 
 ```bash
-dotsecenv secret get 'git::HTTPS_SLASH_GITLAB_DOT_COM_END' --json
+dotsecenv secret get 'git::HTTPS.GITLAB_DOT_COM_END' --json
 ```
 
 ## Troubleshooting

--- a/website/src/content/docs/guides/git-credential-helper.mdx
+++ b/website/src/content/docs/guides/git-credential-helper.mdx
@@ -4,14 +4,20 @@ description: Use dotsecenv as an encrypted credential store for git over HTTPS
 ---
 
 import { Tabs, TabItem, Aside, Steps } from "@astrojs/starlight/components";
+import Experimental from "../../../components/Experimental.astro";
 
-<Aside type="note" title="Available in v0.8.0+">
-  The `git-credential-dotsecenv` helper ships in v0.8.0.
+<Experimental feature="The git credential helper" />
+
+<Aside type="note" title="Unreleased">
+  The `git-credential-dotsecenv` helper is on `main` and has not shipped in a release
+  yet. To try it before then, use the manual install below.
 </Aside>
 
-Use dotsecenv as a [git credential helper](https://git-scm.com/docs/gitcredentials). Tokens for HTTPS remotes are encrypted at rest in your vault instead of sitting in plaintext `~/.git-credentials` or the OS keychain.
+Use dotsecenv as a [git credential helper](https://git-scm.com/docs/gitcredentials). Tokens for HTTPS remotes are encrypted at rest in your vault instead of sitting in plaintext `~/.git-credentials`, and instead of the OS keychain once you point git at dotsecenv alone.
 
-The same helper backs two workflows. In the first, git asks for a username and password once and dotsecenv keeps the token encrypted, a drop-in replacement for `credential.helper store` and `osxkeychain`. In the second, you pair it with a generator like [`git-credential-oauth`](https://github.com/hickford/git-credential-oauth): dotsecenv holds only the OAuth refresh token, git mints short-lived access tokens on demand, and no long-lived personal access token ever lands on disk.
+The same helper backs two workflows. In the first, git asks for a username and password once and dotsecenv keeps the token encrypted, replacing `credential.helper store` or `osxkeychain`. In the second, you pair it with a generator like [`git-credential-oauth`](https://github.com/hickford/git-credential-oauth): git keeps a short-lived access token in play and dotsecenv holds the refresh token that mints the next one, so no long-lived personal access token ever lands on disk. Both the access token and the refresh token are stored, encrypted; the access token is the one that expires on its own.
+
+The OAuth workflow needs git 2.41 or newer. That is the first release where `oauth_refresh_token` survives a round trip through a storage helper. Older git drops the field without saying anything, so the generator opens a browser on every fetch. Ubuntu 22.04 ships 2.34 and Debian 12 ships 2.39. A stored token works on any version.
 
 ## How It Works
 
@@ -19,21 +25,35 @@ git calls the helper with three operations and exchanges `key=value` attributes 
 
 | Operation | git sends            | dotsecenv behavior                                              |
 | --------- | -------------------- | -------------------------------------------------------------- |
-| `get`     | protocol, host, path | Returns the stored credential for that host, or nothing        |
-| `store`   | the full credential  | Saves every field as one encrypted JSON secret                 |
+| `get`     | protocol, host, path, sometimes username | Returns the stored credential, or nothing when none matches |
+| `store`   | the full credential  | Saves the credential fields as one encrypted JSON secret       |
 | `erase`   | protocol, host, path | Marks the secret deleted (idempotent)                          |
 
-The helper derives the secret name from the request context. `https://gitlab.com` becomes the vault key `git::HTTPS_SLASH_GITLAB_DOT_COM`. Dots and other characters that git hosts carry but dotsecenv keys reject are encoded (`.` to `_DOT_`, `/` to `_SLASH_`, `-` to `_DASH_`, `:` to `_COLON_`), so hyphenated hosts, ports, and IP addresses all resolve to a valid key.
+The helper derives the secret name from the request context. `https://gitlab.com` becomes the vault key `git::HTTPS_SLASH_GITLAB_DOT_COM_END`. Characters that git hosts carry but dotsecenv keys reject are encoded (`.` to `_DOT_`, `/` to `_SLASH_`, `-` to `_DASH_`, `:` to `_COLON_`, and `_` itself to `_UND_`), so hyphenated hosts, ports, and IP addresses all resolve to a valid key. The `_END` suffix is there so a name never finishes on an underscore, which dotsecenv rejects.
 
-Because `store` keeps every attribute git sends, the OAuth fields `oauth_refresh_token` and `password_expiry_utc` survive a round trip. That is all a generator helper needs to refresh an expired access token without a browser.
+Because `store` keeps every credential attribute git sends, the OAuth fields `oauth_refresh_token` and `password_expiry_utc` survive a round trip. That is all a generator helper needs to refresh an expired access token without a browser. An `ephemeral` credential is the exception: git marks those as valid for one request, and the helper drops them rather than storing a value that is already dead.
 
-## Which vault credentials go to
+By default the key covers protocol and host, which is what git sends. Turning on `credential.useHttpPath` adds the repository path, and two paths that differ only in letter case then land on the same key, because dotsecenv upper-cases key names. If you turned it on to separate two accounts, use the username scoping below instead.
+
+## Two accounts on one host
+
+The key does not include the username, so a second account on the same host would overwrite the first. The helper refuses to paper over that: when git names the account it wants and the stored record belongs to someone else, `get` returns nothing and git prompts.
+
+To keep both, give each account its own key:
+
+```bash
+git config --global credential.dotsecenv.useUsername true
+```
+
+This is off by default because git often asks without naming an account. A plain `git clone https://host/repo` sends no username, and with scoping on, that request finds nothing and prompts. Turn it on when you actually have two accounts on one host, and put the username in the remote URL (`https://alice@host/repo`) so git always names it.
+
+## Where credentials are stored
 
 The helper does not pick a vault itself. Vault selection follows your dotsecenv configuration, exactly like any other `dotsecenv secret` command. The default config lists the repo-local `.dotsecenv/vault` first and your home vault (`~/.local/share/dotsecenv/vault`) second.
 
 Inside a repository that carries a committed vault, that vault is a resolvable target: storing a credential there encrypts it to the vault's recipients and ships it with the repo. This is by design — it is how a team shares a deploy token or CI credential alongside the code that needs it.
 
-When more than one configured vault resolves, dotsecenv asks you to pick one on `store` and `erase`. Git runs the helper with your terminal attached, so the picker works during a normal `git push`. Without a terminal (a GUI client, CI), the operation fails with `multiple vaults configured and no terminal available`.
+When more than one configured vault resolves, dotsecenv asks you to pick one on `store` and `erase`. Git runs the helper with your terminal attached, so the picker works during a normal `git push`. Without a terminal (a GUI client, CI), the operation fails with `multiple vaults configured and no terminal available; please specify target vault using -v`.
 
 To route git credentials through a dedicated setup, point `DOTSECENV_CONFIG` at an alternate config file listing only the vault you want. The variable is the CLI's own config override, and the helper inherits it from git's environment — set it where git runs, since GUI clients don't source your shell profile.
 
@@ -42,7 +62,7 @@ To route git credentials through a dedicated setup, point `DOTSECENV_CONFIG` at 
 - dotsecenv installed and logged in, with at least one vault (see [Getting Started](/getting-started/))
 - [`jq`](https://jqlang.github.io/jq/) on your `PATH`
 - git with an HTTPS remote
-- For the OAuth workflow: a generator helper such as `git-credential-oauth`
+- For the OAuth workflow: git 2.41 or newer, and a generator helper such as `git-credential-oauth`
 
 ## Installation
 
@@ -103,10 +123,11 @@ git looks for `git-credential-<name>` on your `PATH`, so the helper has to sit i
     <Tabs>
 
     <TabItem label="Stored token">
-    Point git's credential helper at dotsecenv:
+    Clear the helper list, then point it at dotsecenv:
 
     ```bash
-    git config --global credential.helper dotsecenv
+    git config --global --replace-all credential.helper ""
+    git config --global --add credential.helper dotsecenv
     ```
 
     The next time git prompts for a password on an HTTPS remote, it hands the token to dotsecenv, which encrypts it in your vault.
@@ -116,7 +137,7 @@ git looks for `git-credential-<name>` on your `PATH`, so the helper has to sit i
     Chain dotsecenv as the store with a generator that runs last:
 
     ```bash
-    git config --global --unset-all credential.helper
+    git config --global --replace-all credential.helper ""
     git config --global --add credential.helper dotsecenv
     git config --global --add credential.helper oauth
     ```
@@ -129,6 +150,25 @@ git looks for `git-credential-<name>` on your `PATH`, so the helper has to sit i
     </TabItem>
 
     </Tabs>
+
+    <Aside type="caution" title="Why the empty value comes first">
+      `credential.helper` is a list, and git asks every helper on it. An empty value
+      resets that list, which `--unset-all` cannot do because it only clears the file
+      you point it at. On macOS this matters: Apple Git reads a gitconfig inside Xcode
+      that already sets `osxkeychain`. Append instead of reset and the keychain stays
+      ahead of dotsecenv, answering every request and keeping its own copy of every
+      token you store.
+    </Aside>
+
+3. **Confirm dotsecenv is the only helper**
+
+    ```bash
+    git config --get-all credential.helper
+    # dotsecenv
+    ```
+
+    An empty first line is the reset and is expected. Any other name means git will
+    consult that helper too.
 
 </Steps>
 
@@ -151,7 +191,7 @@ printf 'protocol=https\nhost=gitlab.com\n\n' | git-credential-dotsecenv erase
 Confirm the secret landed in your vault:
 
 ```bash
-dotsecenv secret get 'git::HTTPS_SLASH_GITLAB_DOT_COM' --json
+dotsecenv secret get 'git::HTTPS_SLASH_GITLAB_DOT_COM_END' --json
 ```
 
 ## Troubleshooting
@@ -160,9 +200,12 @@ dotsecenv secret get 'git::HTTPS_SLASH_GITLAB_DOT_COM' --json
 | ------------------------------------------------ | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | git prompts for a password every time            | Helper not found, or `get` failing | Check `git credential-dotsecenv` runs, that you ran `dotsecenv login`, and that `jq` is installed                                                            |
 | `jq is required for store`                       | `jq` missing                       | Install `jq` and retry                                                                                                                                       |
-| `multiple vaults configured and no terminal available` | `store`/`erase` ran without a terminal while several vaults resolve | Run the git command in a terminal to get the vault picker, or set `DOTSECENV_CONFIG` to a config listing a single vault                        |
+| `multiple vaults configured and no terminal available; please specify target vault using -v` | `store`/`erase` ran without a terminal while several vaults resolve | Run the git command in a terminal to get the vault picker, or set `DOTSECENV_CONFIG` to a config listing a single vault |
 | git prompts on every fetch even when stored      | GPG agent not caching              | Set `default-cache-ttl 3600` and `max-cache-ttl 14400` in `~/.gnupg/gpg-agent.conf`, then `gpgconf --reload gpg-agent`. See the [GPG Agent guide](/guides/gpg-agent/) |
 | OAuth stops working, browser opens again         | Refresh token revoked or expired   | Re-run the generator's login flow; dotsecenv stores the new refresh token on the next `store`                                                                |
+| The generator opens a browser on every fetch      | git older than 2.41 drops `oauth_refresh_token` | Check `git --version` and upgrade. A stored token works on any version |
+| git still uses an old token after you erased it   | Another helper is ahead of dotsecenv in the list | `git config --get-all credential.helper` should show only the reset and `dotsecenv` |
+| A second account on a host gets no credential     | The stored record belongs to the other account | Set `credential.dotsecenv.useUsername` to `true` and put the username in the remote URL |
 
 ---
 


### PR DESCRIPTION
Follow-up to #255. The guide made four claims the code does not support, and the release notes placed the feature in a version that never carried it.

## It never shipped in v0.8.0

The page opened with "Available in v0.8.0+", and the changelog entry sat under the stamped v0.8.0 section. #255 merged on August 16, after v0.8.0 (July 31) and v0.8.1 (August 3) were both out, so neither release contains the helper. A reader on a current release followed the guide, found nothing on `PATH`, and had nothing on the page to suggest the guide was ahead of the binary.

The changelog entry moves to `## Upcoming`, and the page says plainly that the helper is on `main` and points at the manual install. That aside needs a version once this ships.

## macOS kept the token, and answered first

The setup was `git config --global credential.helper dotsecenv`, an append. `credential.helper` is a list, and Apple Git reads a gitconfig inside Xcode that already sets `osxkeychain`, so the list came out as `[osxkeychain, dotsecenv]`. git stops at the first helper that returns a usable credential, so the keychain answered everything and dotsecenv was never consulted. `store` does not stop, so the keychain also received a copy of every token.

That made two sentences on the page false for anyone following the macOS tab: that tokens sit encrypted "instead of ... the OS keychain", and that this is a drop-in replacement for `osxkeychain`. The OAuth tab was worse, because `--unset-all` only clears the file you point it at and cannot reach a system-scope helper, so the refresh token was copied into the keychain too.

Both workflows now reset the list, which is the only thing that clears a lower-priority config file:

```bash
git config --global --replace-all credential.helper ""
git config --global --add credential.helper dotsecenv
```

There is a verification step after it, since the failure is silent otherwise:

```bash
git config --get-all credential.helper
# (empty line, then) dotsecenv
```

## Three smaller corrections

The OAuth paragraph said dotsecenv holds only the refresh token. `store` keeps every credential field git sends, including the access token, which the page's own workflow description said two sections later.

The vault error was quoted without its second half. The real string is `multiple vaults configured and no terminal available; please specify target vault using -v` (`internal/cli/interactive.go:97`), and the troubleshooting table is what people match against.

The OAuth workflow needs git 2.41 and the page never said so. Older git drops `oauth_refresh_token` silently and the generator opens a browser on every fetch. Ubuntu 22.04 ships 2.34, Debian 12 ships 2.39.

The vault section heading was `Which vault credentials go to`, a fragment. It is now `Where credentials are stored`, matching the sentence-case topical headings used elsewhere on the site.

## Experimental notice

New `website/src/components/Experimental.astro`, holding one copy of the wording for a feature whose behavior can still change: it can change in any release with no deprecation period, and it should stay off critical workloads. Having it in a component means pages don't each write their own version, and the wording changes in one place.

```mdx
import Experimental from "../../../components/Experimental.astro";

<Experimental feature="The git credential helper" />
```

AGENTS.md documents where it lives, where on the page it goes, and that it comes off in the same PR that makes a feature stable. `contrib/` in the layout table also mentions the git helper now, which it did not.

## Behavior documented from the other PRs

Two sections describe what #301 changes, which is why this should merge after it: username scoping through `credential.dotsecenv.useUsername`, and what the key encoding does and does not separate, including the case collision under `credential.useHttpPath` that no encoder-side change can fix, because dotsecenv upper-cases key names itself.

Three troubleshooting rows added for failures that previously had no entry: the browser reopening on old git, a stale token from another helper still in the list, and a second account getting nothing.

Site builds, markdownlint and eslint pass. `Experimental` is allowlisted in MD033 alongside the other components.

---
