### PR TITLE
chore(packages): disable Renovate on the packages satellite

### DIFF
--- a/packages/renovate.json
+++ b/packages/renovate.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "local>dotsecenv/.github"
-  ]
+  "enabled": false,
+  "description": "Disabled. This repo is artifact-only; dependency updates land on dotsecenv/dotsecenv where the packages source lives."
 }

--- a/website/src/content/docs/changelog.mdx
+++ b/website/src/content/docs/changelog.mdx
@@ -11,6 +11,10 @@ All notable changes to dotsecenv are documented here. Each version includes chan
 
 _Unreleased_
 
+### Other
+
+- Disable Renovate on the packages satellite. That repo is artifact-only, so a dependency PR merged there is overwritten by the next publish; the updates land here instead, where the monorepo's Renovate already covers the satellite's publish workflow (#323)
+
 ---
 
 ## v0.9.0


### PR DESCRIPTION
## Description

Disable Renovate on the `dotsecenv/packages` satellite, mirroring `plugin/renovate.json`.

The packages satellite is artifact-only: its contents are pushed from this monorepo by the publish flow, so a Renovate PR merged on the satellite is overwritten by the next publish and reads as drift in between. `dotsecenv/plugin` already carries `"enabled": false` for exactly this reason; packages was the odd one out.

Nothing is lost by disabling it. The monorepo's own Renovate already covers `packages/.github/workflows/publish.yml` — the github-actions manager's fileMatch is anchored `(^|/)`, so the nested path matches — which is where those updates belong anyway.

This takes effect on the satellite only once the file is mirrored there, so run the **Publish Satellites** workflow (`target: packages`) after merge rather than waiting for the next release.

Found while auditing satellite commit provenance for #310, where removing the last non-App writer to the satellite is a prerequisite for locking `main` down to the release App.

## Related Issue

Refs #310

## Type of Change

- [x] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] My commit messages follow the conventional commit format
- [x] I have not included any secrets or credentials

## Testing

`jq -e . packages/renovate.json` parses. No code paths touched; the file is Renovate configuration consumed by the satellite after mirroring.

<!-- Keep the line below as the last line: it separates the Co-authored-by
footer that GitHub appends to the squash commit. -->

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
