### PR TITLE
chore: prepare v0.9.0 release

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotsecenv",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Manage GPG-encrypted environment secrets using the dotsecenv CLI",
   "author": {
     "name": "dotsecenv",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dotsecenv",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Manage GPG-encrypted environment secrets using the dotsecenv CLI",
   "author": {
     "name": "dotsecenv",

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -11,6 +11,12 @@ All notable changes to dotsecenv are documented here. Each version includes chan
 
 _Unreleased_
 
+---
+
+## v0.9.0
+
+_August 17, 2026_
+
 ### Features
 
 - Add `contrib/git-credential-dotsecenv`, an experimental git credential helper that stores HTTPS credentials encrypted in your vault and preserves OAuth `oauth_refresh_token`/`password_expiry_utc` fields so it can back a generator like git-credential-oauth (no stored PAT); the deb/rpm/Arch packages and install.sh install it to a `PATH` directory, and `jq` is a package Recommends since `store` needs it. Point git at it with `git config --global --replace-all credential.helper "" && git config --global --add credential.helper dotsecenv`, which keeps the macOS keychain out of the chain. Needs git 2.41+ for the OAuth workflow (#255, #301, #304, #305)
@@ -29,6 +35,11 @@ _Unreleased_
 - Update GitHub Actions: checkout, setup-go, pnpm/action-setup, harden-runner, attest-build-provenance, setup-uv (#283, #290, #292, #293, #296, #299, #300)
 - Update the Go toolchain to 1.26.6 and uv (#284, #289, #298, #306)
 - Backfill the changelog for the dependency updates merged since v0.8.1 (#315)
+- Remove unreachable helpers from the internal CLI packages, along with a test that could never run (#311)
+- Remove the version-specific vault header marker constants and `HeaderMarkerForVersion`. None matched what a vault file actually contains; legacy markers are still recognised by prefix and v1 vaults still upgrade. This drops exported symbols from `pkg/dotsecenv/vault`, so a Go program importing that package directly may need a change (#312)
+- Remove the unused `InstallTabs` website component (#313)
+- Correct a `release.yml` comment that described the satellite publish jobs as best-effort when they gate on the release chain, and the Go version and mise files listed in AGENTS.md (#314)
+- Tidy stale checksums out of `go.sum` (#321)
 
 ---
 

--- a/website/src/content/docs/guides/git-credential-helper.mdx
+++ b/website/src/content/docs/guides/git-credential-helper.mdx
@@ -8,9 +8,9 @@ import Experimental from "../../../components/Experimental.astro";
 
 <Experimental feature="The git credential helper" />
 
-<Aside type="note" title="Unreleased">
-  The `git-credential-dotsecenv` helper is on `main` and has not shipped in a release
-  yet. To try it before then, use the manual install below.
+<Aside type="note" title="Available in v0.9.0+">
+  The `git-credential-dotsecenv` helper ships in v0.9.0. On an earlier version, use the
+  manual install below.
 </Aside>
 
 Use dotsecenv as a [git credential helper](https://git-scm.com/docs/gitcredentials). Tokens for HTTPS remotes are encrypted at rest in your vault instead of sitting in plaintext `~/.git-credentials`, and instead of the OS keychain once you point git at dotsecenv alone.


### PR DESCRIPTION
Release preparation for v0.9.0. Merge this, then tag.

## What ships

The headline is `contrib/git-credential-dotsecenv`, a git credential helper that keeps HTTPS tokens encrypted in the vault and preserves git's OAuth fields so it can sit behind a generator like `git-credential-oauth`. It is marked experimental on the website, since its behavior and stored shape can still change.

Alongside it: `install.sh` stops reporting helpers it skipped and warns on git older than 2.41, `jq` moves to a package Recommends so the helper works after a plain `apt install`, and a round of cleanup removed unreachable code from `internal/`, three vestigial vault header markers, and an unused website component.

## Pre-release gates

Both were run **before** stamping, which is the order CLAUDE.md specifies.

**Reference drift:** clean. Every command and flag is documented, no duplicate headings.

**Changelog completeness:** reported five PRs with no entry (#311, #312, #313, #314, #321). Added, then stamped. Running `assess.sh` again now reports everything as missing, which is expected rather than a regression: it reads only `## Upcoming`, and the entries have just moved under `## v0.9.0`. The invariant that actually matters was checked directly instead:

```
PRs merged since v0.8.1 : 28
PRs under the v0.9.0 heading : 28
missing: none      spurious: none
```

## In this PR

- `changelog.mdx`: five entries added, `## Upcoming` stamped to `## v0.9.0` / August 17, 2026, fresh empty `## Upcoming` opened above it
- `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json`: 0.8.1 to 0.9.0 via `set-plugin-version.py`, validated with `validate-agent-plugins.py`. The marketplace catalog version stays 1.0.0, which is independent
- `guides/git-credential-helper.mdx`: the "Unreleased" aside becomes "Available in v0.9.0+". It was the one page outside the changelog hardcoding release state

`git diff --check` is clean. Go build, vet, and the full test suite pass; the website lints and builds.

## One thing worth a reviewer's eye

#312 removed `HeaderMarkerV1`, `HeaderMarkerV2`, and `HeaderMarkerForVersion` from `pkg/dotsecenv/vault`. That package is a public surface, so this is technically breaking for a Go program importing it directly. Its changelog entry says so rather than leaving someone to discover it at build time. Nothing in this repo used them, and none of the three matched what a vault file actually contains.

## After merge

```bash
rt git::release --major --sign --push v0.9.0
```

---