### PR TITLE
chore(vault): drop the version-specific header markers

### DIFF
--- a/pkg/dotsecenv/vault/format.go
+++ b/pkg/dotsecenv/vault/format.go
@@ -234,12 +234,6 @@ func isNumeric(s string) bool {
 	return true
 }
 
-// HeaderMarkerForVersion returns the header marker (version-independent).
-// Deprecated: The version parameter is ignored. Use HeaderMarker constant directly.
-func HeaderMarkerForVersion(_ int) string {
-	return HeaderMarker
-}
-
 // detectVersionFromJSON extracts the version from header JSON without full parsing.
 // Uses a heuristic approach:
 // 1. Fast path: assume version field is first ({"version":N,...)

--- a/pkg/dotsecenv/vault/format_v1.go
+++ b/pkg/dotsecenv/vault/format_v1.go
@@ -80,6 +80,3 @@ func UnmarshalHeaderV1(data []byte) (*Header, error) {
 
 	return h, nil
 }
-
-// HeaderMarkerV1 is the header marker for v1 vaults.
-const HeaderMarkerV1 = "# === VAULT HEADER v1 ==="

--- a/pkg/dotsecenv/vault/format_v2.go
+++ b/pkg/dotsecenv/vault/format_v2.go
@@ -56,6 +56,3 @@ func UnmarshalHeaderV2(data []byte) (*Header, error) {
 
 	return h, nil
 }
-
-// HeaderMarkerV2 is the header marker for v2 vaults.
-const HeaderMarkerV2 = "# === VAULT HEADER v2 ==="

--- a/pkg/dotsecenv/vault/upgrade_test.go
+++ b/pkg/dotsecenv/vault/upgrade_test.go
@@ -570,22 +570,3 @@ func TestManagerRequireExplicitUpgrade_NoAutoUpgrade(t *testing.T) {
 		t.Errorf("expected 2 identities, got %d", len(vault.Identities))
 	}
 }
-
-func TestHeaderMarkerForVersion(t *testing.T) {
-	// HeaderMarkerForVersion now returns a constant marker regardless of version
-	tests := []struct {
-		version  int
-		expected string
-	}{
-		{1, HeaderMarker},
-		{2, HeaderMarker},
-		{10, HeaderMarker},
-	}
-
-	for _, tt := range tests {
-		got := HeaderMarkerForVersion(tt.version)
-		if got != tt.expected {
-			t.Errorf("HeaderMarkerForVersion(%d) = %q, want %q", tt.version, got, tt.expected)
-		}
-	}
-}


### PR DESCRIPTION
Three leftovers from the move to a versionless vault header marker. None are reachable, and two are actively misleading.

`HeaderMarkerV1` and `HeaderMarkerV2` have no references anywhere, tests included. They are worse than clutter, because neither matches what a vault file contains:

```go
const HeaderMarkerV2 = "# === VAULT HEADER v2 ==="   // matches nothing
const HeaderMarker   = "# === VAULT HEADER ==="      // what real vaults carry
```

Code written against `HeaderMarkerV2` would compile, read plausibly, and never match a line.

`HeaderMarkerForVersion(_ int)` took a version and ignored it, returning the same constant for every input. Its own doc comment said as much. Its only caller was a test written to confirm that it ignores its argument.

## Legacy vaults keep working

Old versioned markers are recognised by `DetectMarkerType` through a prefix plus a numeric-middle check, not through these constants:

```go
case strings.HasPrefix(line, legacyMarkerPrefix) && strings.HasSuffix(line, legacyMarkerSuffix):
    middle := line[len(legacyMarkerPrefix) : len(line)-len(legacyMarkerSuffix)]
    if len(middle) > 0 && isNumeric(middle) { return MarkerHeaderLegacy }
```

`ValidateHeaderMarker` still accepts both shapes, `UnmarshalHeaderV1` still has callers, and the v1 to v2 upgrade path is untouched. Vault tests and the full suite pass.

## The one judgement call

These are exported from `pkg/`, which AGENTS.md calls a public surface, so this is technically breaking for an external importer. Worth taking anyway: the symbols that would break are the two that cannot match real data and the one that ignores its input.

---