### PR TITLE
fix(packaging): recommend jq instead of suggesting it

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -151,10 +151,15 @@ nfpms:
       - archlinux
     dependencies:
       - gnupg
+    recommends:
+      # git-credential-dotsecenv needs jq for `store`. Recommends, not Depends:
+      # the helper is optional, so jq should not be forced on everyone who
+      # installs dotsecenv. apt and dnf both pull weak dependencies by default,
+      # so anyone who does not opt out gets a working helper. Arch has no nfpm
+      # mapping for this, so there it stays documentation-only.
+      - jq
     suggests:
       - bash-completion
-      # jq is required by the bundled git-credential-dotsecenv helper
-      - jq
     rpm:
       packager: DotSecEnv <release@dotsecenv.com>
       signature:

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -11,6 +11,10 @@ All notable changes to dotsecenv are documented here. Each version includes chan
 
 _Unreleased_
 
+### Bug Fixes
+
+- The deb and rpm packages now list `jq` under Recommends rather than Suggests, so apt and dnf install it by default and `git-credential-dotsecenv store` works on a fresh package install. Arch has no nfpm mapping for weak dependencies, so it stays documented there (#305)
+
 ---
 
 ## v0.8.1

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -11,10 +11,6 @@ All notable changes to dotsecenv are documented here. Each version includes chan
 
 _Unreleased_
 
-### Bug Fixes
-
-- The deb and rpm packages now list `jq` under Recommends rather than Suggests, so apt and dnf install it by default and `git-credential-dotsecenv store` works on a fresh package install. Arch has no nfpm mapping for weak dependencies, so it stays documented there (#305)
-
 ---
 
 ## v0.8.1


### PR DESCRIPTION
Follow-up to #255, and the last of its open threads. `git-credential-dotsecenv` needs `jq` for `store`, and the deb/rpm packages put the helper on `PATH`, but `jq` sat under `suggests`.

Neither apt nor dnf installs Suggests. So someone could install the package, enable the helper, and hit a hard failure on the first push:

```
git-credential-dotsecenv: jq is required for store
```

`get` is worse in its own way, because it degrades quietly and git just prompts again, which reads as "the helper does nothing" rather than as a missing dependency.

## Why not Depends

Copilot's thread asked for a hard dependency. That trades one problem for another: the helper is optional contrib, and `Depends: jq` pushes jq onto everyone who installs dotsecenv, including the majority who never configure git credentials.

`recommends` is the field for exactly this shape, a dependency that is almost always wanted and still removable. apt installs Recommends by default (`APT::Install-Recommends` has been on since lenny) and dnf installs weak dependencies by default (`install_weak_deps=True`). The common path gets a working helper, and anyone who runs `--no-install-recommends` or sets `install_weak_deps=False` has already said they want a smaller install.

## Verified on built packages

`make release-test` runs with `--skip=nfpm`, so CI never inspects package contents and a config-only check would prove nothing. I built a full snapshot with nfpm enabled, against a throwaway signing key, and read the metadata out of the artifacts:

| Format | Result |
| --- | --- |
| deb | `Depends: gnupg`, `Recommends: jq`, `Suggests: bash-completion` |
| rpm | `REQUIRENAME: gnupg`, `RECOMMENDNAME: jq`, `SUGGESTNAME: bash-completion` |
| archlinux | `depend = gnupg`, nothing else |

RPM tag 5046 is the weak-dependency tag, so this is a real Recommends rather than a Requires under another name. Arch is unchanged because nfpm has no archlinux mapping for weak dependencies; `optdepends` would be the equivalent and there is no way to emit it from here. The config comment records that so the next person does not go looking.

`/usr/bin/git-credential-dotsecenv` is still in the deb payload, so nothing about the contents moved.

Independent of the other follow-ups.

---
