### PR TITLE
chore(cli): drop unreachable helpers from internal packages

### DIFF
--- a/cmd/dotsecenv/cmd_init_test.go
+++ b/cmd/dotsecenv/cmd_init_test.go
@@ -79,16 +79,6 @@ func TestInitConfig_HasBehaviorSection(t *testing.T) {
 	}
 }
 
-func TestInitConfig_LoginFlag(t *testing.T) {
-	// The --login flag now creates a signed login proof, which requires GPG
-	// to sign the proof. Skip this test if GPG is not available.
-	skipIfNoGPG(t)
-
-	// This test requires a real GPG key - we need to use e2e tests for proper validation
-	// For now, we just test the flag parsing without actual GPG operations
-	t.Skip("TestInitConfig_LoginFlag requires real GPG key - tested in e2e")
-}
-
 func TestInitConfig_BehaviorCommentsExist(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")

--- a/cmd/dotsecenv/cmd_init_test.go
+++ b/cmd/dotsecenv/cmd_init_test.go
@@ -3,22 +3,12 @@ package main_test
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
 )
-
-// skipIfNoGPG skips the test if GPG is not available
-func skipIfNoGPG(t *testing.T) {
-	t.Helper()
-	_, err := exec.LookPath("gpg")
-	if err != nil {
-		t.Skip("GPG not available, skipping test")
-	}
-}
 
 // configForTest represents the config file structure for test assertions
 type configForTest struct {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -284,12 +284,6 @@ func (c *CLI) Output() *output.Handler {
 	return c.output
 }
 
-// SetJSONMode enables or disables JSON output mode for the current command.
-// This creates a new handler with fresh warning collection.
-func (c *CLI) SetJSONMode(enabled bool) {
-	c.output = c.output.WithJSONMode(enabled)
-}
-
 // Close closes the vault and releases locks
 func (c *CLI) Close() error {
 	if c.vaultResolver != nil {

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/dotsecenv/dotsecenv/pkg/dotsecenv/output"
 )
@@ -71,20 +70,4 @@ func PrintError(w io.Writer, err error) ExitCode {
 	// Generic error
 	_, _ = fmt.Fprintf(w, "%v\n", err)
 	return ExitGeneralError
-}
-
-// PrintWarning prints a warning to stderr.
-func PrintWarning(w io.Writer, message string) {
-	_, _ = fmt.Fprintf(w, "warning: %s\n", message)
-}
-
-// PrintSuccess prints a success message to stdout.
-func PrintSuccess(w io.Writer, message string) {
-	_, _ = fmt.Fprintf(w, "%s\n", message)
-}
-
-// ExitWithError exits the program with the given error.
-func ExitWithError(err error) {
-	code := PrintError(os.Stderr, err)
-	os.Exit(int(code))
 }

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -9,41 +9,6 @@ import (
 	"runtime/debug"
 )
 
-// PrintHelp prints the help message
-func PrintHelp(w io.Writer) {
-	help := `dotsecenv: safe environment secrets
-
-USAGE:
-  dotsecenv [-v VAULT_PATH] [-c CONFIG_PATH] COMMAND [ARGS]
-
-OPTIONS:
-  -v PATH    Path to vault file (global, for all commands)
-  -c PATH    Path to config file (global, for all commands)
-
-COMMANDS:
-  login FINGERPRINT             Initialize user identity
-  init config [-c PATH]         Initialize configuration file
-  init vault [-c PATH]          Initialize vault (interactive from config)
-  init vault -v PATH            Initialize specific vault file
-  secret store SECRET           Store encrypted secret
-  secret get SECRET [--all] [--json] Retrieve secret value(s)
-  secret share SECRET FINGERPRINT [--all] Share secret with another identity
-  secret revoke SECRET FINGERPRINT [--all] Revoke access from identity
-  vault describe [--json]       Describe vaults with identities and secrets
-  vault doctor [--json] [--fix] Run health checks and fix issues
-  validate                      Validate vault and config
-  policy list [--json]          Print the effective system policy
-  policy validate               Validate policy fragments under /etc/dotsecenv/policy.d/
-  version                       Show version information
-
-ENVIRONMENT:
-  DOTSECENV_CONFIG              Override config file path
-  XDG_CONFIG_HOME               Override config directory
-  XDG_DATA_HOME                 Override data directory
-`
-	_, _ = fmt.Fprint(w, help)
-}
-
 // PrintVersion prints the version information
 func PrintVersion(w io.Writer, version, commit, date string) {
 	if version == "" {


### PR DESCRIPTION
Five exported symbols in `internal/` with no caller anywhere, tests included. `internal/` is unimportable outside the module, so nothing external could have been depending on them either.

| File | Removed |
| --- | --- |
| `internal/cli/errors.go` | `PrintWarning`, `PrintSuccess`, `ExitWithError` |
| `internal/cli/help.go` | `PrintHelp` |
| `internal/cli/cli.go` | `SetJSONMode` |

`NewError` and `PrintError` are the two live functions in `errors.go`; `PrintVersion` and `PrintVersionJSON` keep `help.go` alive. Dropping `ExitWithError` made the `os` import unused, which is why that goes too.

`TestInitConfig_LoginFlag` goes with them. Its whole body is `skipIfNoGPG(t)` followed by an unconditional `t.Skip` and no assertions, so it has never executed a line. A test that cannot run is worse than an absent one, because it reads as coverage in a listing.

## One near miss worth recording

`xdg.VaultPath` came up dead by the same search and is not. It is called as `p.VaultPath()` inside its own package, which a package-qualified grep never sees. The compiler caught it. Anyone repeating this sweep should let the build be the authority rather than a grep.

Build, `go vet`, and the full test suite pass.

---