### PR TITLE
docs: correct statements that no longer match the repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -840,11 +840,13 @@ jobs:
       version: ${{ github.ref_name }}
 
   # ---------------------------------------------------------------------------
-  # Monorepo publish jobs (PR 1 of the monorepo migration).
-  # Additive only: old repository_dispatch fan-out above remains intact.
-  # `continue-on-error: true` so failures in these new jobs do not block the
-  # existing pipeline. Status-aware DAG (no draft, sidecar .release-sha,
-  # release-complete integrity gate) lands in PR 3.
+  # Monorepo publish jobs. Each pushes a source directory to its satellite repo
+  # and tags it with the release version.
+  #
+  # These are status-aware rather than best-effort: every job below gates on the
+  # release chain ahead of it with `needs:` plus `if: !failure() && !cancelled()`,
+  # so a half-finished release does not propagate to the satellites. Nothing here
+  # runs with continue-on-error.
   # ---------------------------------------------------------------------------
 
   publish-plugin:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,9 @@ end-to-end test harness verified by network-namespace + strace in CI.
 | `action.yml`        | Composite GitHub Action for installing dotsecenv in CI.                        |
 | `.goreleaser.yaml`  | Release pipeline (signs, attests, packages deb/rpm/archlinux).                 |
 | `lefthook.yml`      | Git hook config: `pre-commit` runs `make lint`, `pre-push` runs `make clean test build e2e`. |
-| `.mise.toml`        | Tool versions for [mise](https://mise.jdx.dev) (installs `dotsecenv` itself for downstream consumers). |
+| `mise.toml`         | Toolchain for working in this repo: go, node, pnpm. `mise install` at the root sets them up. |
+| `.mise.toml`        | Declares `dotsecenv` itself as a [mise](https://mise.jdx.dev) tool, for downstream consumers of this repo. |
+| `.mise.local.toml`  | Committed override that turns the above off, so working in the repo does not install a released `dotsecenv` over your build. |
 
 ## Build / test / lint / e2e
 
@@ -205,7 +207,9 @@ What the script does NOT do — handle manually if needed:
 
 ## Conventions
 
-- **Go version:** 1.26.2 (see `go.mod`). Go 1.26+ required.
+- **Go version:** `go.mod` carries the language version; `mise.toml` pins the
+  toolchain contributors install. They move independently, so read them rather
+  than a number written here.
 - **FIPS 140-3:** Release binaries set `GOFIPS140=v1.26.0` and `CGO_ENABLED=0`.
   The build is pure-Go; **don't add CGO dependencies**.
 - **Vendoring:** Dependencies are vendored. `make build` uses `-mod=vendor`.


### PR DESCRIPTION
Two places where a comment describes something the repo stopped doing.

## release.yml claimed best-effort publishing

The block above the monorepo publish jobs was written partway through that migration:

> `continue-on-error: true` so failures in these new jobs do not block the existing pipeline. Status-aware DAG (no draft, sidecar `.release-sha`, release-complete integrity gate) lands in PR 3.

PR 3 landed. There is no `continue-on-error` anywhere in the file, and every publish job already gates on the release chain with `needs:` plus `if: !failure() && !cancelled()`. A reader trusting the comment would believe a failed release still propagates to the satellites, which is the opposite of what the file does.

## AGENTS.md pinned a Go version in prose

It said 1.26.2 while `go.mod` says 1.26.5 and `mise.toml` says 1.26.6. A version copied into prose goes stale the first time Renovate runs, so it points at the files now.

The layout table also listed only `.mise.toml`, described as the tool versions file. There are three, and that is not the one contributors need:

| File | Purpose |
| --- | --- |
| `mise.toml` | go, node, pnpm for working in this repo |
| `.mise.toml` | declares `dotsecenv` as a tool for downstream consumers |
| `.mise.local.toml` | committed override disabling the above in-repo |

All three are listed now. The `.mise.local.toml` arrangement is deliberate and clever, and surprising enough to write down, since that filename is normally a developer's personal file rather than a committed one.

actionlint is clean.

---