### PR TITLE
docs(changelog): backfill the dependency updates since v0.8.1

### DIFF
--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -28,6 +28,7 @@ _Unreleased_
 - Update lint and JS tooling: eslint, typescript-eslint, pnpm (#287, #291, #294)
 - Update GitHub Actions: checkout, setup-go, pnpm/action-setup, harden-runner, attest-build-provenance, setup-uv (#283, #290, #292, #293, #296, #299, #300)
 - Update the Go toolchain to 1.26.6 and uv (#284, #289, #298, #306)
+- Backfill the changelog for the dependency updates merged since v0.8.1 (#315)
 
 ---
 

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -18,11 +18,16 @@ _Unreleased_
 ### Bug Fixes
 
 - `install.sh` no longer reports a Terraform or git credential helper it skipped: both are absent from release archives older than the one that added them, and the summary now names only what it wrote. Installing the git credential helper also warns when git predates 2.41, where the OAuth workflow's `oauth_refresh_token` starts round-tripping (#302)
+- Update Lipgloss to v2.0.6 (#295)
 
 ### Other
 
 - Document `--[no-]install-git-credentials-helper` and `INSTALL_GIT_CREDENTIALS_HELPER` in the installation tutorial (#302)
 - New `Experimental` website component carries one standard notice for features whose behavior can still change; the git credential helper guide is the first to use it (#304)
+- Update the Astro ecosystem for the website build (#288, #308)
+- Update lint and JS tooling: eslint, typescript-eslint, pnpm (#287, #291, #294)
+- Update GitHub Actions: checkout, setup-go, pnpm/action-setup, harden-runner, attest-build-provenance, setup-uv (#283, #290, #292, #293, #296, #299, #300)
+- Update the Go toolchain to 1.26.6 and uv (#284, #289, #298, #306)
 
 ---
 


### PR DESCRIPTION
`bash .claude/skills/changelog/assess.sh` reported 17 merged PRs since the `v0` tag with no entry under `## Upcoming`, every one of them Renovate. CLAUDE.md makes an empty list a pre-release gate, so the next release would have tripped on it.

Grouped rather than listed one per line, the way v0.7.0 handled its own Renovate batch. Seventeen bullets for dependency bumps buries the entries people actually read:

```
- Update the Astro ecosystem for the website build (#288, #308)
- Update lint and JS tooling: eslint, typescript-eslint, pnpm (#287, #291, #294)
- Update GitHub Actions: checkout, setup-go, pnpm/action-setup, harden-runner,
  attest-build-provenance, setup-uv (#283, #290, #292, #293, #296, #299, #300)
- Update the Go toolchain to 1.26.6 and uv (#284, #289, #298, #306)
```

#295 sits under Bug Fixes rather than Other because it is a `fix(deps)`, matching how v0.8.0 filed module updates. `assess.sh` matches on PR number anywhere under Upcoming, so grouping keeps the gate satisfied.

Gate is clean after this apart from this PR's own commit, which the entry below covers.

---